### PR TITLE
Add exit flag to coverage script

### DIFF
--- a/.github/workflows/scripts/coverage.sh
+++ b/.github/workflows/scripts/coverage.sh
@@ -2,7 +2,7 @@
 set -e
 
 # Remove stale coverage report
-rm -r coverage
+rm -rf coverage
 mkdir coverage
 
 # Run tests with profiling instrumentation

--- a/.github/workflows/scripts/coverage.sh
+++ b/.github/workflows/scripts/coverage.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+set -e
 
 # Remove stale coverage report
 rm -r coverage


### PR DESCRIPTION
# Description of change

Add an early exit flag `-e` to coverage shell script, so that it exits early on any failures (test failures, etc).

## Type of change

- Bug fix (a non-breaking change which fixes an issue)

## Change checklist

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have checked that new and existing unit tests pass locally with my changes
