### PR TITLE
Avoid allocations on `TritBuf::filled` for `T1B1`

### DIFF
--- a/bee-ternary/CHANGELOG.md
+++ b/bee-ternary/CHANGELOG.md
@@ -19,6 +19,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Security -->
 
+<!-- ## 0.3.2-alpha - 2020-08-XX
+
+### Changed
+
+- Optimize `TritBuf::filled` for `T1B1`. -->
+
 ## 0.3.1-alpha - 2020-07-23
 
 ### Added

--- a/bee-ternary/src/lib.rs
+++ b/bee-ternary/src/lib.rs
@@ -741,11 +741,7 @@ impl<T: RawEncodingBuf> TritBuf<T> {
 
     /// Create a new [`TritBuf`] of the given length, filled with copies of the provided trit.
     pub fn filled(len: usize, trit: <T::Slice as RawEncoding>::Trit) -> Self {
-        let mut this = Self::with_capacity(len);
-        for _ in 0..len {
-            this.push(trit);
-        }
-        this
+        Self::from_trits(&vec![trit; len])
     }
 
     /// Create a new [`TritBuf`] of the given length, filled with zero trit.

--- a/bee-ternary/src/t1b1.rs
+++ b/bee-ternary/src/t1b1.rs
@@ -154,6 +154,17 @@ where
         }
     }
 
+    /// Create a new buffer containing the given trits
+    fn from_trits(trits: &[<Self::Slice as RawEncoding>::Trit]) -> Self
+    where
+        Self: Sized,
+    {
+        Self {
+            _phantom: PhantomData,
+            inner: trits.to_vec(),
+        }
+    }
+
     fn push(&mut self, trit: <Self::Slice as RawEncoding>::Trit) {
         self.inner.push(trit);
     }


### PR DESCRIPTION
# Description of change

Make `filled` calls `from_trits` and implement it for `T1B1` as a conversion from trit slice to vector avoid a lot of `push` and then allocations.

## Type of change

- Enhancement (a non-breaking change which adds functionality)

## How the change has been tested

Existing tests.

## Change checklist

Tick the boxes that are relevant to your changes, and delete any items that are not.

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that new and existing unit tests pass locally with my changes
- [x] I have updated the CHANGELOG.md, if my changes are significant enough
