### PR TITLE
Packable improvements

### DIFF
--- a/bee-common/bee-common/CHANGELOG.md
+++ b/bee-common/bee-common/CHANGELOG.md
@@ -19,6 +19,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Security -->
 
+## 0.1.1-alpha - 2020-11-12
+
+### Added
+
+- Impl `Packable` for `bool`;
+- Impl `Packable` for `Option<P: Packable>`;
+
+### Changed
+
+- Make `pack_new` return a `Vec<u8>` instead of a `Result`;
+- Require `Packable::Error` to be `Debug`;
+
 ## 0.1.0-alpha - 2020-11-02
 
 ### Added

--- a/bee-common/bee-common/Cargo.toml
+++ b/bee-common/bee-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bee-common"
-version = "0.1.0-alpha"
+version = "0.1.1-alpha"
 authors = ["IOTA Stiftung"]
 edition = "2018"
 description = "Common utilities used across the bee framework"

--- a/bee-common/bee-common/src/packable.rs
+++ b/bee-common/bee-common/src/packable.rs
@@ -54,10 +54,7 @@ impl Packable for bool {
     where
         Self: Sized,
     {
-        Ok(match u8::unpack(reader)? {
-            0 => false,
-            _ => true,
-        })
+        Ok(!matches!(u8::unpack(reader)?, 0))
     }
 }
 
@@ -84,11 +81,11 @@ impl<P: Packable> Packable for Option<P> {
     fn pack<W: Write>(&self, writer: &mut W) -> Result<(), Self::Error> {
         match self {
             Some(p) => {
-                true.pack(writer).map_err(|e| OptionError::Bool(e))?;
-                p.pack(writer).map_err(|e| OptionError::Inner(e))?;
+                true.pack(writer).map_err(OptionError::Bool)?;
+                p.pack(writer).map_err(OptionError::Inner)?;
             }
             None => {
-                false.pack(writer).map_err(|e| OptionError::Bool(e))?;
+                false.pack(writer).map_err(OptionError::Bool)?;
             }
         }
 
@@ -99,8 +96,8 @@ impl<P: Packable> Packable for Option<P> {
     where
         Self: Sized,
     {
-        Ok(match bool::unpack(reader).map_err(|e| OptionError::Bool(e))? {
-            true => Some(P::unpack(reader).map_err(|e| OptionError::Inner(e))?),
+        Ok(match bool::unpack(reader).map_err(OptionError::Bool)? {
+            true => Some(P::unpack(reader).map_err(OptionError::Inner)?),
             false => None,
         })
     }

--- a/bee-common/bee-common/src/packable.rs
+++ b/bee-common/bee-common/src/packable.rs
@@ -16,7 +16,7 @@ pub use std::io::{Read, Write};
 /// A trait to pack and unpack types to and from bytes.
 pub trait Packable {
     /// Associated error type.
-    type Error;
+    type Error: std::fmt::Debug;
 
     /// Returns the length of the packed bytes.
     fn packed_len(&self) -> usize;
@@ -25,11 +25,12 @@ pub trait Packable {
     fn pack<W: Write>(&self, writer: &mut W) -> Result<(), Self::Error>;
 
     /// Packs the instance to bytes and writes them to a newly allocated vector.
-    fn pack_new(&self) -> Result<Vec<u8>, Self::Error> {
+    fn pack_new(&self) -> Vec<u8> {
         let mut bytes = Vec::with_capacity(self.packed_len());
-        self.pack(&mut bytes)?;
+        // Packing to bytes can't fail.
+        self.pack(&mut bytes).unwrap();
 
-        Ok(bytes)
+        bytes
     }
 
     /// Reads bytes from the passed reader and unpacks them into an instance.

--- a/bee-common/bee-common/src/packable.rs
+++ b/bee-common/bee-common/src/packable.rs
@@ -60,11 +60,11 @@ impl Packable for bool {
 
 /// Error that occurs on `Option<P: Packable>` operations.
 #[derive(Debug)]
-pub enum OptionError<P> {
+pub enum OptionError<E> {
     /// Error that occurs on boolean `Packable` operations.
     Bool(<bool as Packable>::Error),
     /// Error that occurs on inner `Packable` operations.
-    Inner(P),
+    Inner(E),
 }
 
 impl<P: Packable> Packable for Option<P> {

--- a/bee-common/bee-common/tests/packable.rs
+++ b/bee-common/bee-common/tests/packable.rs
@@ -46,3 +46,18 @@ fn packable_bool() {
     assert_eq!(bool::unpack(&mut 1u8.pack_new().as_slice()).unwrap(), true);
     assert_eq!(bool::unpack(&mut 42u8.pack_new().as_slice()).unwrap(), true);
 }
+
+#[test]
+fn packable_option() {
+    assert_eq!(None::<u64>.packed_len(), 1);
+    assert_eq!(
+        Option::<u64>::unpack(&mut None::<u64>.pack_new().as_slice()).unwrap(),
+        None
+    );
+
+    assert_eq!(Some(42u64).packed_len(), 9);
+    assert_eq!(
+        Option::<u64>::unpack(&mut Some(42u64).pack_new().as_slice()).unwrap(),
+        Some(42u64)
+    );
+}

--- a/bee-common/bee-common/tests/packable.rs
+++ b/bee-common/bee-common/tests/packable.rs
@@ -16,7 +16,10 @@ macro_rules! impl_packable_test_for_num {
         #[test]
         fn $name() {
             let num: $ty = $value;
-            assert_eq!($ty::unpack(&mut num.pack_new().as_slice()).unwrap(), num);
+            let bytes = num.pack_new();
+
+            assert_eq!(bytes.len(), num.packed_len());
+            assert_eq!($ty::unpack(&mut bytes.as_slice()).unwrap(), num);
         }
     };
 }

--- a/bee-common/bee-common/tests/packable.rs
+++ b/bee-common/bee-common/tests/packable.rs
@@ -16,18 +16,30 @@ macro_rules! impl_packable_test_for_num {
         #[test]
         fn $name() {
             let num: $ty = $value;
-            assert_eq!(num, $ty::unpack(&mut num.pack_new().unwrap().as_slice()).unwrap());
+            assert_eq!($ty::unpack(&mut num.pack_new().unwrap().as_slice()).unwrap(), num);
         }
     };
 }
 
-impl_packable_test_for_num!(pack_unpack_i8, i8, 0x6F);
-impl_packable_test_for_num!(pack_unpack_u8, u8, 0x6F);
-impl_packable_test_for_num!(pack_unpack_i16, i16, 0x6F7B);
-impl_packable_test_for_num!(pack_unpack_u16, u16, 0x6F7B);
-impl_packable_test_for_num!(pack_unpack_i32, i32, 0x6F7BD423);
-impl_packable_test_for_num!(pack_unpack_u32, u32, 0x6F7BD423);
-impl_packable_test_for_num!(pack_unpack_i64, i64, 0x6F7BD423100423DB);
-impl_packable_test_for_num!(pack_unpack_u64, u64, 0x6F7BD423100423DB);
-impl_packable_test_for_num!(pack_unpack_i128, i128, 0x6F7BD423100423DBFF127B91CA0AB123);
-impl_packable_test_for_num!(pack_unpack_u128, u128, 0x6F7BD423100423DBFF127B91CA0AB123);
+impl_packable_test_for_num!(packable_i8, i8, 0x6F);
+impl_packable_test_for_num!(packable_u8, u8, 0x6F);
+impl_packable_test_for_num!(packable_i16, i16, 0x6F7B);
+impl_packable_test_for_num!(packable_u16, u16, 0x6F7B);
+impl_packable_test_for_num!(packable_i32, i32, 0x6F7BD423);
+impl_packable_test_for_num!(packable_u32, u32, 0x6F7BD423);
+impl_packable_test_for_num!(packable_i64, i64, 0x6F7BD423100423DB);
+impl_packable_test_for_num!(packable_u64, u64, 0x6F7BD423100423DB);
+impl_packable_test_for_num!(packable_i128, i128, 0x6F7BD423100423DBFF127B91CA0AB123);
+impl_packable_test_for_num!(packable_u128, u128, 0x6F7BD423100423DBFF127B91CA0AB123);
+
+#[test]
+fn packable_bool() {
+    assert_eq!(false.packed_len(), 1);
+    assert_eq!(bool::unpack(&mut false.pack_new().unwrap().as_slice()).unwrap(), false);
+    assert_eq!(bool::unpack(&mut 0u8.pack_new().unwrap().as_slice()).unwrap(), false);
+
+    assert_eq!(true.packed_len(), 1);
+    assert_eq!(bool::unpack(&mut true.pack_new().unwrap().as_slice()).unwrap(), true);
+    assert_eq!(bool::unpack(&mut 1u8.pack_new().unwrap().as_slice()).unwrap(), true);
+    assert_eq!(bool::unpack(&mut 42u8.pack_new().unwrap().as_slice()).unwrap(), true);
+}

--- a/bee-common/bee-common/tests/packable.rs
+++ b/bee-common/bee-common/tests/packable.rs
@@ -16,7 +16,7 @@ macro_rules! impl_packable_test_for_num {
         #[test]
         fn $name() {
             let num: $ty = $value;
-            assert_eq!($ty::unpack(&mut num.pack_new().unwrap().as_slice()).unwrap(), num);
+            assert_eq!($ty::unpack(&mut num.pack_new().as_slice()).unwrap(), num);
         }
     };
 }
@@ -35,11 +35,11 @@ impl_packable_test_for_num!(packable_u128, u128, 0x6F7BD423100423DBFF127B91CA0AB
 #[test]
 fn packable_bool() {
     assert_eq!(false.packed_len(), 1);
-    assert_eq!(bool::unpack(&mut false.pack_new().unwrap().as_slice()).unwrap(), false);
-    assert_eq!(bool::unpack(&mut 0u8.pack_new().unwrap().as_slice()).unwrap(), false);
+    assert_eq!(bool::unpack(&mut false.pack_new().as_slice()).unwrap(), false);
+    assert_eq!(bool::unpack(&mut 0u8.pack_new().as_slice()).unwrap(), false);
 
     assert_eq!(true.packed_len(), 1);
-    assert_eq!(bool::unpack(&mut true.pack_new().unwrap().as_slice()).unwrap(), true);
-    assert_eq!(bool::unpack(&mut 1u8.pack_new().unwrap().as_slice()).unwrap(), true);
-    assert_eq!(bool::unpack(&mut 42u8.pack_new().unwrap().as_slice()).unwrap(), true);
+    assert_eq!(bool::unpack(&mut true.pack_new().as_slice()).unwrap(), true);
+    assert_eq!(bool::unpack(&mut 1u8.pack_new().as_slice()).unwrap(), true);
+    assert_eq!(bool::unpack(&mut 42u8.pack_new().as_slice()).unwrap(), true);
 }


### PR DESCRIPTION
### Added

- Impl `Packable` for `bool`;
- Impl `Packable` for `Option<P: Packable>`;

### Changed

- Make `pack_new` return a `Vec<u8>` instead of a `Result`;
- Require `Packable::Error` to be `Debug`;

## Change checklist

Tick the boxes that are relevant to your changes, and delete any items that are not.

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that new and existing unit tests pass locally with my changes
- [x] I have updated the CHANGELOG.md, if my changes are significant enough
