### PR TITLE
Add docs to core data types in bee-message crate.

### DIFF
--- a/bee-message/src/constants.rs
+++ b/bee-message/src/constants.rs
@@ -3,9 +3,19 @@
 
 use core::ops::{Range, RangeInclusive};
 
+/// The total number of IOTAs in circulation.
 pub const IOTA_SUPPLY: u64 = 2_779_530_283_277_761;
+
 // TODO split
+
+/// The maximum number of outputs for a transaction.
 pub const INPUT_OUTPUT_COUNT_MAX: usize = 127;
+
+/// The range of valid numbers of outputs for a transaction [1..127].
 pub const INPUT_OUTPUT_COUNT_RANGE: RangeInclusive<usize> = 1..=INPUT_OUTPUT_COUNT_MAX;
+
+/// The range of valid numbers of unlock blocks for a transaction [1..127].
 pub const UNLOCK_BLOCK_COUNT_RANGE: RangeInclusive<usize> = INPUT_OUTPUT_COUNT_RANGE;
+
+/// The valid range of indices for inputs and outputs for a transaction [0..126].
 pub const INPUT_OUTPUT_INDEX_RANGE: Range<u16> = 0..INPUT_OUTPUT_COUNT_MAX as u16;

--- a/bee-message/src/message.rs
+++ b/bee-message/src/message.rs
@@ -16,12 +16,20 @@ use std::sync::{atomic::AtomicBool, Arc};
 pub const MESSAGE_LENGTH_MIN: usize = 53;
 pub const MESSAGE_LENGTH_MAX: usize = 32768;
 
+/// A Message is the object that nodes gossip around the network.
+///
+/// Spec: #iota-protocol-rfc-draft https://github.com/GalRogozinski/protocol-rfcs/blob/message/text/0017-message/0017-message.md
 #[derive(Clone, Debug, Eq, PartialEq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Message {
+    /// network_id specifies which network this message is meant for (mainnet, testnet, private net).
     network_id: u64,
+    /// parents are the [MessageId]s that this message directly approves.
+    /// The list contains between 1 and 8 sorted unique entries.
     parents: Parents,
+    /// The optional [Payload] of the message.
     payload: Option<Payload>,
+    /// The result of the Proof of Work (PoW) in order to be accepted into the tangle.
     nonce: u64,
 }
 

--- a/bee-message/src/message.rs
+++ b/bee-message/src/message.rs
@@ -17,7 +17,7 @@ use std::sync::{atomic::AtomicBool, Arc};
 pub const MESSAGE_LENGTH_MIN: usize = 53;
 
 /// The maximum number of bytes in a message (1024*32).
-/// https://github.com/GalRogozinski/protocol-rfcs/blob/message/text/0017-message/0017-message.md#message-validation
+/// <https://github.com/GalRogozinski/protocol-rfcs/blob/message/text/0017-message/0017-message.md#message-validation>
 pub const MESSAGE_LENGTH_MAX: usize = 32768;
 
 /// A `Message` is the object that nodes gossip around the network.

--- a/bee-message/src/message.rs
+++ b/bee-message/src/message.rs
@@ -46,7 +46,9 @@ impl Message {
 
     /// Calculate and return the the ID of the message.
     ///
-    /// TODO should not return bytes anymore ?
+    /// The ID is obtained by taking the Blake2b256 hash of the message contents.
+    ///
+    /// TODO: should not return bytes anymore ?
     pub fn id(&self) -> (MessageId, Vec<u8>) {
         let bytes = self.pack_new();
         let id = Blake2b256::digest(&bytes);
@@ -55,6 +57,8 @@ impl Message {
     }
 
     /// Return the ID of the network this message belongs to.
+    ///
+    /// This is used to indicate if the message is for the mainnet, testnet, or a private net.
     pub fn network_id(&self) -> u64 {
         self.network_id
     }
@@ -69,7 +73,7 @@ impl Message {
         &self.payload
     }
 
-    // Return the PoW nonce for this message.
+    /// Return the PoW nonce for this message.
     pub fn nonce(&self) -> u64 {
         self.nonce
     }

--- a/bee-message/src/message.rs
+++ b/bee-message/src/message.rs
@@ -13,7 +13,11 @@ use crypto::hashes::{blake2b::Blake2b256, Digest};
 
 use std::sync::{atomic::AtomicBool, Arc};
 
+/// The minimum number of bytes in a message.
 pub const MESSAGE_LENGTH_MIN: usize = 53;
+
+/// The maximum number of bytes in a message (1024*32).
+/// https://github.com/GalRogozinski/protocol-rfcs/blob/message/text/0017-message/0017-message.md#message-validation
 pub const MESSAGE_LENGTH_MAX: usize = 32768;
 
 /// A Message is the object that nodes gossip around the network.
@@ -34,11 +38,14 @@ pub struct Message {
 }
 
 impl Message {
+    /// Create a new [Message] builder.
     pub fn builder() -> MessageBuilder {
         MessageBuilder::new()
     }
 
-    // TODO should not return bytes anymore ?
+    /// Calculate and return the the ID of the message.
+    ///
+    /// TODO should not return bytes anymore ?
     pub fn id(&self) -> (MessageId, Vec<u8>) {
         let bytes = self.pack_new();
         let id = Blake2b256::digest(&bytes);
@@ -46,18 +53,22 @@ impl Message {
         (MessageId::new(id.into()), bytes)
     }
 
+    /// Return the ID of the network this message belongs to.
     pub fn network_id(&self) -> u64 {
         self.network_id
     }
 
+    /// Return the set of transactions that this message directly approves (the parents).
     pub fn parents(&self) -> &Parents {
         &self.parents
     }
 
+    /// Return the (optional) payload this message contains.
     pub fn payload(&self) -> &Option<Payload> {
         &self.payload
     }
 
+    // Return the PoW nonce for this message.
     pub fn nonce(&self) -> u64 {
         self.nonce
     }

--- a/bee-message/src/message.rs
+++ b/bee-message/src/message.rs
@@ -20,9 +20,10 @@ pub const MESSAGE_LENGTH_MIN: usize = 53;
 /// https://github.com/GalRogozinski/protocol-rfcs/blob/message/text/0017-message/0017-message.md#message-validation
 pub const MESSAGE_LENGTH_MAX: usize = 32768;
 
-/// A Message is the object that nodes gossip around the network.
+/// A `Message` is the object that nodes gossip around the network.
 ///
-/// Spec: #iota-protocol-rfc-draft https://github.com/GalRogozinski/protocol-rfcs/blob/message/text/0017-message/0017-message.md
+/// Spec: #iota-protocol-rfc-draft
+/// <https://github.com/GalRogozinski/protocol-rfcs/blob/message/text/0017-message/0017-message.md>
 #[derive(Clone, Debug, Eq, PartialEq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Message {
@@ -38,7 +39,7 @@ pub struct Message {
 }
 
 impl Message {
-    /// Create a new [Message] builder.
+    /// Create a new [MessageBuilder], the only way to construct an instance of a `Message`.
     pub fn builder() -> MessageBuilder {
         MessageBuilder::new()
     }
@@ -132,6 +133,7 @@ impl Packable for Message {
     }
 }
 
+/// A `MessageBuilder` is how you construct a [Message].
 pub struct MessageBuilder<P: Provider = Miner> {
     network_id: Option<u64>,
     parents: Option<Parents>,

--- a/bee-message/src/message_id.rs
+++ b/bee-message/src/message_id.rs
@@ -9,24 +9,24 @@ use core::{convert::TryInto, str::FromStr};
 
 /// The length of the BLAKE2b-256 hash output.
 ///
-/// See https://www.blake2.net/ for more information.
+/// See <https://www.blake2.net/> for more information.
 pub const MESSAGE_ID_LENGTH: usize = 32;
 
 /// The BLAKE2b-256 hash of the byte contents of the message.
 ///
-/// Use crypto::hashes::Blake2b256::digest() to produce the hashed value.
+/// Use `crypto::hashes::Blake2b256::digest` to produce the hashed value.
 ///
-/// See https://www.blake2.net/ for more information.
+/// See <https://www.blake2.net/> for more information.
 #[derive(Clone, Copy, Eq, Hash, PartialEq, Ord, PartialOrd)]
 pub struct MessageId([u8; MESSAGE_ID_LENGTH]);
 
 impl MessageId {
-    /// Construct a new MessageId from the BLAKE2b-256 hash of a message.
+    /// Construct a new `MessageId` from the BLAKE2b-256 hash of a message.
     pub fn new(bytes: [u8; MESSAGE_ID_LENGTH]) -> Self {
         bytes.into()
     }
 
-    /// Create a null message ID (all zeros).
+    /// Create a null `MessageId` (all zeros).
     pub fn null() -> Self {
         Self([0u8; MESSAGE_ID_LENGTH])
     }

--- a/bee-message/src/message_id.rs
+++ b/bee-message/src/message_id.rs
@@ -7,12 +7,21 @@ use bee_common::packable::{Packable, Read, Write};
 
 use core::{convert::TryInto, str::FromStr};
 
+/// The length of the BLAKE2b-256 hash output.
+///
+/// See https://www.blake2.net/ for more information.
 pub const MESSAGE_ID_LENGTH: usize = 32;
 
+/// The BLAKE2b-256 hash of the byte contents of the message.
+///
+/// Use crypto::hashes::Blake2b256::digest() to produce the hashed value.
+///
+/// See https://www.blake2.net/ for more information.
 #[derive(Clone, Copy, Eq, Hash, PartialEq, Ord, PartialOrd)]
 pub struct MessageId([u8; MESSAGE_ID_LENGTH]);
 
 impl MessageId {
+    /// Construct a new MessageId from the BLAKE2b-256 hash of a message.
     pub fn new(bytes: [u8; MESSAGE_ID_LENGTH]) -> Self {
         bytes.into()
     }

--- a/bee-message/src/message_id.rs
+++ b/bee-message/src/message_id.rs
@@ -26,6 +26,7 @@ impl MessageId {
         bytes.into()
     }
 
+    /// Create a null message ID (all zeros).
     pub fn null() -> Self {
         Self([0u8; MESSAGE_ID_LENGTH])
     }

--- a/bee-message/src/parents.rs
+++ b/bee-message/src/parents.rs
@@ -12,6 +12,11 @@ use core::ops::{Deref, RangeInclusive};
 
 pub const MESSAGE_PARENTS_RANGE: RangeInclusive<usize> = 1..=8;
 
+/// A Message's Parents are the [MessageId]s of the transactions it directly approves.
+///
+/// There must be between 1 and 8 parents, and they must be sorted and unique.
+///
+/// Spec: #protocol-rfc-draft https://github.com/GalRogozinski/protocol-rfcs/blob/message/text/0017-message/0017-message.md
 #[derive(Clone, Debug, Eq, PartialEq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Parents(Vec<MessageId>);
@@ -26,6 +31,9 @@ impl Deref for Parents {
 
 #[allow(clippy::len_without_is_empty)]
 impl Parents {
+    /// Create a new Parents set.
+    ///
+    /// The vector must contain 1-8 unique and sorted entries.
     pub fn new(inner: Vec<MessageId>) -> Result<Self, Error> {
         if !MESSAGE_PARENTS_RANGE.contains(&inner.len()) {
             return Err(Error::InvalidParentsCount(inner.len()));

--- a/bee-message/src/parents.rs
+++ b/bee-message/src/parents.rs
@@ -16,11 +16,12 @@ use core::ops::{Deref, RangeInclusive};
 /// The range containing the valid number of parents (directly approved transactions).
 pub const MESSAGE_PARENTS_RANGE: RangeInclusive<usize> = 1..=8;
 
-/// A Message's Parents are the [MessageId]s of the transactions it directly approves.
+/// A [`Message`](crate::Message)'s `Parents` are the [`MessageId`]s of the transactions it directly approves.
 ///
 /// There must be between 1 and 8 parents, and they must be sorted and unique.
 ///
-/// Spec: #iota-protocol-rfc-draft https://github.com/GalRogozinski/protocol-rfcs/blob/message/text/0017-message/0017-message.md
+/// Spec: #iota-protocol-rfc-draft
+/// <https://github.com/GalRogozinski/protocol-rfcs/blob/message/text/0017-message/0017-message.md>
 #[derive(Clone, Debug, Eq, PartialEq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Parents(Vec<MessageId>);
@@ -35,7 +36,7 @@ impl Deref for Parents {
 
 #[allow(clippy::len_without_is_empty)]
 impl Parents {
-    /// Create a new Parents set.
+    /// Create a new `Parents` set.
     ///
     /// The vector must contain 1-8 unique and sorted entries.
     pub fn new(inner: Vec<MessageId>) -> Result<Self, Error> {

--- a/bee-message/src/parents.rs
+++ b/bee-message/src/parents.rs
@@ -1,6 +1,9 @@
 // Copyright 2020 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
+//! The parents module defines the core data type ([Parents]) for storing the
+//! messages directly approved by another message.
+
 use crate::{Error, MessageId, MESSAGE_ID_LENGTH};
 
 use bee_common::{
@@ -10,6 +13,7 @@ use bee_common::{
 
 use core::ops::{Deref, RangeInclusive};
 
+/// The range containing the valid number of parents (directly approved transactions).
 pub const MESSAGE_PARENTS_RANGE: RangeInclusive<usize> = 1..=8;
 
 /// A Message's Parents are the [MessageId]s of the transactions it directly approves.
@@ -46,10 +50,12 @@ impl Parents {
         Ok(Self(inner))
     }
 
+    /// Return the number of parents.
     pub fn len(&self) -> usize {
         self.0.len()
     }
 
+    /// Return an iterator over the parents.
     pub fn iter(&self) -> impl Iterator<Item = &MessageId> + '_ {
         self.0.iter()
     }

--- a/bee-message/src/parents.rs
+++ b/bee-message/src/parents.rs
@@ -16,7 +16,7 @@ pub const MESSAGE_PARENTS_RANGE: RangeInclusive<usize> = 1..=8;
 ///
 /// There must be between 1 and 8 parents, and they must be sorted and unique.
 ///
-/// Spec: #protocol-rfc-draft https://github.com/GalRogozinski/protocol-rfcs/blob/message/text/0017-message/0017-message.md
+/// Spec: #iota-protocol-rfc-draft https://github.com/GalRogozinski/protocol-rfcs/blob/message/text/0017-message/0017-message.md
 #[derive(Clone, Debug, Eq, PartialEq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Parents(Vec<MessageId>);

--- a/bee-message/src/payload/mod.rs
+++ b/bee-message/src/payload/mod.rs
@@ -19,6 +19,7 @@ use bee_common::packable::{Packable, Read, Write};
 
 use alloc::boxed::Box;
 
+/// The payload of a message on the tangle.
 #[non_exhaustive]
 #[derive(Clone, Debug, Eq, PartialEq)]
 #[cfg_attr(

--- a/bee-message/src/payload/mod.rs
+++ b/bee-message/src/payload/mod.rs
@@ -1,6 +1,8 @@
 // Copyright 2020 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
+//! The payload module defines the core data types for representing message payloads.
+
 pub mod indexation;
 pub mod milestone;
 pub mod receipt;

--- a/bee-message/src/solid_entry_point.rs
+++ b/bee-message/src/solid_entry_point.rs
@@ -14,6 +14,11 @@ use core::ops::Deref;
 #[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
 pub struct SolidEntryPoint(MessageId);
 
+/// A SolidEntryPoint is a [MessageId] of a message even if we do not have them
+/// or their past in the database. The often come from a snapshot file and
+/// allow a node to solidify without needing the full tangle history.assert_eq!
+///
+/// Spec: #iota-protocol-rfc https://github.com/iotaledger/protocol-rfcs/blob/master/text/0005-white-flag/0005-white-flag.md
 impl SolidEntryPoint {
     pub fn new(message_id: MessageId) -> Self {
         message_id.into()

--- a/bee-message/src/solid_entry_point.rs
+++ b/bee-message/src/solid_entry_point.rs
@@ -1,6 +1,9 @@
 // Copyright 2020 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
+//! The solid_entry_point module defined the [SolidEntryPoint] type which represents
+//! an already solidified message in the tangle.
+
 use crate::MessageId;
 
 use bee_common::packable::{Packable, Read, Write};
@@ -9,25 +12,31 @@ use ref_cast::RefCast;
 
 use core::ops::Deref;
 
+/// A SolidEntryPoint is a [MessageId] of a message even if we do not have them
+/// or their past in the database. The often come from a snapshot file and
+/// allow a node to solidify without needing the full tangle history.
+///
+/// This is a type wrapper around a [MessageId] to differentiate it from
+/// a non-solidified message.
+///
+/// Spec: #iota-protocol-rfc https://github.com/iotaledger/protocol-rfcs/blob/master/text/0005-white-flag/0005-white-flag.md
 #[derive(RefCast)]
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
 pub struct SolidEntryPoint(MessageId);
 
-/// A SolidEntryPoint is a [MessageId] of a message even if we do not have them
-/// or their past in the database. The often come from a snapshot file and
-/// allow a node to solidify without needing the full tangle history.assert_eq!
-///
-/// Spec: #iota-protocol-rfc https://github.com/iotaledger/protocol-rfcs/blob/master/text/0005-white-flag/0005-white-flag.md
 impl SolidEntryPoint {
+    /// Create a SolidEntryPoint from an existing [MessageId].
     pub fn new(message_id: MessageId) -> Self {
         message_id.into()
     }
 
+    /// Create a null SolidEntryPoint (the zero-message).
     pub fn null() -> Self {
         Self(MessageId::null())
     }
 
+    /// Returns the underlying [MessageId].
     pub fn message_id(&self) -> &MessageId {
         &self.0
     }

--- a/bee-message/src/solid_entry_point.rs
+++ b/bee-message/src/solid_entry_point.rs
@@ -12,31 +12,32 @@ use ref_cast::RefCast;
 
 use core::ops::Deref;
 
-/// A SolidEntryPoint is a [MessageId] of a message even if we do not have them
-/// or their past in the database. The often come from a snapshot file and
-/// allow a node to solidify without needing the full tangle history.
+/// A SolidEntryPoint is a [`MessageId`](crate::MessageId) of a message even if we do not have them
+/// or their past in the database. The often come from a snapshot file and allow a node to solidify
+/// without needing the full tangle history.
 ///
-/// This is a type wrapper around a [MessageId] to differentiate it from
-/// a non-solidified message.
+/// This is a type wrapper around a [`MessageId`](crate::MessageId) to differentiate it from a
+/// non-solidified message.
 ///
-/// Spec: #iota-protocol-rfc https://github.com/iotaledger/protocol-rfcs/blob/master/text/0005-white-flag/0005-white-flag.md
+/// Spec: #iota-protocol-rfc
+/// <https://github.com/iotaledger/protocol-rfcs/blob/master/text/0005-white-flag/0005-white-flag.md>
 #[derive(RefCast)]
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
 pub struct SolidEntryPoint(MessageId);
 
 impl SolidEntryPoint {
-    /// Create a SolidEntryPoint from an existing [MessageId].
+    /// Create a `SolidEntryPoint` from an existing `MessageId`.
     pub fn new(message_id: MessageId) -> Self {
         message_id.into()
     }
 
-    /// Create a null SolidEntryPoint (the zero-message).
+    /// Create a null `SolidEntryPoint` (the zero-message).
     pub fn null() -> Self {
         Self(MessageId::null())
     }
 
-    /// Returns the underlying [MessageId].
+    /// Returns the underlying `MessageId`.
     pub fn message_id(&self) -> &MessageId {
         &self.0
     }


### PR DESCRIPTION
# Description of change

Adds high level documentation to some of the core types defining the IOTA Chrysalis protocol. Where applicable, link out to external resources (BLAKE2b, IOTA protocol rfcs, etc.)

When linking to specifications I've used the format:

```
Spec: #iota-protocol-rfc <LINK>
```

or, if the RFC has not been finalized:

```
Spec: #iota-protocol-rfc-draft <LINK>
```

Hopefully this will make it easier to identify where data structures/ algos are spec defined, as well as which parts are still in draft.

## Type of change

- Documentation Fix

## How the change has been tested

N/A - documentation change only

## Change checklist

Tick the boxes that are relevant to your changes, and delete any items that are not.

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
