### PR TITLE
BCurlP transpose binary encoding for Trits

### DIFF
--- a/bee-crypto/CHANGELOG.md
+++ b/bee-crypto/CHANGELOG.md
@@ -19,6 +19,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Security -->
 
+<!-- ## 0.2.1-alpha - 2020-08-27
+
+### Changed
+
+- Transpose binary encoded trit representation to be more performant; -->
+
 ## 0.2.0-alpha - 2020-08-20
 
 ### Added

--- a/bee-crypto/src/ternary/sponge/batched_curlp/bct.rs
+++ b/bee-crypto/src/ternary/sponge/batched_curlp/bct.rs
@@ -12,35 +12,35 @@
 use std::ops::{Deref, DerefMut, Range};
 
 #[derive(Clone, Copy, Debug)]
-pub struct BCTrit(pub usize, pub usize);
+pub(crate) struct BCTrit(pub(crate) usize, pub(crate) usize);
 
 impl BCTrit {
     const fn zero() -> Self {
         Self(0, 0)
     }
 
-    pub fn lo(&self) -> usize {
+    pub(crate) fn lo(&self) -> usize {
         self.0
     }
 
-    pub fn hi(&self) -> usize {
+    pub(crate) fn hi(&self) -> usize {
         self.1
     }
 }
 
 #[derive(Clone)]
-pub struct BCTritBuf {
+pub(crate) struct BCTritBuf {
     inner: Vec<BCTrit>,
 }
 
 impl BCTritBuf {
-    pub fn zeros(len: usize) -> Self {
+    pub(crate) fn zeros(len: usize) -> Self {
         Self {
             inner: vec![BCTrit::zero(); len],
         }
     }
 
-    pub fn filled(value: usize, len: usize) -> Self {
+    pub(crate) fn filled(value: usize, len: usize) -> Self {
         Self {
             inner: vec![BCTrit(value, value); len],
         }
@@ -62,40 +62,40 @@ impl DerefMut for BCTritBuf {
 }
 
 #[repr(transparent)]
-pub struct BCTrits {
+pub(crate) struct BCTrits {
     inner: [BCTrit],
 }
 
 impl BCTrits {
-    pub fn fill(&mut self, value: usize) {
+    pub(crate) fn fill(&mut self, value: usize) {
         for BCTrit(hi, lo) in &mut self.inner {
             *lo = value;
             *hi = value;
         }
     }
 
-    pub fn len(&self) -> usize {
+    pub(crate) fn len(&self) -> usize {
         self.inner.len()
     }
 
-    pub fn copy_from_slice(&mut self, slice: &Self) {
+    pub(crate) fn copy_from_slice(&mut self, slice: &Self) {
         self.inner.copy_from_slice(&slice.inner)
     }
 
-    pub unsafe fn get_unchecked<I: BCTritsIndex>(&self, index: I) -> &I::Output {
+    pub(crate) unsafe fn get_unchecked<I: BCTritsIndex>(&self, index: I) -> &I::Output {
         index.get_unchecked(self)
     }
 
-    pub unsafe fn get_unchecked_mut<I: BCTritsIndex>(&mut self, index: I) -> &mut I::Output {
+    pub(crate) unsafe fn get_unchecked_mut<I: BCTritsIndex>(&mut self, index: I) -> &mut I::Output {
         index.get_unchecked_mut(self)
     }
 
-    pub fn iter(&self) -> impl Iterator<Item = &BCTrit> {
+    pub(crate) fn iter(&self) -> impl Iterator<Item = &BCTrit> {
         self.inner.iter()
     }
 }
 
-pub trait BCTritsIndex {
+pub(crate) trait BCTritsIndex {
     type Output: ?Sized;
 
     unsafe fn get_unchecked(self, trits: &BCTrits) -> &Self::Output;

--- a/bee-crypto/src/ternary/sponge/batched_curlp/bct.rs
+++ b/bee-crypto/src/ternary/sponge/batched_curlp/bct.rs
@@ -89,6 +89,10 @@ impl BCTrits {
     pub unsafe fn get_unchecked_mut<I: BCTritsIndex>(&mut self, index: I) -> &mut I::Output {
         index.get_unchecked_mut(self)
     }
+
+    pub fn iter(&self) -> impl Iterator<Item = &BCTrit> {
+        self.inner.iter()
+    }
 }
 
 pub trait BCTritsIndex {

--- a/bee-crypto/src/ternary/sponge/batched_curlp/bct_curlp.rs
+++ b/bee-crypto/src/ternary/sponge/batched_curlp/bct_curlp.rs
@@ -20,7 +20,7 @@ use crate::ternary::{
     HASH_LENGTH,
 };
 
-pub struct BCTCurlP {
+pub(crate) struct BCTCurlP {
     rounds: CurlPRounds,
     state: BCTritBuf,
     scratch_pad: BCTritBuf,
@@ -28,7 +28,7 @@ pub struct BCTCurlP {
 
 impl BCTCurlP {
     #[allow(clippy::assertions_on_constants)]
-    pub fn new(rounds: CurlPRounds) -> Self {
+    pub(crate) fn new(rounds: CurlPRounds) -> Self {
         // Ensure that changing the hash length will not cause undefined behaviour.
         assert!(3 * HASH_LENGTH > 728);
         Self {
@@ -38,11 +38,11 @@ impl BCTCurlP {
         }
     }
 
-    pub fn reset(&mut self) {
+    pub(crate) fn reset(&mut self) {
         self.state.fill(HIGH_BITS);
     }
 
-    pub fn transform(&mut self) {
+    pub(crate) fn transform(&mut self) {
         let mut scratch_pad_index = 0;
 
         // All the unchecked accesses here are guaranteed to be safe by the assertion inside `new`.
@@ -91,7 +91,7 @@ impl BCTCurlP {
         }
     }
 
-    pub fn absorb(&mut self, bc_trits: &BCTritBuf) {
+    pub(crate) fn absorb(&mut self, bc_trits: &BCTritBuf) {
         let mut length = bc_trits.len();
         let mut offset = 0;
 
@@ -114,7 +114,7 @@ impl BCTCurlP {
 
     // This method shouldn't assume that `result` has any particular content, just that it has an
     // adequate size.
-    pub fn squeeze_into(&mut self, result: &mut BCTritBuf) {
+    pub(crate) fn squeeze_into(&mut self, result: &mut BCTritBuf) {
         let trit_count = result.len();
 
         let hash_count = trit_count / HASH_LENGTH;

--- a/bee-crypto/src/ternary/sponge/batched_curlp/mod.rs
+++ b/bee-crypto/src/ternary/sponge/batched_curlp/mod.rs
@@ -127,10 +127,10 @@ impl BatchHasher {
     /// rule for the `(0, 0)` pair of bits which is mapped to the `0` trit.
     fn demux(&mut self, index: usize) -> TritBuf {
         for (bc_trit, btrit) in self.bct_hashes.iter().zip(self.buf_demux.iter_mut()) {
-            let low = (bc_trit.lo() >> index) & 1;
+            let lo = (bc_trit.lo() >> index) & 1;
             let hi = (bc_trit.hi() >> index) & 1;
 
-            *btrit = match (low, hi) {
+            *btrit = match (lo, hi) {
                 (1, 0) => Btrit::NegOne,
                 (0, 1) => Btrit::PlusOne,
                 // This can only be `(0, 0)` or `(1, 1)`.


### PR DESCRIPTION
# Description of change

This PR changes the binary trit encoding used by our batched CurlP
implementation to be more cache-friendly.

## Type of change

Enhancement (a non-breaking change which adds functionality)

## How the change has been tested

This is an internal change and the current test suite passed correctly. I also
noticed a 10% improvement in the throughtput measured by the benchmarks.

## Change checklist

Tick the boxes that are relevant to your changes, and delete any items that are not.

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that new and existing unit tests pass locally with my changes
- [x] I have updated the CHANGELOG.md, if my changes are significant enough
