### PR TITLE
Add no_std support to bee-common-derive 

### DIFF
--- a/bee-common/bee-common-derive/CHANGELOG.md
+++ b/bee-common/bee-common-derive/CHANGELOG.md
@@ -19,11 +19,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Security -->
 
-## 0.1.0-alpha - 2020-09-29
+## 0.1.1-alpha - 2020-09-29
 
 ### Added
 
-- `no_std` support
+- `no_std` support;
 
 ## 0.1.0-alpha - 2020-07-16
 

--- a/bee-common/bee-common-derive/CHANGELOG.md
+++ b/bee-common/bee-common-derive/CHANGELOG.md
@@ -19,6 +19,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Security -->
 
+## 0.1.0-alpha - 2020-09-29
+
+### Added
+
+- `no_std` support
+
 ## 0.1.0-alpha - 2020-07-16
 
 ### Added

--- a/bee-common/bee-common-derive/Cargo.toml
+++ b/bee-common/bee-common-derive/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bee-common-derive"
-version = "0.1.0-alpha"
+version = "0.1.1-alpha"
 authors = ["IOTA Stiftung"]
 edition = "2018"
 description = "Derive macros for the bee-common crate"

--- a/bee-common/bee-common-derive/src/lib.rs
+++ b/bee-common/bee-common-derive/src/lib.rs
@@ -12,11 +12,12 @@
 //! Derive macros for the bee-common crate.
 
 #![warn(missing_docs)]
+#![no_std]
 
 use quote::quote;
 use syn::{parse_macro_input, DeriveInput};
 
-/// Derives an implementation of the trait `std::fmt::Debug` for a secret type that doesn't leak its internal secret.
+/// Derives an implementation of the trait `core::fmt::Debug` for a secret type that doesn't leak its internal secret.
 /// Implements https://github.com/iotaledger/bee-rfcs/blob/master/text/0042-secret-debug-display.md.
 /// Based on https://github.com/dtolnay/syn/blob/master/examples/heapsize/heapsize_derive/src/lib.rs.
 #[proc_macro_derive(SecretDebug)]
@@ -30,8 +31,8 @@ pub fn derive_secret_debug(input: proc_macro::TokenStream) -> proc_macro::TokenS
 
     // The generated implementation.
     let expanded = quote! {
-        impl #impl_generics std::fmt::Debug for #name #ty_generics {
-            fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        impl #impl_generics core::fmt::Debug for #name #ty_generics {
+            fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 write!(f, "<Omitted secret>")
             }
         }
@@ -40,7 +41,7 @@ pub fn derive_secret_debug(input: proc_macro::TokenStream) -> proc_macro::TokenS
     expanded.into()
 }
 
-/// Derives an implementation of the trait `std::fmt::Display` for a secret type that doesn't leak its internal secret.
+/// Derives an implementation of the trait `core::fmt::Display` for a secret type that doesn't leak its internal secret.
 /// Implements https://github.com/iotaledger/bee-rfcs/blob/master/text/0042-secret-debug-display.md.
 /// Based on https://github.com/dtolnay/syn/blob/master/examples/heapsize/heapsize_derive/src/lib.rs.
 #[proc_macro_derive(SecretDisplay)]
@@ -54,8 +55,8 @@ pub fn derive_secret_display(input: proc_macro::TokenStream) -> proc_macro::Toke
 
     // The generated implementation.
     let expanded = quote! {
-        impl #impl_generics std::fmt::Display for #name #ty_generics {
-            fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        impl #impl_generics core::fmt::Display for #name #ty_generics {
+            fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 write!(f, "<Omitted secret>")
             }
         }
@@ -64,7 +65,7 @@ pub fn derive_secret_display(input: proc_macro::TokenStream) -> proc_macro::Toke
     expanded.into()
 }
 
-/// Derives an implementation of the trait `std::ops::Drop` for a secret type that calls `Zeroize::zeroize`.
+/// Derives an implementation of the trait `core::ops::Drop` for a secret type that calls `Zeroize::zeroize`.
 /// Implements https://github.com/iotaledger/bee-rfcs/blob/master/text/0044-secret-zeroize-drop.md.
 /// Based on https://github.com/dtolnay/syn/blob/master/examples/heapsize/heapsize_derive/src/lib.rs.
 #[proc_macro_derive(SecretDrop)]
@@ -78,7 +79,7 @@ pub fn derive_secret_drop(input: proc_macro::TokenStream) -> proc_macro::TokenSt
 
     // The generated implementation.
     let expanded = quote! {
-        impl #impl_generics std::ops::Drop for #name #ty_generics {
+        impl #impl_generics core::ops::Drop for #name #ty_generics {
             fn drop(&mut self) {
                 self.zeroize()
             }

--- a/bee-signing/Cargo.toml
+++ b/bee-signing/Cargo.toml
@@ -11,7 +11,7 @@ keywords = ["iota", "tangle", "bee", "framework", "signing"]
 homepage = "https://www.iota.org"
 
 [dependencies]
-bee-common-derive = { version = "0.1.0-alpha", path = "../bee-common/bee-common-derive" }
+bee-common-derive = { version = "0.1.1-alpha", path = "../bee-common/bee-common-derive" }
 bee-crypto = { version = "0.2.0-alpha", path = "../bee-crypto" }
 bee-ternary = { version = "0.3.1-alpha", path = "../bee-ternary" }
 


### PR DESCRIPTION
# Description of change

Add `no_std` support to `bee-common-derive` so it can be used in both std an no_std environment.

## Type of change

- Enhancement (a non-breaking change which adds functionality)

## How the change has been tested

Build on CI should pass.

## Change checklist

Tick the boxes that are relevant to your changes, and delete any items that are not.

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that new and existing unit tests pass locally with my changes
- [x] I have updated the CHANGELOG.md, if my changes are significant enough
