### PR TITLE
Reduce match expressions

### DIFF
--- a/bee-common/bee-common/src/packable.rs
+++ b/bee-common/bee-common/src/packable.rs
@@ -92,7 +92,7 @@ impl<P: Packable> Packable for Option<P> {
     type Error = OptionError<P::Error>;
 
     fn packed_len(&self) -> usize {
-        true.packed_len() + self.iter().map(Packable::packed_len).sum::<usize>()
+        true.packed_len() + self.as_ref().map_or(0, Packable::packed_len)
     }
 
     fn pack<W: Write>(&self, writer: &mut W) -> Result<(), Self::Error> {

--- a/bee-common/bee-common/src/packable.rs
+++ b/bee-common/bee-common/src/packable.rs
@@ -57,7 +57,7 @@ where
     type Error = P::Error;
 
     fn packed_len(&self) -> usize {
-        0u64.packed_len() + self.iter().map(|x| x.packed_len()).sum::<usize>()
+        0u64.packed_len() + self.iter().map(Packable::packed_len).sum::<usize>()
     }
 
     fn pack<W: Write>(&self, writer: &mut W) -> Result<(), Self::Error> {
@@ -92,7 +92,7 @@ impl<P: Packable> Packable for Option<P> {
     type Error = OptionError<P::Error>;
 
     fn packed_len(&self) -> usize {
-        true.packed_len() + self.iter().map(|p| p.packed_len()).sum::<usize>()
+        true.packed_len() + self.iter().map(Packable::packed_len).sum::<usize>()
     }
 
     fn pack<W: Write>(&self, writer: &mut W) -> Result<(), Self::Error> {


### PR DESCRIPTION
# Description of change

Reduces some unnecessary match expressions, that made the code a bit more verbose than it needs to be, like matching against a `bool` or against an `Option`. In another instance one could one-line things by iterating over the associated `Option`.

## Type of change

- Enhancement (a non-breaking change which adds functionality)

## How the change has been tested

- I ran the unit-tests, and all succeeded.

## Change checklist

Tick the boxes that are relevant to your changes, and delete any items that are not.

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have checked that new and existing unit tests pass locally with my changes
