### PR TITLE
fix(rest-api): remove `max_results` and `count` from address balance

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1428,7 +1428,7 @@ checksum = "c9495705279e7140bf035dde1f6e750c162df8b625267cd52cc44e0b156732c8"
 dependencies = [
  "cfg-if 1.0.0",
  "libc",
- "wasi 0.10.1+wasi-snapshot-preview1",
+ "wasi 0.10.0+wasi-snapshot-preview1",
 ]
 
 [[package]]
@@ -1671,9 +1671,9 @@ dependencies = [
 
 [[package]]
 name = "if-watch"
-version = "0.1.7"
+version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "16d7c5e361e6b05c882b4847dd98992534cebc6fcde7f4bc98225bcf10fd6d0d"
+checksum = "97b8538953a3f0d0d3868f0a706eb4273535e10d72acb5c82c1c23ae48835c85"
 dependencies = [
  "async-io",
  "futures",
@@ -1764,9 +1764,9 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.46"
+version = "0.3.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf3d7383929f7c9c7c2d0fa596f325832df98c3704f2c60553080f7127a58175"
+checksum = "5cfb73131c35423a367daf8cbd24100af0d077668c8c2943f0e7dd775fef0f65"
 dependencies = [
  "wasm-bindgen",
 ]
@@ -3351,11 +3351,12 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.1.43"
+version = "0.1.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca8a50ef2360fbd1eeb0ecd46795a87a19024eb4b53c5dc916ca1fd95fe62438"
+checksum = "6db9e6914ab8b1ae1c260a4ae7a49b6c5611b40328a735b21862567685e73255"
 dependencies = [
  "libc",
+ "wasi 0.10.0+wasi-snapshot-preview1",
  "winapi",
 ]
 
@@ -3774,15 +3775,15 @@ checksum = "cccddf32554fecc6acb585f82a32a72e28b48f8c4c1883ddfeeeaa96f7d8e519"
 
 [[package]]
 name = "wasi"
-version = "0.10.1+wasi-snapshot-preview1"
+version = "0.10.0+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "93c6c3420963c5c64bca373b25e77acb562081b9bb4dd5bb864187742186cea9"
+checksum = "1a143597ca7c7793eff794def352d41792a93c481eb1042423ff7ff72ba2c31f"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.69"
+version = "0.2.70"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3cd364751395ca0f68cafb17666eee36b63077fb5ecd972bbcd74c90c4bf736e"
+checksum = "55c0f7123de74f0dab9b7d00fd614e7b19349cd1e2f5252bbe9b1754b59433be"
 dependencies = [
  "cfg-if 1.0.0",
  "serde",
@@ -3792,9 +3793,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.69"
+version = "0.2.70"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1114f89ab1f4106e5b55e688b828c0ab0ea593a1ea7c094b141b14cbaaec2d62"
+checksum = "7bc45447f0d4573f3d65720f636bbcc3dd6ce920ed704670118650bcd47764c7"
 dependencies = [
  "bumpalo",
  "lazy_static",
@@ -3807,9 +3808,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.19"
+version = "0.4.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fe9756085a84584ee9457a002b7cdfe0bfff169f45d2591d8be1345a6780e35"
+checksum = "3de431a2910c86679c34283a33f66f4e4abd7e0aec27b6669060148872aadf94"
 dependencies = [
  "cfg-if 1.0.0",
  "js-sys",
@@ -3819,9 +3820,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.69"
+version = "0.2.70"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a6ac8995ead1f084a8dea1e65f194d0973800c7f571f6edd70adf06ecf77084"
+checksum = "3b8853882eef39593ad4174dd26fc9865a64e84026d223f63bb2c42affcbba2c"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -3829,9 +3830,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.69"
+version = "0.2.70"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5a48c72f299d80557c7c62e37e7225369ecc0c963964059509fbafe917c7549"
+checksum = "4133b5e7f2a531fa413b3a1695e925038a05a71cf67e87dafa295cb645a01385"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3842,9 +3843,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.69"
+version = "0.2.70"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e7811dd7f9398f14cc76efd356f98f03aa30419dea46aa810d71e819fc97158"
+checksum = "dd4945e4943ae02d15c13962b38a5b1e81eadd4b71214eee75af64a4d6a4fd64"
 
 [[package]]
 name = "wasm-timer"
@@ -3863,9 +3864,9 @@ dependencies = [
 
 [[package]]
 name = "web-sys"
-version = "0.3.46"
+version = "0.3.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "222b1ef9334f92a21d3fb53dc3fd80f30836959a90f9274a626d7e06315ba3c3"
+checksum = "c40dc691fc48003eba817c38da7113c15698142da971298003cac3ef175680b3"
 dependencies = [
  "js-sys",
  "wasm-bindgen",

--- a/bee-api/bee-rest-api/src/handlers/balance_ed25519.rs
+++ b/bee-api/bee-rest-api/src/handlers/balance_ed25519.rs
@@ -25,10 +25,7 @@ pub(crate) async fn balance_ed25519<B: StorageBackend>(
         .await
         .map_err(|_| reject::custom(ServiceUnavailable("can not fetch from storage".to_string())))?
     {
-        Some(mut ids) => {
-            let max_results = 1000;
-            let count = ids.len();
-            ids.truncate(max_results);
+        Some(ids) => {
             let mut balance = 0;
             for id in ids {
                 if let Some(output) = Fetch::<OutputId, bee_ledger::model::Output>::fetch(storage.deref(), &id)
@@ -53,8 +50,6 @@ pub(crate) async fn balance_ed25519<B: StorageBackend>(
             Ok(warp::reply::json(&SuccessBody::new(BalanceForAddressResponse {
                 address_type: 1,
                 address: addr.to_string(),
-                max_results,
-                count,
                 balance,
             })))
         }
@@ -70,9 +65,6 @@ pub struct BalanceForAddressResponse {
     pub address_type: u8,
     // hex encoded address
     pub address: String,
-    #[serde(rename = "maxResults")]
-    pub max_results: usize,
-    pub count: usize,
     pub balance: u64,
 }
 

--- a/bee-api/bee-rest-api/src/storage.rs
+++ b/bee-api/bee-rest-api/src/storage.rs
@@ -1,16 +1,13 @@
 // Copyright 2020 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
-use bee_ledger::model::{Output, Spent};
+use bee_ledger::model::{Balance, Output, Spent};
 use bee_message::{
-    payload::transaction::{Ed25519Address, OutputId},
+    payload::transaction::{Address, Ed25519Address, OutputId},
     prelude::HashedIndex,
     MessageId,
 };
-use bee_storage::{
-    access::{Exist, Fetch},
-    backend,
-};
+use bee_storage::{access::Fetch, backend};
 
 pub trait StorageBackend:
     backend::StorageBackend
@@ -19,6 +16,7 @@ pub trait StorageBackend:
     + Fetch<OutputId, Output>
     + Fetch<OutputId, Spent>
     + Fetch<Ed25519Address, Vec<OutputId>>
+    + Fetch<Address, Balance>
     + bee_protocol::storage::StorageBackend
 {
 }

--- a/bee-ledger/src/model/balance.rs
+++ b/bee-ledger/src/model/balance.rs
@@ -20,6 +20,15 @@ impl Balance {
             dust_output,
         }
     }
+    pub fn balance(&self) -> u64 {
+        self.balance
+    }
+    pub fn dust_allowance(&self) -> u64 {
+        self.dust_allowance
+    }
+    pub fn dust_output(&self) -> u64 {
+        self.dust_output
+    }
 }
 
 impl Packable for Balance {


### PR DESCRIPTION
# Description of change

Fixes the response for the `address/{address}` endpoint (Hornet removed the `max_results` and `count` fields).

## Links to any relevant issues

N/A

## Type of change

- Bug fix (a non-breaking change which fixes an issue)
- Enhancement (a non-breaking change which adds functionality)

## How the change has been tested

CLI Wallet

## Change checklist

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that new and existing unit tests pass locally with my changes
- [ ] I have updated the CHANGELOG.md, if my changes are significant enough
