### PR TITLE
'libp2p::PeerId' wrapper

### DIFF
--- a/bee-api/bee-rest-api/src/handlers/add_peer.rs
+++ b/bee-api/bee-rest-api/src/handlers/add_peer.rs
@@ -67,7 +67,7 @@ pub(crate) async fn add_peer(
             };
 
             if let Err(e) = network_controller.send(AddPeer {
-                id: peer_id,
+                id: peer_id.clone(),
                 address: multi_address.clone(),
                 alias: alias.clone(),
                 relation: PeerRelation::Known,
@@ -77,7 +77,7 @@ pub(crate) async fn add_peer(
 
             Ok(warp::reply::with_status(
                 warp::reply::json(&SuccessBody::new(AddPeerResponse(PeerDto {
-                    id: peer_id.to_string(),
+                    id: peer_id.long().to_string(),
                     alias,
                     multi_addresses: vec![multi_address.to_string()],
                     relation: RelationDto::Known,

--- a/bee-network/src/conns/errors.rs
+++ b/bee-network/src/conns/errors.rs
@@ -1,11 +1,9 @@
 // Copyright 2020 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::Multiaddr;
+use crate::{Multiaddr, PeerId};
 
-use thiserror::Error as ErrorAttr;
-
-#[derive(Debug, ErrorAttr)]
+#[derive(Debug, thiserror::Error)]
 pub enum Error {
     #[error("Building the underlying transport layer failed.")]
     CreatingTransportFailed,
@@ -16,27 +14,27 @@ pub enum Error {
     #[error("Tried to dial a banned address: {}.", .0)]
     DialedBannedAddress(Multiaddr),
     #[error("Tried to dial a banned peer: {}.", .0)]
-    DialedBannedPeer(String),
+    DialedBannedPeer(PeerId),
     #[error("Tried to dial self: {}.", .0)]
-    DialedSelf(String),
+    DialedSelf(PeerId),
     #[error("Tried to dial own listen address: {}.", .0)]
     DialedOwnAddress(Multiaddr),
     #[error("Tried to dial an unlisted peer: {}.", .0)]
-    DialedUnlistedPeer(String),
+    DialedUnlistedPeer(PeerId),
     #[error("Tried to dial a peer, that was rejected from the peerlist: {}.", .0)]
-    DialedRejectedPeer(String),
+    DialedRejectedPeer(PeerId),
     #[error("Failed dialing address: {}.", .0)]
     DialingFailed(Multiaddr),
     #[error("Already connected to peer: {}.", .0)]
-    DuplicateConnection(String),
+    DuplicateConnection(PeerId),
     #[error("Peer identifies with {}, but we expected: {}", .received, .expected)]
-    PeerIdMismatch { expected: String, received: String },
+    PeerIdMismatch { expected: PeerId, received: PeerId },
     #[error("Creating outbound substream with {} failed.", .0)]
-    CreatingOutboundSubstreamFailed(String),
+    CreatingOutboundSubstreamFailed(PeerId),
     #[error("Creating inbound substream with {} failed.", .0)]
-    CreatingInboundSubstreamFailed(String),
+    CreatingInboundSubstreamFailed(PeerId),
     #[error("Failed to upgrade a substream with {}.", .0)]
-    SubstreamProtocolUpgradeFailed(String),
+    SubstreamProtocolUpgradeFailed(PeerId),
     #[error("Failed to send an internal event ({}).", .0)]
     InternalEventSendFailure(&'static str),
     #[error("Failed to write a message to a stream.")]

--- a/bee-network/src/interaction/commands.rs
+++ b/bee-network/src/interaction/commands.rs
@@ -1,9 +1,9 @@
 // Copyright 2020 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::peers::PeerRelation;
+use crate::{peers::PeerRelation, PeerId};
 
-use libp2p::{Multiaddr, PeerId};
+use libp2p::Multiaddr;
 
 use tokio::sync::mpsc;
 

--- a/bee-network/src/peers/errors.rs
+++ b/bee-network/src/peers/errors.rs
@@ -1,11 +1,9 @@
 // Copyright 2020 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::{conns::Error as ConnError, Multiaddr};
+use crate::{conns::Error as ConnectionError, Multiaddr, PeerId};
 
-use thiserror::Error as ErrorAttr;
-
-#[derive(Debug, ErrorAttr)]
+#[derive(Debug, thiserror::Error)]
 pub enum Error {
     #[error("Failed to send an event ({}).", .0)]
     EventSendFailure(&'static str),
@@ -14,21 +12,21 @@ pub enum Error {
     // #[error("Failed to send a message to {}", .0)]
     // SendMessageFailure(String),
     #[error("Unlisted peer: {}", .0)]
-    UnlistedPeer(String),
+    UnlistedPeer(PeerId),
     // #[error("Disconnected peer: {}", .0)]
     // DisconnectedPeer(String),
     #[error("Failed to connect to peer. Cause: {:?}", .0)]
-    ConnectFailure(ConnError),
+    ConnectFailure(ConnectionError),
     #[error("Already banned that address: {}", .0)]
     AddressAlreadyBanned(Multiaddr),
     #[error("Already banned that peer: {}", .0)]
-    PeerAlreadyBanned(String),
+    PeerAlreadyBanned(PeerId),
     #[error("Already unbanned that address: {}", .0)]
     AddressAlreadyUnbanned(Multiaddr),
     #[error("Already unbanned that peer: {}", .0)]
-    PeerAlreadyUnbanned(String),
+    PeerAlreadyUnbanned(PeerId),
     #[error("Already added that peer: {}", .0)]
-    PeerAlreadyAdded(String),
+    PeerAlreadyAdded(PeerId),
     #[error("Tried to add more unknown peers than allowed ({}).", .0)]
     UnknownPeerLimitReached(usize),
 }

--- a/bee-node/src/tools/p2p_identity.rs
+++ b/bee-node/src/tools/p2p_identity.rs
@@ -1,7 +1,7 @@
 // Copyright 2020 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
-use bee_network::{Keypair, PeerId, PublicKey};
+use bee_network::{Keypair, PeerId};
 
 use structopt::StructOpt;
 
@@ -14,8 +14,5 @@ pub fn exec(_tool: &P2pIdentityTool) {
 
     println!("Your p2p private key:\t{}", hex::encode(keypair.encode()));
     println!("Your p2p public key:\t{}", hex::encode(public.encode()));
-    println!(
-        "Your p2p PeerID:\t{}",
-        PeerId::from_public_key(PublicKey::Ed25519(public))
-    );
+    println!("Your p2p PeerID:\t{}", PeerId::from_public_key(public));
 }

--- a/bee-peering/src/config.rs
+++ b/bee-peering/src/config.rs
@@ -3,7 +3,7 @@
 
 use crate::manual::{ManualPeeringConfig, ManualPeeringConfigBuilder};
 
-use bee_network::{Keypair, PeerId, PublicKey};
+use bee_network::{Keypair, PeerId};
 
 use serde::Deserialize;
 
@@ -40,7 +40,7 @@ impl PeeringConfigBuilder {
             generate_random_identity()
         };
 
-        let peer_id = PeerId::from_public_key(PublicKey::Ed25519(identity.public()));
+        let peer_id = PeerId::from_public_key(identity.public());
 
         PeeringConfig {
             identity_private_key: (identity, identity_string, new),

--- a/bee-peering/src/manual/manual.rs
+++ b/bee-peering/src/manual/manual.rs
@@ -22,7 +22,7 @@ impl PeerManager for ManualPeerManager {
         for (mut address, alias) in config.peers {
             // NOTE: `unwrap`ing should be fine here since it comes from the config.
             if let Protocol::P2p(multihash) = address.pop().unwrap() {
-                let id = PeerId::from_multihash(multihash).expect("Invalid Multiaddr.");
+                let id = PeerId::from_multihash(multihash).expect("Invalid Multiaddr.").into();
 
                 add_peer(network, id, address, alias);
             } else {


### PR DESCRIPTION
# Description of change

I wasn't really happy with the previous extension trait `ShortId`. It was very easy to implement, and just by exporting it, other bee crates could easily make use of it to create a shorter representation of the `PeerId`. The disadvantage was that whenever downstream code wanted to get this shorter repr., 2 allocations were required. At first the `PeerId` needed to be converted into an owned base58 representation. From that we would select a certain substring and turn that into an owned string for the caller to consume. This new implementation wraps the original peer id, and creates a buffer eagerly during construction. Alternatively one could use an Option to delay this until actually required. `PeerId`s are supposed to be displayed in various situations like logs and the user interface. Therefore it makes sense to not recreate its string representation over and over.

## Type of change

- Breaking change (fix or feature that would cause existing functionality to not work as expected)
