### PR TITLE
Track bee-common in code coverage stats

### DIFF
--- a/.github/workflows/scripts/coverage.sh
+++ b/.github/workflows/scripts/coverage.sh
@@ -11,8 +11,7 @@ RUSTFLAGS="-Zinstrument-coverage" LLVM_PROFILE_FILE="bee-%m.profraw" cargo +nigh
 # Merge all .profraw files into "bee.profdata"
 echo "Merging coverage data..."
 PROFRAW=""
-for file in \
-  $(find . -type f -name "*.profraw"); \
+for file in $(find . -type f -name "*.profraw");
 do
   echo "Found $file"
   PROFRAW="${PROFRAW} $file"

--- a/.github/workflows/scripts/coverage.sh
+++ b/.github/workflows/scripts/coverage.sh
@@ -10,7 +10,15 @@ RUSTFLAGS="-Zinstrument-coverage" LLVM_PROFILE_FILE="bee-%m.profraw" cargo +nigh
 
 # Merge all .profraw files into "bee.profdata"
 echo "Merging coverage data..."
-cargo +nightly profdata -- merge */bee-*.profraw -o bee.profdata
+PROFRAW=""
+for file in \
+  $(find . -type f -name "*.profraw"); \
+do
+  echo "Found $file"
+  PROFRAW="${PROFRAW} $file"
+done
+
+cargo +nightly profdata -- merge ${PROFRAW} -o bee.profdata
 
 # List the test binaries
 echo "Locating test binaries..."

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@
   <img src="https://github.com/iotaledger/bee/workflows/Clippy/badge.svg">
   <img src="https://github.com/iotaledger/bee/workflows/Build/badge.svg">
   <img src="https://github.com/iotaledger/bee/workflows/Test/badge.svg">
-  <img src="https://coveralls.io/repos/github/iotaledger/bee/badge.svg?branch=master">
+  <img src="https://coveralls.io/repos/github/iotaledger/bee/badge.svg?branch=dev">
 </p>
 
 <p align="center">


### PR DESCRIPTION
# Description of change

Fix for issue with finding `*.profdata` files more than one directory down from the root.

Also added the coverage badge for the `dev` branch to the README.

## Type of change

- Bug fix (a non-breaking change which fixes an issue)

## How the change has been tested

Run locally and tested the workflow: `bee-common` is now recorded in the coverage data.

## Change checklist

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have checked that new and existing unit tests pass locally with my changes
