### PR TITLE
transaction: re-export TransactionBuilder

### DIFF
--- a/bee-transaction/src/lib.rs
+++ b/bee-transaction/src/lib.rs
@@ -28,3 +28,4 @@ pub mod transaction;
 
 #[cfg(any(feature = "types", feature = "all"))]
 pub use crate::transaction::Transaction;
+pub use crate::transaction::TransactionBuilder;


### PR DESCRIPTION
TransactionBuilder is not accessible by other crates. This means that other crates cannot create new transactions, only parse bytes from existing transactions into transaction objects. TransactionBuilder is required by external crates; for example by tangle app extensions - such as CHAT.ixi - which create new transactions.