### PR TITLE
Added support for trit conversion to arbitrary integers, underflow

### DIFF
--- a/bee-ternary/CHANGELOG.md
+++ b/bee-ternary/CHANGELOG.md
@@ -19,21 +19,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Security -->
 
-<!-- ## Unreleased - YYYY-MM-DD
+## 0.3.0-alpha - 2020-07-20
 
 ### Added
 
 - Support for arbitrary trit to numeric type conversion
-
-### Changed
-
-### Deprecated
-
-### Removed
-
-### Fixed
-
-### Security -->
 
 ## 0.2.0-alpha - 2020-07-17
 

--- a/bee-ternary/CHANGELOG.md
+++ b/bee-ternary/CHANGELOG.md
@@ -19,6 +19,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Security -->
 
+<!-- ## Unreleased - YYYY-MM-DD
+
+### Added
+
+- Support for arbitrary trit to numeric type conversion
+
+### Changed
+
+### Deprecated
+
+### Removed
+
+### Fixed
+
+### Security -->
+
 ## 0.2.0-alpha - 2020-07-17
 
 ### Added

--- a/bee-ternary/Cargo.toml
+++ b/bee-ternary/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bee-ternary"
-version = "0.2.0-alpha"
+version = "0.3.0-alpha"
 authors = ["IOTA Stiftung"]
 edition = "2018"
 description = "Ergonomic ternary manipulation utilities"

--- a/bee-ternary/src/trit/balanced.rs
+++ b/bee-ternary/src/trit/balanced.rs
@@ -10,6 +10,8 @@
 // See the License for the specific language governing permissions and limitations under the License.
 
 use super::{ShiftTernary, Trit, Utrit};
+use crate::convert;
+use num_traits::{CheckedAdd, CheckedSub, Num};
 use std::{convert::TryFrom, fmt, ops::Neg};
 
 #[derive(Copy, Clone, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
@@ -81,6 +83,14 @@ impl Trit for Btrit {
             Btrit::NegOne => &NEG_ONE,
             Btrit::Zero => &ZERO,
             Btrit::PlusOne => &PLUS_ONE,
+        }
+    }
+
+    fn add_to_num<I: Num + CheckedAdd + CheckedSub>(&self, n: I) -> Result<I, convert::Error> {
+        match self {
+            Btrit::NegOne => n.checked_sub(&I::one()).ok_or(convert::Error::Underflow),
+            Btrit::Zero => Ok(n),
+            Btrit::PlusOne => n.checked_add(&I::one()).ok_or(convert::Error::Overflow),
         }
     }
 }

--- a/bee-ternary/src/trit/mod.rs
+++ b/bee-ternary/src/trit/mod.rs
@@ -9,6 +9,8 @@
 // an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and limitations under the License.
 
+use crate::convert;
+use num_traits::{CheckedAdd, CheckedSub, Num};
 use std::{convert::TryFrom, fmt, hash};
 
 /// Balanced trits.
@@ -33,6 +35,9 @@ pub trait Trit:
     ///
     /// Note that this is largely an implementation detail and is rarely useful for API users.
     fn as_arbitrary_ref<'a>(&self) -> &'a Self;
+
+    /// Attempt to add this trit to a numeric value.
+    fn add_to_num<I: Num + CheckedAdd + CheckedSub>(&self, n: I) -> Result<I, convert::Error>;
 }
 
 /// A trait implemented by trits that can be shifted between balance domains.

--- a/bee-ternary/src/trit/unbalanced.rs
+++ b/bee-ternary/src/trit/unbalanced.rs
@@ -10,7 +10,8 @@
 // See the License for the specific language governing permissions and limitations under the License.
 
 use super::{Btrit, ShiftTernary, Trit};
-
+use crate::convert;
+use num_traits::{CheckedAdd, CheckedSub, Num};
 use std::{convert::TryFrom, fmt};
 
 #[derive(Copy, Clone, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
@@ -70,6 +71,14 @@ impl Trit for Utrit {
             Utrit::Zero => &ZERO,
             Utrit::One => &ONE,
             Utrit::Two => &TWO,
+        }
+    }
+
+    fn add_to_num<I: Num + CheckedAdd + CheckedSub>(&self, n: I) -> Result<I, convert::Error> {
+        match self {
+            Utrit::Zero => Ok(n),
+            Utrit::One => n.checked_add(&I::one()).ok_or(convert::Error::Overflow),
+            Utrit::Two => n.checked_add(&(I::one() + I::one())).ok_or(convert::Error::Overflow),
         }
     }
 }


### PR DESCRIPTION
# Description of change

Allows conversion between arbitrary trit buffers and arbitrary numeric types.

## Links to any relevant issues

## Type of change

Choose a type of change, and delete any options that are not relevant.

- Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How the change has been tested

Extensive existing tests continue to pass.

## Change checklist

Tick the boxes that are relevant to your changes, and delete any items that are not.

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that new and existing unit tests pass locally with my changes
- [x] I have updated the CHANGELOG.md, if my changes are significant enough
