### PR TITLE
feat(ternary) use i128/u128 only when cfg(has_i128)

### DIFF
--- a/bee-crypto/Cargo.toml
+++ b/bee-crypto/Cargo.toml
@@ -11,7 +11,7 @@ keywords = ["iota", "tangle", "bee", "framework", "crypto"]
 homepage = "https://www.iota.org"
 
 [dependencies]
-bee-ternary = { version = "0.3.2-alpha", path = "../bee-ternary" }
+bee-ternary = { version = "0.3.3-alpha", path = "../bee-ternary" }
 
 byteorder = "1.3.4"
 lazy_static = "1.4.0"

--- a/bee-signing/Cargo.toml
+++ b/bee-signing/Cargo.toml
@@ -13,7 +13,7 @@ homepage = "https://www.iota.org"
 [dependencies]
 bee-common-derive = { version = "0.1.1-alpha", path = "../bee-common/bee-common-derive" }
 bee-crypto = { version = "0.2.0-alpha", path = "../bee-crypto" }
-bee-ternary = { version = "0.3.2-alpha", path = "../bee-ternary" }
+bee-ternary = { version = "0.3.3-alpha", path = "../bee-ternary" }
 
 rand = "0.7"
 sha3 = "0.9.0"

--- a/bee-ternary/CHANGELOG.md
+++ b/bee-ternary/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Removed
 
 ### Fixed
+- `TryFrom<Trits>` implemented for `u128` and `i128` only when `cfg(has_i128)`
 
 ### Security -->
 

--- a/bee-ternary/CHANGELOG.md
+++ b/bee-ternary/CHANGELOG.md
@@ -16,9 +16,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Removed
 
 ### Fixed
-- `TryFrom<Trits>` implemented for `u128` and `i128` only when `cfg(has_i128)`
 
 ### Security -->
+
+## 0.3.3-alpha - 2020-11-06
+
+### Fixed
+
+- `TryFrom<Trits>` implemented for `u128` and `i128` only when `cfg(has_i128)`.
 
 ## 0.3.2-alpha - 2020-10-19
 

--- a/bee-ternary/Cargo.toml
+++ b/bee-ternary/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bee-ternary"
-version = "0.3.2-alpha"
+version = "0.3.3-alpha"
 authors = ["IOTA Stiftung"]
 edition = "2018"
 description = "Ergonomic ternary manipulation utilities"

--- a/bee-ternary/src/convert.rs
+++ b/bee-ternary/src/convert.rs
@@ -58,6 +58,7 @@ macro_rules! signed_try_from_trits {
 // We have to implement manually due to Rust's orphan rules :(
 // This macro accepts anything that implements:
 // `Clone + CheckedAdd + Signed + AsPrimitive<i8> + FromPrimitive`
+#[cfg(has_i128)]
 signed_try_from_trits!(i128);
 signed_try_from_trits!(i64);
 signed_try_from_trits!(i32);
@@ -87,6 +88,7 @@ macro_rules! unsigned_try_from_trits {
 // We have to implement manually due to Rust's orphan rules :(
 // This macro accepts anything that implements:
 // `Clone + CheckedAdd + Unsigned + AsPrimitive<u8> + FromPrimitive`
+#[cfg(has_i128)]
 unsigned_try_from_trits!(u128);
 unsigned_try_from_trits!(u64);
 unsigned_try_from_trits!(u32);

--- a/bee-test/Cargo.toml
+++ b/bee-test/Cargo.toml
@@ -11,7 +11,7 @@ keywords = ["iota", "tangle", "bee", "framework", "test"]
 homepage = "https://www.iota.org"
 
 [dependencies]
-bee-ternary = { version = "0.3.2-alpha", features = [ "serde1" ], path = "../bee-ternary" }
+bee-ternary = { version = "0.3.3-alpha", features = [ "serde1" ], path = "../bee-ternary" }
 
 rand = "0.7.3"
 


### PR DESCRIPTION
# Description of change

Changes required so bee-ternary can compile on ESP32 targets.

## Type of change

- Bug fix (a non-breaking change which fixes an issue)

## How the change has been tested

Compiling to ESP32.

## Change checklist

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have checked that new and existing unit tests pass locally with my changes
