### PR TITLE
return all confirmed messages from the "update_past_cone" and consume them in "update_future_cones"

### DIFF
--- a/bee-protocol/src/worker/milestone_cone_updater.rs
+++ b/bee-protocol/src/worker/milestone_cone_updater.rs
@@ -154,15 +154,15 @@ async fn update_future_cone<B: StorageBackend>(tangle: &MsTangle<B>, child: Mess
             }
 
             // unwrap() is safe since None values are filtered above
-            let best_otrsi = max(parent1_otsri.unwrap(), parent2_otsri.unwrap());
-            let best_ytrsi = min(parent1_ytrsi.unwrap(), parent2_ytrsi.unwrap());
+            let new_otrsi = min(parent1_otsri.unwrap(), parent2_otsri.unwrap());
+            let new_ytrsi = max(parent1_ytrsi.unwrap(), parent2_ytrsi.unwrap());
 
             // in case the messages already inherited the best OTRSI/YTRSI values, continue
             let current_otrsi = tangle.otrsi(&message_id).await;
             let current_ytrsi = tangle.ytrsi(&message_id).await;
 
             if let (Some(otrsi), Some(ytrsi)) = (current_otrsi, current_ytrsi) {
-                if otrsi == best_otrsi && ytrsi == best_ytrsi {
+                if otrsi == new_otrsi && ytrsi == new_ytrsi {
                     continue;
                 }
             }
@@ -170,8 +170,8 @@ async fn update_future_cone<B: StorageBackend>(tangle: &MsTangle<B>, child: Mess
             // update outdated OTRSI/YTRSI values
             tangle
                 .update_metadata(&message_id, |metadata| {
-                    metadata.set_otrsi(best_otrsi);
-                    metadata.set_ytrsi(best_ytrsi);
+                    metadata.set_otrsi(new_otrsi);
+                    metadata.set_ytrsi(new_ytrsi);
                 })
                 .await;
 

--- a/bee-protocol/src/worker/propagator.rs
+++ b/bee-protocol/src/worker/propagator.rs
@@ -65,15 +65,15 @@ async fn propagate<B: StorageBackend>(
             // get best OTRSI/YTRSI from parents
             // unwrap() is safe because parents are solid which implies that OTRSI/YTRSI values are
             // available.
-            let best_otrsi = max(parent1_otsri.unwrap(), parent2_otsri.unwrap());
-            let best_ytrsi = min(parent1_ytrsi.unwrap(), parent2_ytrsi.unwrap());
+            let new_otrsi = min(parent1_otsri.unwrap(), parent2_otsri.unwrap());
+            let new_ytrsi = max(parent1_ytrsi.unwrap(), parent2_ytrsi.unwrap());
 
             let index = tangle
                 .update_metadata(&message_id, |metadata| {
                     // OTRSI/YTRSI values need to be set before the solid flag, to ensure that the
                     // MilestoneConeUpdater is aware of all values.
-                    metadata.set_otrsi(best_otrsi);
-                    metadata.set_ytrsi(best_ytrsi);
+                    metadata.set_otrsi(new_otrsi);
+                    metadata.set_ytrsi(new_ytrsi);
                     metadata.solidify();
 
                     if metadata.flags().is_milestone() {


### PR DESCRIPTION
# Description of change

Return all confirmed messages from the "update_past_cone" and consume them in "update_future_cones".
The confirmed messages are consumed in following way:
1) for every confirmed message, add the direct children to the `children_to_visit`
2) iterate `children_to_visit`
3) skip in case the child is part of the confirmed messages set (that was produced by `update_past_cone()`
4) skip in case the child was already visited by a future cone walk
5) skip if the parents don't have OTRSI/YTRSI values (not solid yet)
6) skip if the child already inherited the OTRSI/YTRSI values (propagator.rs was faster)
7) else set the OTRSI/YTRSI values
8) add the direct children of the child to `children_to_visit` and go back to step 2)


## Links to any relevant issues

https://github.com/iotaledger/bee/issues/272

## Type of change

Choose a type of change, and delete any options that are not relevant.

- Bug fix (a non-breaking change which fixes an issue)
- Enhancement (a non-breaking change which adds functionality)

## How the change has been tested

Describe the tests that you ran to verify your changes.

Make sure to provide instructions for the maintainer as well as any relevant configurations.

## Change checklist

Tick the boxes that are relevant to your changes, and delete any items that are not.

- [X] I have followed the contribution guidelines for this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] I have checked that new and existing unit tests pass locally with my changes
- [X] I have updated the CHANGELOG.md, if my changes are significant enough
