### PR TITLE
Fix/readme windows autocrlf

### DIFF
--- a/bee-node/README.md
+++ b/bee-node/README.md
@@ -28,8 +28,6 @@ choco install git --params '/NoAutoCrlf' nodejs-lts cmake --installargs 'ADD_CMA
 ```
 Restart Powershell
 
-> **WARNING**: If you already had git installed from another source and havent already, set `autocrlf` to `false` for this repo.
-
 ### Rust
 
 Minimum required version 1.47.


### PR DESCRIPTION
# Description of change

As we have a gitattributes file in the node-dashboard now, which handles line endings for the user, we can remove the warning about the autocrlf  config

## Links to any relevant issues

Fixes #390

## Type of change

- Enhancement (a non-breaking change which adds functionality)
- Documentation Fix

## How the change has been tested

Building Bee with dashboard worked fine.

## Change checklist

Tick the boxes that are relevant to your changes, and delete any items that are not.

- [x] I have followed the contribution guidelines for this project
- [x] I have made corresponding changes to the documentation