### PR TITLE
fix(ci): Run CI on chrysalis-pt-2 branch

### DIFF
--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -7,6 +7,7 @@ on:
     branches:
       - dev
       - stable
+      - chrysalis-pt-2
     paths:
       - "**/Cargo.lock"
       - "**/Cargo.toml"
@@ -14,6 +15,7 @@ on:
     branches:
       - dev
       - stable
+      - chrysalis-pt-2
     paths:
       - "**/Cargo.lock"
       - "**/Cargo.toml"

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -5,10 +5,12 @@ on:
     branches:
       - dev
       - stable
+      - chrysalis-pt-2
   pull_request:
     branches:
       - dev
       - stable
+      - chrysalis-pt-2
 
 jobs:
   check:

--- a/.github/workflows/clippy.yml
+++ b/.github/workflows/clippy.yml
@@ -5,10 +5,12 @@ on:
     branches:
       - dev
       - stable
+      - chrysalis-pt-2
   pull_request:
     branches:
       - dev
       - stable
+      - chrysalis-pt-2
 
 jobs:
   clippy:

--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -5,10 +5,12 @@ on:
     branches:
       - dev
       - stable
+      - chrysalis-pt-2
   pull_request:
     branches:
       - dev
       - stable
+      - chrysalis-pt-2
 
 jobs:
   format:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,10 +5,12 @@ on:
     branches:
       - dev
       - stable
+      - chrysalis-pt-2
   pull_request:
     branches:
       - dev
       - stable
+      - chrysalis-pt-2
 
 jobs:
   test:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -29,6 +29,13 @@ jobs:
         toolchain: ${{ matrix.rust }}
         override: true
 
+    - name: Set up MSYS2 and install clang
+      if: matrix.os == 'windows-latest'
+      uses: msys2/setup-msys2@v2
+      with:
+        update: true
+        install: mingw-w64-x86_64-clang
+
     - name: Cache cargo registry
       uses: actions/cache@v2
       with:

--- a/.github/workflows/udeps.yml
+++ b/.github/workflows/udeps.yml
@@ -5,10 +5,12 @@ on:
     branches:
       - dev
       - stable
+      - chrysalis-pt-2
   pull_request:
     branches:
       - dev
       - stable
+      - chrysalis-pt-2
 
 jobs:
   udeps:


### PR DESCRIPTION
# Description of change

When the default branch was changed to `chrysalis-pt-2`, the CI configs were not updated. As a result, they don't run on PRs or pushes to the `chrysalis-pt-2` branch

## Links to any relevant issues

N/A

## Type of change

- Bug fix (a non-breaking change which fixes an issue)

## How the change has been tested

N/A

## Change checklist

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code