### PR TITLE
Add license check workflow

### DIFF
--- a/.github/workflows/licenses.yml
+++ b/.github/workflows/licenses.yml
@@ -1,0 +1,23 @@
+name: License check
+
+on:
+  push:
+    branches:
+      - chrysalis-pt-2
+  pull_request:
+    branches:
+      - chrysalis-pt-2
+
+jobs:
+  licenses:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions-rs/install@v0.1
+        with:
+          crate: cargo-lichking
+          version: 0.9.0
+      - uses: actions-rs/cargo@v1
+        with:
+          command: lichking
+          args: check


### PR DESCRIPTION
# Description of change

Adds license check workflow on pushes and PRs with `cargo-lichking`. Currently fails with an incompatible license in crate `colored`.

## Type of change

- Enhancement (a non-breaking change which adds functionality)

## How the change has been tested

Run on my fork to ensure the workflow functions as expected.

## Change checklist

Tick the boxes that are relevant to your changes, and delete any items that are not.

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
