### PR TITLE
fix b1t6 decode

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -96,7 +96,7 @@ dependencies = [
 
 [[package]]
 name = "bee-ternary"
-version = "0.4.0-alpha"
+version = "0.4.1-alpha"
 dependencies = [
  "autocfg",
  "num-traits",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -62,7 +62,7 @@ dependencies = [
 
 [[package]]
 name = "bee-runtime"
-version = "0.1.0-alpha"
+version = "0.1.1-alpha"
 dependencies = [
  "async-trait",
  "bee-storage",

--- a/bee-crypto/Cargo.toml
+++ b/bee-crypto/Cargo.toml
@@ -11,7 +11,7 @@ keywords = ["iota", "tangle", "bee", "framework", "crypto"]
 homepage = "https://www.iota.org"
 
 [dependencies]
-bee-ternary = { version = "0.4.0-alpha", path = "../bee-ternary" }
+bee-ternary = { version = "0.4.1-alpha", path = "../bee-ternary" }
 
 byteorder = "1.3"
 lazy_static = "1.4"

--- a/bee-signing/Cargo.toml
+++ b/bee-signing/Cargo.toml
@@ -13,7 +13,7 @@ homepage = "https://www.iota.org"
 [dependencies]
 bee-common-derive = { version = "0.1.1-alpha", path = "../bee-common/bee-common-derive" }
 bee-crypto = { version = "0.2.0-alpha", path = "../bee-crypto" }
-bee-ternary = { version = "0.4.0-alpha", path = "../bee-ternary" }
+bee-ternary = { version = "0.4.1-alpha", path = "../bee-ternary" }
 
 rand = "0.8"
 sha3 = "0.9"

--- a/bee-ternary/CHANGELOG.md
+++ b/bee-ternary/CHANGELOG.md
@@ -19,6 +19,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Security -->
 
+## 0.4.1-alpha - 2021-03-15
+
+### Fixed
+
+- T6B1 decoding.
+
 ## 0.4.0-alpha - 2021-01-18
 
 ### Added

--- a/bee-ternary/CHANGELOG.md
+++ b/bee-ternary/CHANGELOG.md
@@ -29,7 +29,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- T6B1 bytes-as-trits encoding and decoding support.
+- B1T6 bytes-as-trits encoding and decoding support.
 
 ## 0.3.4-alpha - 2020-11-13
 

--- a/bee-ternary/CHANGELOG.md
+++ b/bee-ternary/CHANGELOG.md
@@ -23,7 +23,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- T6B1 decoding.
+- B1T6 decoding.
 
 ## 0.4.0-alpha - 2021-01-18
 

--- a/bee-ternary/Cargo.toml
+++ b/bee-ternary/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bee-ternary"
-version = "0.4.0-alpha"
+version = "0.4.1-alpha"
 authors = ["IOTA Stiftung"]
 edition = "2018"
 description = "Ergonomic ternary manipulation utilities"

--- a/bee-ternary/src/b1t6.rs
+++ b/bee-ternary/src/b1t6.rs
@@ -19,7 +19,8 @@ pub enum DecodeError {
 pub fn decode(src: &Trits) -> Result<Vec<u8>, DecodeError> {
     assert!(src.len() % TRITS_PER_BYTE == 0);
     src.iter_trytes()
-        .zip(src[TRITS_PER_TRYTE..].iter_trytes())
+        .step_by(2)
+        .zip(src[TRITS_PER_TRYTE..].iter_trytes().step_by(2))
         .map(|(a, b)| decode_group(a, b).ok_or(DecodeError::InvalidTrytes([a, b])))
         .collect()
 }

--- a/bee-test/Cargo.toml
+++ b/bee-test/Cargo.toml
@@ -11,7 +11,7 @@ keywords = ["iota", "tangle", "bee", "framework", "test"]
 homepage = "https://www.iota.org"
 
 [dependencies]
-bee-ternary = { version = "0.4.0-alpha", features = [ "serde1" ], path = "../bee-ternary" }
+bee-ternary = { version = "0.4.1-alpha", features = [ "serde1" ], path = "../bee-ternary" }
 
 rand = "0.8"
 

--- a/bee-test/tests/ternary/b1t6.rs
+++ b/bee-test/tests/ternary/b1t6.rs
@@ -1,12 +1,15 @@
 // Copyright 2020-2021 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
-use bee_ternary::{b1t6::encode, T1B1Buf};
+use bee_ternary::{
+    b1t6::{decode, encode},
+    T1B1Buf,
+};
 
 // TODO factorize tests
 
 #[test]
-fn decode() {
+fn b1t6_decode() {
     let bytes = vec![1u8];
     let str = encode::<T1B1Buf>(&bytes)
         .iter_trytes()
@@ -77,4 +80,15 @@ fn decode() {
         .collect::<String>();
 
     assert_eq!(str, "GWLW9DLDDCLAJDQXBWUZYZODBYPBJCQ9NCQYT9IYMBMWNASBEDTZOYCYUBGDM9C9");
+}
+
+#[test]
+fn encode_decode() {
+    let bytes = [
+        111, 158, 133, 16, 184, 139, 14, 164, 251, 198, 132, 223, 144, 186, 49, 5, 64, 55, 10, 4, 3, 6, 123, 34, 206,
+        244, 151, 31, 236, 62, 139, 184, 187, 7, 40, 131,
+    ];
+    let encoded = encode::<T1B1Buf>(&bytes);
+    let decoded = decode(&encoded).unwrap();
+    assert_eq!(bytes, decoded[..]);
 }

--- a/bee-test/tests/ternary/b1t6.rs
+++ b/bee-test/tests/ternary/b1t6.rs
@@ -1,17 +1,14 @@
 // Copyright 2020-2021 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
-use bee_ternary::{
-    b1t6::{decode, encode},
-    T1B1Buf,
-};
+use bee_ternary::{b1t6, T1B1Buf};
 
 // TODO factorize tests
 
 #[test]
-fn b1t6_decode() {
+fn encode() {
     let bytes = vec![1u8];
-    let str = encode::<T1B1Buf>(&bytes)
+    let str = b1t6::encode::<T1B1Buf>(&bytes)
         .iter_trytes()
         .map(char::from)
         .collect::<String>();
@@ -19,7 +16,7 @@ fn b1t6_decode() {
     assert_eq!(str, "A9");
 
     let bytes = vec![127u8];
-    let str = encode::<T1B1Buf>(&bytes)
+    let str = b1t6::encode::<T1B1Buf>(&bytes)
         .iter_trytes()
         .map(char::from)
         .collect::<String>();
@@ -27,7 +24,7 @@ fn b1t6_decode() {
     assert_eq!(str, "SE");
 
     let bytes = vec![128u8];
-    let str = encode::<T1B1Buf>(&bytes)
+    let str = b1t6::encode::<T1B1Buf>(&bytes)
         .iter_trytes()
         .map(char::from)
         .collect::<String>();
@@ -35,7 +32,7 @@ fn b1t6_decode() {
     assert_eq!(str, "GV");
 
     let bytes = vec![255u8];
-    let str = encode::<T1B1Buf>(&bytes)
+    let str = b1t6::encode::<T1B1Buf>(&bytes)
         .iter_trytes()
         .map(char::from)
         .collect::<String>();
@@ -43,7 +40,7 @@ fn b1t6_decode() {
     assert_eq!(str, "Z9");
 
     let bytes = vec![0u8, 1u8];
-    let str = encode::<T1B1Buf>(&bytes)
+    let str = b1t6::encode::<T1B1Buf>(&bytes)
         .iter_trytes()
         .map(char::from)
         .collect::<String>();
@@ -55,7 +52,7 @@ fn b1t6_decode() {
         0u8, 1u8, 0u8, 1u8, 0u8, 1u8, 0u8, 1u8, 0u8, 1u8, 0u8, 1u8, 0u8, 1u8, 0u8, 1u8, 0u8, 1u8, 0u8, 1u8, 0u8, 1u8,
         0u8, 1u8, 0u8, 1u8, 0u8, 1u8,
     ];
-    let str = encode::<T1B1Buf>(&bytes)
+    let str = b1t6::encode::<T1B1Buf>(&bytes)
         .iter_trytes()
         .map(char::from)
         .collect::<String>();
@@ -66,7 +63,7 @@ fn b1t6_decode() {
     );
 
     let bytes = hex::decode("0001027e7f8081fdfeff").unwrap();
-    let str = encode::<T1B1Buf>(&bytes)
+    let str = b1t6::encode::<T1B1Buf>(&bytes)
         .iter_trytes()
         .map(char::from)
         .collect::<String>();
@@ -74,7 +71,7 @@ fn b1t6_decode() {
     assert_eq!(str, "99A9B9RESEGVHVX9Y9Z9");
 
     let bytes = hex::decode("9ba06c78552776a596dfe360cc2b5bf644c0f9d343a10e2e71debecd30730d03").unwrap();
-    let str = encode::<T1B1Buf>(&bytes)
+    let str = b1t6::encode::<T1B1Buf>(&bytes)
         .iter_trytes()
         .map(char::from)
         .collect::<String>();
@@ -88,7 +85,7 @@ fn encode_decode() {
         111, 158, 133, 16, 184, 139, 14, 164, 251, 198, 132, 223, 144, 186, 49, 5, 64, 55, 10, 4, 3, 6, 123, 34, 206,
         244, 151, 31, 236, 62, 139, 184, 187, 7, 40, 131,
     ];
-    let encoded = encode::<T1B1Buf>(&bytes);
-    let decoded = decode(&encoded).unwrap();
+    let encoded = b1t6::encode::<T1B1Buf>(&bytes);
+    let decoded = b1t6::decode(&encoded).unwrap();
     assert_eq!(bytes, decoded[..]);
 }


### PR DESCRIPTION
# Description of change

Fix b1t6 decode by skipping every second tryte before zipping the trytes

## Type of change

- Bug fix (a non-breaking change which fixes an issue)

## How the change has been tested

with
```Rust

#[test]
fn encode_decode() {
    let bytes = [
        111, 158, 133, 16, 184, 139, 14, 164, 251, 198, 132, 223, 144, 186, 49, 5, 64, 55, 10, 4, 3, 6, 123, 34, 206,
        244, 151, 31, 236, 62, 139, 184, 187, 7, 40, 131,
    ];
    let encoded = encode::<crate::T1B1Buf>(&bytes);
    let decoded = decode(&encoded).unwrap();
    assert_eq!(bytes, decoded[..]);
}
```

## Change checklist

Tick the boxes that are relevant to your changes, and delete any items that are not.

- [ ] I have followed the contribution guidelines for this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that new and existing unit tests pass locally with my changes
- [ ] I have updated the CHANGELOG.md, if my changes are significant enough
