### PR TITLE
Run 'xMRSI updater' only for received milestones within BELOW_MAX_DEPTH

### DIFF
--- a/bee-protocol/src/worker/index_updater.rs
+++ b/bee-protocol/src/worker/index_updater.rs
@@ -149,7 +149,7 @@ async fn update_past_cone<B: StorageBackend>(
         updated.insert(parent_id);
     }
 
-    debug!("Updated milestone index for {} messages.", updated.len());
+    debug!("Set milestone index ({}) for {} messages.", index, updated.len());
 
     updated
 }

--- a/bee-protocol/src/worker/index_updater.rs
+++ b/bee-protocol/src/worker/index_updater.rs
@@ -83,13 +83,13 @@ async fn process<B: StorageBackend>(tangle: &MsTangle<B>, milestone: Milestone, 
         let roots = update_past_cone(tangle, parent1, parent2, index).await;
 
         // Note: For tip-selection only the most recent tangle is relevent. That means that during
-        // synchronization we do not need to update xMRSI values before (LMI - BELOW_MAX_DEPTH).
+        // synchronization we do not need to update xMRSI values or tip scores before (LMI - BELOW_MAX_DEPTH).
         if index > tangle.get_latest_milestone_index() - BELOW_MAX_DEPTH.into() {
             update_future_cone(tangle, roots).await;
-        }
 
-        // Update tip pool after all values got updated.
-        tangle.update_tip_scores().await;
+            // Update tip pool after all values got updated.
+            tangle.update_tip_scores().await;
+        }
     }
 }
 
@@ -123,7 +123,6 @@ async fn update_past_cone<B: StorageBackend>(
 
         tangle
             .update_metadata(&parent_id, |metadata| {
-                // TODO: Throw one of those indexes away ;)
                 metadata.set_milestone_index(index);
                 // TODO: That was fine in a synchronous scenario, where this algo had the newest information,
                 // but probably isn't the case in the now asynchronous scenario. Investigate!
@@ -183,7 +182,7 @@ async fn update_future_cone<B: StorageBackend>(tangle: &MsTangle<B>, roots: Hash
             for child in &children {
                 if let Some(child_metadata) = tangle.get_metadata(&child).await {
                     // We can ignore children that are already confirmed
-                    // TODO: resolve ambiguity betwenn `is_confirmed()` and `milestone_index().is_some()`
+                    // TODO: resolve ambiguity between `is_confirmed()` and `milestone_index().is_some()`
                     // if child_metadata.flags().is_confirmed() {
                     if child_metadata.milestone_index().is_some() {
                         continue;

--- a/bee-protocol/src/worker/solidifier.rs
+++ b/bee-protocol/src/worker/solidifier.rs
@@ -19,7 +19,7 @@ use bee_message::{
     MessageId,
 };
 use bee_runtime::{event::Bus, node::Node, shutdown_stream::ShutdownStream, worker::Worker};
-use bee_tangle::{traversal, MsTangle, TangleWorker};
+use bee_tangle::{traversal, MsTangle, TangleWorker, BELOW_MAX_DEPTH};
 
 use async_trait::async_trait;
 use futures::StreamExt;
@@ -85,11 +85,9 @@ async fn solidify<B: StorageBackend>(
         warn!("Sending message_id to ledger worker failed: {}.", e);
     }
 
-    const MAX_BELOW_DEPTH: u32 = 15;
-
     // Note: For tip-selection only the most recent tangle is relevent. That means that during
-    // synchronization we do not need to update xMRSI values before MAX_BELOW_DEPTH.
-    if index > tangle.get_latest_milestone_index() - MAX_BELOW_DEPTH.into() {
+    // synchronization we do not need to update xMRSI values before (LMI - BELOW_MAX_DEPTH).
+    if index > tangle.get_latest_milestone_index() - BELOW_MAX_DEPTH.into() {
         if let Err(e) = index_updater_worker
             // TODO get MS
             .send(IndexUpdaterWorkerEvent(index, Milestone::new(id, 0)))

--- a/bee-tangle/src/lib.rs
+++ b/bee-tangle/src/lib.rs
@@ -19,6 +19,7 @@ mod vertex;
 
 pub use ms_tangle::MsTangle;
 pub use tangle::{Hooks, Tangle};
+pub use urts::BELOW_MAX_DEPTH;
 pub use worker::TangleWorker;
 
 use bee_message::Message;

--- a/bee-tangle/src/urts.rs
+++ b/bee-tangle/src/urts.rs
@@ -27,7 +27,7 @@ const YTRSI_DELTA: u32 = 8;
 const OTRSI_DELTA: u32 = 13;
 // M: the maximum allowed delta value between OTRSI of a given message in relation to the current LSMI before it
 // gets lazy.
-const BELOW_MAX_DEPTH: u32 = 15;
+pub const BELOW_MAX_DEPTH: u32 = 15;
 // If the amount of non-lazy tips exceed this limit, remove the parent(s) of the inserted tip to compensate for the
 // excess. This rule helps to reduce the amount of tips in the network.
 const MAX_LIMIT_NON_LAZY: u8 = 100;


### PR DESCRIPTION
# Description of change

With this PR the xMRSI future cone walker will only run for the most recent Tangle (Milestones within BELOW_MAX_DEPTH). This frees up resources for the syncing process, and prevents the node from doing useless computation.

## Type of change

- Enhancement (a non-breaking change which adds functionality)

