### PR TITLE
Use compile time checked parents type

### DIFF
--- a/bee-api/bee-rest-api/src/handlers/message_metadata.rs
+++ b/bee-api/bee-rest-api/src/handlers/message_metadata.rs
@@ -128,7 +128,7 @@ pub(crate) async fn message_metadata<B: StorageBackend>(
 
             Ok(warp::reply::json(&SuccessBody::new(MessageMetadataResponse {
                 message_id: message_id.to_string(),
-                parent_message_ids: message.parents().iter().map(|id| id.to_string()).collect(),
+                parent_message_ids: message.parents().map(|id| id.to_string()).collect(),
                 is_solid,
                 referenced_by_milestone_index,
                 milestone_index,

--- a/bee-api/bee-rest-api/src/handlers/submit_message.rs
+++ b/bee-api/bee-rest-api/src/handlers/submit_message.rs
@@ -105,7 +105,7 @@ pub(crate) async fn submit_message<B: StorageBackend>(
     let message = if let Some(nonce) = nonce {
         let mut builder = MessageBuilder::new()
             .with_network_id(network_id)
-            .with_parents(parents)
+            .with_parents(parents.into())
             .with_nonce_provider(ConstantBuilder::new().with_value(nonce).finish(), 0f64, None);
         if let Some(payload) = payload {
             builder = builder.with_payload(payload)
@@ -121,7 +121,7 @@ pub(crate) async fn submit_message<B: StorageBackend>(
         }
         let mut builder = MessageBuilder::new()
             .with_network_id(network_id)
-            .with_parents(parents)
+            .with_parents(parents.into())
             .with_nonce_provider(
                 MinerBuilder::new().with_num_workers(num_cpus::get()).finish(),
                 protocol_config.minimum_pow_score(),

--- a/bee-api/bee-rest-api/src/types.rs
+++ b/bee-api/bee-rest-api/src/types.rs
@@ -600,7 +600,7 @@ impl TryFrom<&Box<MilestonePayload>> for Box<MilestonePayloadDto> {
             kind: 1,
             index: value.essence().index(),
             timestamp: value.essence().timestamp(),
-            parents: value.essence().parents().iter().map(|p| p.to_string()).collect(),
+            parents: value.essence().parents().map(|p| p.to_string()).collect(),
             inclusion_merkle_proof: hex::encode(value.essence().merkle_proof()),
             public_keys: value.essence().public_keys().iter().map(hex::encode).collect(),
             receipt: value.essence().receipt().map(TryInto::try_into).transpose()?,

--- a/bee-ledger/src/worker.rs
+++ b/bee-ledger/src/worker.rs
@@ -61,7 +61,7 @@ where
 
     let mut metadata = WhiteFlagMetadata::new(MilestoneIndex(milestone.essence().index()));
 
-    let parents = message.parents().to_vec();
+    let parents = message.parents().copied().collect();
 
     drop(message);
 

--- a/bee-message/src/lib.rs
+++ b/bee-message/src/lib.rs
@@ -17,6 +17,6 @@ pub mod prelude;
 pub mod solid_entry_point;
 
 pub use error::Error;
-pub use message::{Message, MessageBuilder, MESSAGE_LENGTH_MAX, MESSAGE_LENGTH_MIN, MESSAGE_PARENTS_RANGE};
+pub use message::{Message, MessageBuilder, MESSAGE_LENGTH_MAX, MESSAGE_LENGTH_MIN};
 pub use message_id::{MessageId, MESSAGE_ID_LENGTH};
 pub use parents::Parents;

--- a/bee-message/src/parents.rs
+++ b/bee-message/src/parents.rs
@@ -5,7 +5,10 @@ use crate::{Error, MessageId, MESSAGE_ID_LENGTH};
 
 use bee_common::packable::{Packable, Read, Write};
 
-use std::{marker::PhantomData, ops::Deref};
+use std::{
+    marker::PhantomData,
+    ops::{Deref, RangeInclusive},
+};
 
 macro_rules! make_stages {
     ($($parent_n:ident),+) => {
@@ -143,9 +146,15 @@ impl Packable for Parents {
     fn unpack<R: Read + ?Sized>(reader: &mut R) -> Result<Self, Self::Error> {
         let _parents_len = u8::unpack(reader)? as usize;
 
+        // const MESSAGE_PARENTS_RANGE: RangeInclusive<usize> = 1..=8;
+
         // if !MESSAGE_PARENTS_RANGE.contains(&parents_len) {
         //     return Err(Error::InvalidParentsCount(parents_len));
         // }
+
+        // NB: The code doesn't depend on `parents_len`, or its correctness anymore. Instead, the
+        // code errors out, if it can not unpack at least 1, or even more than 8 parents. Each
+        // `parents` variable is a distinct type according to the builder stage we're in.
 
         let parents = Parents::new(MessageId::unpack(reader)?);
 

--- a/bee-message/src/parents.rs
+++ b/bee-message/src/parents.rs
@@ -5,11 +5,13 @@ use crate::{Error, MessageId, MESSAGE_ID_LENGTH};
 
 use bee_common::packable::{Packable, Read, Write};
 
+use serde::{Deserialize, Serialize};
+
 use core::ops::RangeInclusive;
 
 pub const MESSAGE_PARENTS_RANGE: RangeInclusive<usize> = 1..=8;
 
-#[derive(Clone, Debug, Eq, PartialEq)]
+#[derive(Clone, Debug, Eq, PartialEq, Deserialize, Serialize)]
 pub struct Parents {
     first: MessageId,
     others: Vec<MessageId>,

--- a/bee-protocol/src/worker/index_updater.rs
+++ b/bee-protocol/src/worker/index_updater.rs
@@ -74,7 +74,7 @@ where
 async fn process<B: StorageBackend>(tangle: &MsTangle<B>, milestone: Milestone, index: MilestoneIndex) {
     let message_id = milestone.message_id();
 
-    if let Some(parents) = tangle.get(message_id).await.map(|message| message.parents().to_vec()) {
+    if let Some(parents) = tangle.get(message_id).await.map(|message| message.parents().copied().collect()) {
         // Update the past cone of this milestone by setting its milestone index, and return them.
         let roots = update_past_cone(tangle, parents, index).await;
 
@@ -125,7 +125,7 @@ async fn update_past_cone<B: StorageBackend>(
             })
             .await;
 
-        if let Some(mut grand_parents) = tangle.get(&parent_id).await.map(|parent| parent.parents().to_vec()) {
+        if let Some(mut grand_parents) = tangle.get(&parent_id).await.map(|parent| parent.parents().copied().collect()) {
             parents.append(&mut grand_parents);
         }
 

--- a/bee-protocol/src/worker/message/payload/milestone.rs
+++ b/bee-protocol/src/worker/message/payload/milestone.rs
@@ -55,7 +55,7 @@ async fn validate<B: StorageBackend>(
 
     match message.payload() {
         Some(Payload::Milestone(milestone)) => {
-            if message.parents() != milestone.essence().parents() {
+            if !message.parents().eq(milestone.essence().parents()) {
                 return Err(Error::ParentsMismatch);
             }
 

--- a/bee-protocol/src/worker/message/processor.rs
+++ b/bee-protocol/src/worker/message/processor.rs
@@ -145,7 +145,8 @@ where
 
                         let metadata = MessageMetadata::arrived();
 
-                        let parents = message.parents().to_vec();
+                        // TODO try to avoid that
+                        let parents = message.parents().copied().collect::<Vec<MessageId>>();
 
                         // store message
                         let inserted = tangle.insert(message, message_id, metadata).await.is_some();
@@ -190,7 +191,6 @@ where
                                 metrics.messages_average_latency_set(latency_sum / latency_num);
 
                                 for parent in parents.iter() {
-                                    // TODO only request once if same parents
                                     helper::request_message(
                                         &tangle,
                                         &message_requester,

--- a/bee-protocol/src/worker/propagator.rs
+++ b/bee-protocol/src/worker/propagator.rs
@@ -41,7 +41,11 @@ async fn propagate<B: StorageBackend>(
         }
 
         // TODO Copying parents to avoid double locking, will be refactored.
-        if let Some(parents) = tangle.get(&message_id).await.map(|message| message.parents().to_vec()) {
+        if let Some(parents) = tangle
+            .get(&message_id)
+            .await
+            .map(|message| message.parents().copied().collect::<Vec<MessageId>>())
+        {
             // If one of the parents is not yet solid, we skip the current message.
             for parent in parents.iter() {
                 if !tangle.is_solid_message(parent).await {

--- a/bee-protocol/src/worker/solidifier.rs
+++ b/bee-protocol/src/worker/solidifier.rs
@@ -160,7 +160,7 @@ where
                                 *lsmi + 1,
                                 *next - 1
                             );
-                            for parent in message.parents().iter() {
+                            for parent in message.parents() {
                                 helper::request_message(
                                     &tangle,
                                     &message_requester,

--- a/bee-tangle/src/tangle.rs
+++ b/bee-tangle/src/tangle.rs
@@ -143,7 +143,7 @@ where
         let r = match self.vertices.write().await.entry(message_id) {
             Entry::Occupied(_) => None,
             Entry::Vacant(entry) => {
-                for parent in message.parents().iter() {
+                for parent in message.parents() {
                     self.add_child_inner(*parent, message_id).await;
                 }
                 let vtx = Vertex::new(message, metadata);

--- a/bee-tangle/src/traversal.rs
+++ b/bee-tangle/src/traversal.rs
@@ -14,65 +14,65 @@ use bee_message::MessageId;
 
 use std::{collections::HashSet, future::Future};
 
-/// A Tangle walker that - given a starting vertex - visits all of its ancestors that are connected through
-/// the first *parent* edge. The walk continues as long as the visited vertices match a certain condition. For each
-/// visited vertex a customized logic can be applied. Each traversed vertex provides read access to its
-/// associated data and metadata.
-pub async fn visit_parents_follow_first_parent<Metadata, Match, Apply, H: Hooks<Metadata>>(
-    tangle: &Tangle<Metadata, H>,
-    mut message_id: MessageId,
-    mut matches: Match,
-    mut apply: Apply,
-) where
-    Metadata: Clone + Copy,
-    Match: FnMut(&MessageRef, &Metadata) -> bool,
-    Apply: FnMut(&MessageId, &MessageRef, &Metadata),
-{
-    while let Some(vtx) = tangle.get_vertex(&message_id).await {
-        if !matches(vtx.message(), vtx.metadata()) {
-            break;
-        } else {
-            apply(&message_id, vtx.message(), vtx.metadata());
-            message_id = vtx.parents()[0];
-        }
-    }
-}
+// /// A Tangle walker that - given a starting vertex - visits all of its ancestors that are connected through
+// /// the first *parent* edge. The walk continues as long as the visited vertices match a certain condition. For each
+// /// visited vertex a customized logic can be applied. Each traversed vertex provides read access to its
+// /// associated data and metadata.
+// pub async fn visit_parents_follow_first_parent<Metadata, Match, Apply, H: Hooks<Metadata>>(
+//     tangle: &Tangle<Metadata, H>,
+//     mut message_id: MessageId,
+//     mut matches: Match,
+//     mut apply: Apply,
+// ) where
+//     Metadata: Clone + Copy,
+//     Match: FnMut(&MessageRef, &Metadata) -> bool,
+//     Apply: FnMut(&MessageId, &MessageRef, &Metadata),
+// {
+//     while let Some(vtx) = tangle.get_vertex(&message_id).await {
+//         if !matches(vtx.message(), vtx.metadata()) {
+//             break;
+//         } else {
+//             apply(&message_id, vtx.message(), vtx.metadata());
+//             message_id = vtx.parents()[0];
+//         }
+//     }
+// }
 
-/// A Tangle walker that - given a starting vertex - visits all of its children that are connected through
-/// the first *parent* edge. The walk continues as long as the visited vertices match a certain condition. For each
-/// visited vertex a customized logic can be applied. Each traversed vertex provides read access to its
-/// associated data and metadata.
-pub async fn visit_children_follow_first_parent<Metadata, Match, Apply, H: Hooks<Metadata>>(
-    tangle: &Tangle<Metadata, H>,
-    root: MessageId,
-    mut matches: Match,
-    mut apply: Apply,
-) where
-    Metadata: Clone + Copy,
-    Match: FnMut(&MessageRef, &Metadata) -> bool,
-    Apply: FnMut(&MessageId, &MessageRef, &Metadata),
-{
-    // TODO could be simplified like visit_parents_follow_parent1 ? Meaning no vector ?
-    let mut children = vec![root];
-
-    while let Some(ref parent_id) = children.pop() {
-        if let Some(parent) = tangle.get_vertex(parent_id).await {
-            if matches(parent.message(), parent.metadata()) {
-                apply(parent_id, parent.message(), parent.metadata());
-
-                if let Some(parent_children) = tangle.get_children(parent_id).await {
-                    for child_id in parent_children {
-                        if let Some(child) = tangle.get_vertex(&child_id).await {
-                            if &child.parents()[0] == parent_id {
-                                children.push(child_id);
-                            }
-                        }
-                    }
-                }
-            }
-        }
-    }
-}
+// /// A Tangle walker that - given a starting vertex - visits all of its children that are connected through
+// /// the first *parent* edge. The walk continues as long as the visited vertices match a certain condition. For each
+// /// visited vertex a customized logic can be applied. Each traversed vertex provides read access to its
+// /// associated data and metadata.
+// pub async fn visit_children_follow_first_parent<Metadata, Match, Apply, H: Hooks<Metadata>>(
+//     tangle: &Tangle<Metadata, H>,
+//     root: MessageId,
+//     mut matches: Match,
+//     mut apply: Apply,
+// ) where
+//     Metadata: Clone + Copy,
+//     Match: FnMut(&MessageRef, &Metadata) -> bool,
+//     Apply: FnMut(&MessageId, &MessageRef, &Metadata),
+// {
+//     // TODO could be simplified like visit_parents_follow_parent1 ? Meaning no vector ?
+//     let mut children = vec![root];
+//
+//     while let Some(ref parent_id) = children.pop() {
+//         if let Some(parent) = tangle.get_vertex(parent_id).await {
+//             if matches(parent.message(), parent.metadata()) {
+//                 apply(parent_id, parent.message(), parent.metadata());
+//
+//                 if let Some(parent_children) = tangle.get_children(parent_id).await {
+//                     for child_id in parent_children {
+//                         if let Some(child) = tangle.get_vertex(&child_id).await {
+//                             if &child.parents()[0] == parent_id {
+//                                 children.push(child_id);
+//                             }
+//                         }
+//                     }
+//                 }
+//             }
+//         }
+//     }
+// }
 
 /// A Tangle walker that - given a starting vertex - visits all of its ancestors that are connected through
 /// either the *parent1* or the *parent2* edge. The walk continues as long as the visited vertices match a certain
@@ -107,7 +107,7 @@ pub async fn visit_parents_depth_first<Fut, Metadata, Match, Apply, ElseApply, M
                     if matches(message_id, vtx.message().clone(), *vtx.metadata()).await {
                         apply(&message_id, vtx.message(), vtx.metadata());
 
-                        for parent in vtx.parents().iter() {
+                        for parent in vtx.parents() {
                             parents.push(*parent);
                         }
                     } else {

--- a/bee-tangle/src/vertex.rs
+++ b/bee-tangle/src/vertex.rs
@@ -27,7 +27,7 @@ where
         }
     }
 
-    pub fn parents(&self) -> &[MessageId] {
+    pub fn parents(&self) -> impl Iterator<Item = &MessageId> + '_ {
         self.message.parents()
     }
 

--- a/bee-test/src/rand/message.rs
+++ b/bee-test/src/rand/message.rs
@@ -4,12 +4,13 @@
 use crate::rand::{
     bytes::{rand_bytes, rand_bytes_32},
     integer::rand_integer,
+    parents::rand_parents,
     string::rand_string,
 };
 
 use bee_message::{
     payload::{indexation::IndexationPayload, Payload},
-    Message, MessageBuilder, MessageId,
+    Message, MessageBuilder, MessageId, Parents,
 };
 use bee_pow::providers::{Constant, ConstantBuilder, ProviderBuilder};
 
@@ -30,7 +31,7 @@ pub fn rand_payload() -> Payload {
     rand_indexation().into()
 }
 
-pub fn rand_message_with_parents(parents: Vec<MessageId>) -> Message {
+pub fn rand_message_with_parents(parents: Parents) -> Message {
     MessageBuilder::<Constant>::new()
         .with_network_id(rand_integer())
         .with_parents(parents)
@@ -41,6 +42,5 @@ pub fn rand_message_with_parents(parents: Vec<MessageId>) -> Message {
 }
 
 pub fn rand_message() -> Message {
-    // TODO variable number of parents
-    rand_message_with_parents(vec![rand_message_id(), rand_message_id()])
+    rand_message_with_parents(rand_parents())
 }

--- a/bee-test/src/rand/mod.rs
+++ b/bee-test/src/rand/mod.rs
@@ -12,6 +12,7 @@ pub mod milestone;
 pub mod option;
 pub mod output;
 pub mod output_diff;
+pub mod parents;
 pub mod snapshot;
 pub mod solid_entry_point;
 pub mod string;

--- a/bee-test/src/rand/parents.rs
+++ b/bee-test/src/rand/parents.rs
@@ -1,0 +1,13 @@
+// Copyright 2020 IOTA Stiftung
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::rand::{
+    integer::rand_integer_range,
+    message::{rand_message_id, rand_message_ids},
+};
+
+use bee_message::Parents;
+
+pub fn rand_parents() -> Parents {
+    Parents::new(rand_message_id(), rand_message_ids(rand_integer_range(0..8))).unwrap()
+}

--- a/bee-test/src/rand/parents.rs
+++ b/bee-test/src/rand/parents.rs
@@ -1,13 +1,10 @@
 // Copyright 2020 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::rand::{
-    integer::rand_integer_range,
-    message::{rand_message_id, rand_message_ids},
-};
+use crate::rand::{integer::rand_integer_range, message::rand_message_ids};
 
 use bee_message::Parents;
 
 pub fn rand_parents() -> Parents {
-    Parents::new(rand_message_id(), rand_message_ids(rand_integer_range(0..8))).unwrap()
+    rand_message_ids(rand_integer_range(0..8)).into()
 }


### PR DESCRIPTION
# Description of change

Based off of Thibault's 'use-parents-type' PR I created an alternative solution:

Advantages:
* Uses only a `Vec` internally instead of a single field and a vec, which makes sorting and deduping message ids easier, which this PR already comes with.
* The instantiated `Parents` type guarantees the correct range of parents (1..=8). This is achieved through a stage-builder pattern.
* The `Parents` type `deref`s to a `Vec`, and impls `From<Vec>`

Disadvantages:
* The stage-builder pattern is relatively verbose, and especially in our case we have 8 stages (1 for each parent). I tried to mitigate this problem a bit by making use of macros.
* The code is a bit weird, because you cannot use loops.
