### PR TITLE
Trigger "LatestSolidMilestoneChanged" event only when a milestone is solid and valid

### DIFF
--- a/bee-protocol/src/protocol/protocol.rs
+++ b/bee-protocol/src/protocol/protocol.rs
@@ -29,6 +29,7 @@ use futures::channel::oneshot;
 use log::{debug, error, info};
 use tokio::task::spawn;
 
+use crate::worker::SolidMilestoneAnnouncerWorker;
 use std::sync::Arc;
 
 static PROTOCOL: spin::RwLock<Option<&'static Protocol>> = spin::RwLock::new(None);
@@ -76,6 +77,7 @@ impl Protocol {
             .with_worker_cfg::<StatusWorker>(config.workers.status_interval)
             .with_worker::<HeartbeaterWorker>()
             .with_worker::<MessageSubmitterWorker>()
+            .with_worker::<SolidMilestoneAnnouncerWorker>()
     }
 
     pub fn events<N: Node>(node: &N, config: ProtocolConfig) {

--- a/bee-protocol/src/worker/mod.rs
+++ b/bee-protocol/src/worker/mod.rs
@@ -15,6 +15,7 @@ mod peer;
 mod propagator;
 mod requester;
 mod responder;
+mod solid_milestone_announcer;
 mod solidifier;
 mod status;
 mod storage;
@@ -38,6 +39,7 @@ pub(crate) use requester::{
 pub(crate) use responder::{
     MessageResponderWorker, MessageResponderWorkerEvent, MilestoneResponderWorker, MilestoneResponderWorkerEvent,
 };
+pub(crate) use solid_milestone_announcer::{SolidMilestoneAnnouncerWorker, SolidMilestoneAnnouncerWorkerEvent};
 pub(crate) use solidifier::{KickstartWorker, MilestoneSolidifierWorker, MilestoneSolidifierWorkerEvent};
 pub(crate) use status::StatusWorker;
 pub use storage::StorageWorker;

--- a/bee-protocol/src/worker/solid_milestone_announcer.rs
+++ b/bee-protocol/src/worker/solid_milestone_announcer.rs
@@ -1,0 +1,78 @@
+// Copyright 2020 IOTA Stiftung
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::{Milestone, MilestoneIndex};
+
+use bee_common::{node::Node, shutdown_stream::ShutdownStream, worker::Worker};
+use bee_message::MessageId;
+
+use async_trait::async_trait;
+use futures::{channel::oneshot, stream::StreamExt};
+use log::{error, info, warn};
+
+use crate::{
+    event::LatestSolidMilestoneChanged,
+    worker::{MilestoneConeUpdaterWorker, MilestoneConeUpdaterWorkerEvent},
+};
+use bee_common::event::Bus;
+use std::{any::TypeId, convert::Infallible};
+
+pub(crate) struct SolidMilestoneAnnouncerWorkerEvent {
+    pub(crate) milestone_message_id: MessageId,
+    pub(crate) propagator_waiter: oneshot::Receiver<()>,
+    pub(crate) milestone_validator_waiter: oneshot::Receiver<MilestoneIndex>,
+}
+
+pub(crate) struct SolidMilestoneAnnouncerWorker {
+    pub(crate) tx: flume::Sender<SolidMilestoneAnnouncerWorkerEvent>,
+}
+
+#[async_trait]
+impl<N: Node> Worker<N> for SolidMilestoneAnnouncerWorker {
+    type Config = ();
+    type Error = Infallible;
+
+    fn dependencies() -> &'static [TypeId] {
+        vec![TypeId::of::<MilestoneConeUpdaterWorker>()].leak()
+    }
+
+    async fn start(node: &mut N, _config: Self::Config) -> Result<Self, Self::Error> {
+        let (tx, rx) = flume::unbounded();
+        let cone_updater = node.worker::<MilestoneConeUpdaterWorker>().unwrap().tx.clone();
+        let bus = node.resource::<Bus>();
+
+        node.spawn::<Self, _, _>(|shutdown| async move {
+            info!("Running.");
+
+            let mut receiver = ShutdownStream::new(shutdown, rx.into_stream());
+
+            while let Some(event) = receiver.next().await {
+                let event: SolidMilestoneAnnouncerWorkerEvent = event;
+
+                if let Err(e) = event.propagator_waiter.await {
+                    error!("Waiting for propagator failed: {:?}.", e);
+                }
+
+                match event.milestone_validator_waiter.await {
+                    Ok(index) => {
+                        if let Err(e) = cone_updater.send(MilestoneConeUpdaterWorkerEvent {
+                            milestone_message_id: event.milestone_message_id,
+                            milestone_index: index,
+                        }) {
+                            error!("Sending milestone index to: {:?}.", e);
+                        }
+                        bus.dispatch(LatestSolidMilestoneChanged(Milestone {
+                            message_id: event.milestone_message_id,
+                            index,
+                        }));
+                    }
+                    Err(e) => error!("Waiting for milestone validator failed: {:?}.", e),
+                }
+            }
+
+            info!("Stopped.");
+        });
+
+        Ok(Self { tx })
+    }
+}


### PR DESCRIPTION
# Description of change

Currently, the `LatestSolidMilestoneChanged` event might get triggered in the `PropagatorWorker` **or** in the `MilestoneValidatorWorker`. Since these two workers are working independently there might be the case that the `LatestSolidMilestoneChanged`  gets triggered even if the milestone was not validated yet. 

A `LatestSolidMilestoneChanged` event only should get triggered when the milestone is solid and valid.

This PR's solves exactly that: the  `LatestSolidMilestoneChanged` will only get fired when all conditions are met.
A `SolidMilestoneAnnouncerWorker` waits for the conditions to be full-filled and fires the event.

## Type of change

- Bug fix (a non-breaking change which fixes an issue)

## How the change has been tested

only self-review yet

## Change checklist

Tick the boxes that are relevant to your changes, and delete any items that are not.

- [X] I have followed the contribution guidelines for this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that new and existing unit tests pass locally with my changes
- [X] I have updated the CHANGELOG.md, if my changes are significant enough
