### PR TITLE
Aligns log output to increase readability

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -30,7 +30,7 @@ checksum = "cdb031dd78e28731d87d56cc8ffef4a8f36ca26c38fe2de700543e627f8a464a"
 
 [[package]]
 name = "bee-common"
-version = "0.3.0-alpha"
+version = "0.3.1-alpha"
 dependencies = [
  "autocfg",
  "chrono",

--- a/bee-common/bee-common/CHANGELOG.md
+++ b/bee-common/bee-common/CHANGELOG.md
@@ -19,6 +19,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Security -->
 
+## 0.3.1-alpha - 2021-02-15
+
+### Added
+
+- `LoggerConfig::target_width`;
+- `LoggerConfig::level_width`;
+
 ## 0.3.0-alpha - 2021-01-15
 
 ### Added

--- a/bee-common/bee-common/Cargo.toml
+++ b/bee-common/bee-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bee-common"
-version = "0.3.0-alpha"
+version = "0.3.1-alpha"
 authors = ["IOTA Stiftung"]
 edition = "2018"
 description = "Common utilities used across the bee framework"

--- a/bee-common/bee-common/src/logger/config.rs
+++ b/bee-common/bee-common/src/logger/config.rs
@@ -10,6 +10,10 @@ use std::borrow::Cow;
 
 /// Default value for the color flag.
 const DEFAULT_COLOR_ENABLED: bool = true;
+/// Default value for the target width.
+const DEFAULT_TARGET_WIDTH: usize = 42;
+/// Default value for the level width.
+const DEFAULT_LEVEL_WIDTH: usize = 5;
 /// Default name for an output.
 const DEFAULT_OUTPUT_NAME: &str = LOGGER_STDOUT_NAME;
 /// Default log level for an output.
@@ -82,6 +86,10 @@ pub struct LoggerOutputConfig {
 pub struct LoggerConfigBuilder {
     /// Color flag of the logger.
     color_enabled: Option<bool>,
+    /// Width of the target section of a log.
+    target_width: Option<usize>,
+    /// Width of the level section of a log.
+    level_width: Option<usize>,
     /// Outputs of the logger.
     outputs: Option<Vec<LoggerOutputConfigBuilder>>,
 }
@@ -90,6 +98,18 @@ impl LoggerConfigBuilder {
     /// Sets the color flag of a logger.
     pub fn color_enabled(mut self, color: bool) -> Self {
         self.color_enabled.replace(color);
+        self
+    }
+
+    /// Sets the target width.
+    pub fn with_target_width(mut self, width: usize) -> Self {
+        self.target_width.replace(width);
+        self
+    }
+
+    /// Sets the target width.
+    pub fn with_level_width(mut self, width: usize) -> Self {
+        self.level_width.replace(width);
         self
     }
 
@@ -122,6 +142,8 @@ impl LoggerConfigBuilder {
 
         LoggerConfig {
             color_enabled: self.color_enabled.unwrap_or(DEFAULT_COLOR_ENABLED),
+            target_width: self.target_width.unwrap_or(DEFAULT_TARGET_WIDTH),
+            level_width: self.level_width.unwrap_or(DEFAULT_LEVEL_WIDTH),
             outputs,
         }
     }
@@ -132,6 +154,10 @@ impl LoggerConfigBuilder {
 pub struct LoggerConfig {
     /// Color flag of the logger.
     pub(crate) color_enabled: bool,
+    /// Width of the target section of a log.
+    pub(crate) target_width: usize,
+    /// Width of the level section of a log.
+    pub(crate) level_width: usize,
     /// Outputs of the logger.
     pub(crate) outputs: Vec<LoggerOutputConfig>,
 }

--- a/bee-common/bee-common/src/logger/mod.rs
+++ b/bee-common/bee-common/src/logger/mod.rs
@@ -31,11 +31,13 @@ pub enum Error {
 macro_rules! log_format {
     ($target:expr, $level:expr, $message:expr) => {
         format_args!(
-            "{}[{}][{}] {}",
+            "{} {:target_width$} {:^level_width$} {}",
             chrono::Local::now().format("[%Y-%m-%d][%H:%M:%S]"),
             $target,
             $level,
-            $message
+            $message,
+            level_width = 5,
+            target_width = 40
         )
     };
 }

--- a/bee-common/bee-common/src/logger/mod.rs
+++ b/bee-common/bee-common/src/logger/mod.rs
@@ -32,7 +32,7 @@ macro_rules! log_format {
     ($target:expr, $level:expr, $message:expr) => {
         format_args!(
             "{} {:target_width$} {:level_width$} {}",
-            chrono::Local::now().format("[%Y-%m-%d %H:%M:%S]"),
+            chrono::Local::now().format("%Y-%m-%d %H:%M:%S"),
             $target,
             $level,
             $message,

--- a/bee-common/bee-common/src/logger/mod.rs
+++ b/bee-common/bee-common/src/logger/mod.rs
@@ -31,13 +31,13 @@ pub enum Error {
 macro_rules! log_format {
     ($target:expr, $level:expr, $message:expr) => {
         format_args!(
-            "{} {:target_width$} {:^level_width$} {}",
-            chrono::Local::now().format("[%Y-%m-%d][%H:%M:%S]"),
+            "{} {:target_width$} {:level_width$} {}",
+            chrono::Local::now().format("[%Y-%m-%d %H:%M:%S]"),
             $target,
             $level,
             $message,
-            level_width = 5,
-            target_width = 40
+            target_width = 42,
+            level_width = 5
         )
     };
 }


### PR DESCRIPTION
Aligns the log output in the following way:
```
2021-02-10 00:17:38 swarm_client::host::host                   INFO  Network host started.
2021-02-10 00:17:38 swarm_client::service::service             INFO  Network service started.
2021-02-10 00:17:38 swarm_client::service::service             INFO  Reconnecter running.
2021-02-10 00:17:38 swarm_client::service::service             INFO  Command handler running.
2021-02-10 00:17:38 swarm_client::service::service             INFO  Event handler running.
2021-02-10 00:17:38 swarm_client::host::host                   INFO  Binding address(es): /ip4/0.0.0.0/tcp/15600
2021-02-10 00:17:38 libp2p_tcp                                 DEBUG listening on 0.0.0.0:15600
2021-02-10 00:17:38 swarm_client::host::host                   INFO  Host running.
2021-02-10 00:17:38 swarm_client::swarm::behavior              DEBUG Swarm produced MdnsEvent::Discovered event (0).
2021-02-10 00:17:38 swarm_client::swarm::behavior              DEBUG Kademlia RoutingUpdated.
2021-02-10 00:17:38 swarm_client::host::host                   INFO  Dialing peer 12D3KooWREofWSyKBHZRSadGrLRW1qfZaBaM9PBMom2Sws9TttYA.
2021-02-10 00:17:38 libp2p_tcp                                 DEBUG dialing 127.0.0.1:16600
2021-02-10 00:17:38 libp2p_tcp                                 DEBUG New listen address: /ip4/192.168.1.8/tcp/15600
```
I think this will make reading Bee's log output easier, not only for us devs, but also for testers and the community when trying to help with debugging.


