### PR TITLE
fix(crypto): remove bound of Hash::try_from

### DIFF
--- a/bee-crypto/CHANGELOG.md
+++ b/bee-crypto/CHANGELOG.md
@@ -13,13 +13,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Deprecated
 
-- Fix `try_from` method of `Hash`
-
 ### Removed
 
 ### Fixed
 
 ### Security -->
+
+## 0.1.2-alpha - 2020-08-19
+
+### Fixed
+
+- Fix `try_from` method of `Hash`
 
 ## 0.1.1-alpha - 2020-08-11
 

--- a/bee-crypto/CHANGELOG.md
+++ b/bee-crypto/CHANGELOG.md
@@ -13,6 +13,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Deprecated
 
+- Fix `try_from` method of `Hash`
+
 ### Removed
 
 ### Fixed

--- a/bee-crypto/CHANGELOG.md
+++ b/bee-crypto/CHANGELOG.md
@@ -23,7 +23,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- Fix `try_from` method of `Hash`
+- `TryFrom<&'a Trits> for Hash`;
 
 ## 0.1.1-alpha - 2020-08-11
 

--- a/bee-crypto/Cargo.toml
+++ b/bee-crypto/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bee-crypto"
-version = "0.1.1-alpha"
+version = "0.1.2-alpha"
 authors = ["IOTA Stiftung"]
 edition = "2018"
 description = "Cryptographic primitives of the IOTA protocol"

--- a/bee-crypto/src/ternary/hash.rs
+++ b/bee-crypto/src/ternary/hash.rs
@@ -9,7 +9,7 @@
 // an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and limitations under the License.
 
-use bee_ternary::{raw::RawEncoding, Btrit, Trits, T1B1};
+use bee_ternary::{Btrit, Trits, T1B1};
 
 use std::{
     cmp::PartialEq,
@@ -53,10 +53,10 @@ impl Hash {
     }
 }
 
-impl<'a, T: RawEncoding<Trit = Btrit>> TryFrom<&'a Trits<T>> for Hash {
+impl<'a> TryFrom<&'a Trits> for Hash {
     type Error = Error;
 
-    fn try_from(trits: &'a Trits<T>) -> Result<Self, Self::Error> {
+    fn try_from(trits: &'a Trits) -> Result<Self, Self::Error> {
         if trits.len() == HASH_LENGTH {
             let mut hash = Self([Btrit::Zero; HASH_LENGTH]);
             hash.copy_from(trits);

--- a/bee-crypto/tests/ternary_hash.rs
+++ b/bee-crypto/tests/ternary_hash.rs
@@ -10,7 +10,9 @@
 // See the License for the specific language governing permissions and limitations under the License.
 
 use bee_crypto::ternary::{Hash, HASH_LENGTH};
-use bee_ternary::Btrit;
+use bee_ternary::{Btrit, TritBuf, T1B1Buf};
+
+use std::convert::TryFrom;
 
 #[test]
 fn hash_weight() {
@@ -19,4 +21,10 @@ fn hash_weight() {
         hash.as_trits_mut().set(HASH_LENGTH - i - 1, Btrit::PlusOne);
         assert_eq!(hash.weight(), i as u8);
     }
+}
+
+#[test]
+fn trits_to_hash() {
+    let trits = TritBuf::<T1B1Buf>::zeros(243);
+    let _hash = Hash::try_from(trits.as_slice()).unwrap();
 }

--- a/bee-crypto/tests/ternary_hash.rs
+++ b/bee-crypto/tests/ternary_hash.rs
@@ -10,7 +10,7 @@
 // See the License for the specific language governing permissions and limitations under the License.
 
 use bee_crypto::ternary::{Hash, HASH_LENGTH};
-use bee_ternary::{Btrit, TritBuf, T1B1Buf};
+use bee_ternary::{Btrit, T1B1Buf, TritBuf};
 
 use std::convert::TryFrom;
 
@@ -26,5 +26,6 @@ fn hash_weight() {
 #[test]
 fn trits_to_hash() {
     let trits = TritBuf::<T1B1Buf>::zeros(243);
-    let _hash = Hash::try_from(trits.as_slice()).unwrap();
+    let hash = Hash::try_from(trits.as_slice()).unwrap();
+    assert_eq!(hash, Hash::zeros());
 }

--- a/bee-signing/Cargo.toml
+++ b/bee-signing/Cargo.toml
@@ -12,7 +12,7 @@ homepage = "https://www.iota.org"
 
 [dependencies]
 bee-common-derive = { version = "0.1.0-alpha", path = "../bee-common/bee-common-derive" }
-bee-crypto = { version = "0.1.1-alpha", path = "../bee-crypto" }
+bee-crypto = { version = "0.1.2-alpha", path = "../bee-crypto" }
 bee-ternary = { version = "0.3.1-alpha", path = "../bee-ternary" }
 
 rand = "0.7"


### PR DESCRIPTION
# Description of change

Current `TryFrom` trait implementation of `Hash` has a trait bound that make it unable to convert any `Trits`/`TritBuf` to `Hash`. 
Remove it could make the conversion work again.

## Type of change

- Bug fix (a non-breaking change which fixes an issue)

## How the change has been tested

Tests under `bee-crypto`

## Change checklist

Tick the boxes that are relevant to your changes, and delete any items that are not.

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that new and existing unit tests pass locally with my changes
- [x] I have updated the CHANGELOG.md, if my changes are significant enough
