### PR TITLE
Add more unit tests for core bee-message types.

### DIFF
--- a/bee-message/tests/address.rs
+++ b/bee-message/tests/address.rs
@@ -1,15 +1,24 @@
 // Copyright 2020 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
+use bee_common::packable::Packable;
 use bee_message::prelude::*;
+
+use core::convert::TryInto;
 
 const ED25519_ADDRESS: &str = "52fdfc072182654f163f5f0f9a621d729566c74d10037c4d7bbb0407d1e2c649";
 
+// The kind of an `Address` is the kind of the underlying address.
+#[test]
+fn kind() {
+    let bytes: [u8; 32] = hex::decode(ED25519_ADDRESS).unwrap().try_into().unwrap();
+    let ed25519_address = Address::from(Ed25519Address::new(bytes));
+    assert_eq!(0, ed25519_address.kind());
+}
+
 #[test]
 fn generate_bech32_string() {
-    let mut bytes = [0; 32];
-    let vec = hex::decode(ED25519_ADDRESS).unwrap();
-    bytes.copy_from_slice(&vec);
+    let bytes: [u8; 32] = hex::decode(ED25519_ADDRESS).unwrap().try_into().unwrap();
     let address = Address::from(Ed25519Address::new(bytes));
     let bech32_string = address.to_bech32("iota");
     assert_eq!(
@@ -20,9 +29,7 @@ fn generate_bech32_string() {
 
 #[test]
 fn generate_bech32_testnet_string() {
-    let mut bytes = [0; 32];
-    let vec = hex::decode(ED25519_ADDRESS).unwrap();
-    bytes.copy_from_slice(&vec);
+    let bytes: [u8; 32] = hex::decode(ED25519_ADDRESS).unwrap().try_into().unwrap();
     let address = Address::from(Ed25519Address::new(bytes));
     let bech32_string = address.to_bech32("atoi");
     assert_eq!(
@@ -33,9 +40,7 @@ fn generate_bech32_testnet_string() {
 
 #[test]
 fn bech32_string_to_address() {
-    let mut bytes = [0; 32];
-    let vec = hex::decode(ED25519_ADDRESS).unwrap();
-    bytes.copy_from_slice(&vec);
+    let bytes: [u8; 32] = hex::decode(ED25519_ADDRESS).unwrap().try_into().unwrap();
     let address = Address::try_from_bech32(&Address::from(Ed25519Address::new(bytes)).to_bech32("iota")).unwrap();
     if let Address::Ed25519(ed) = address {
         assert_eq!(
@@ -54,4 +59,13 @@ fn bech32_string_to_address() {
     } else {
         panic!("Expecting an Ed25519 address");
     }
+}
+
+#[test]
+fn pack_unpack_valid_ed25519() {
+    let bytes: [u8; 32] = hex::decode(ED25519_ADDRESS).unwrap().try_into().unwrap();
+    let address = Address::from(Ed25519Address::new(bytes));
+    let address_packed = address.pack_new();
+    assert_eq!(address_packed.len(), address.packed_len());
+    assert_eq!(address, Packable::unpack(&mut address_packed.as_slice()).unwrap());
 }

--- a/bee-message/tests/ed25519_address.rs
+++ b/bee-message/tests/ed25519_address.rs
@@ -8,7 +8,8 @@ use core::{convert::TryInto, str::FromStr};
 
 const ED25519_ADDRESS: &str = "52fdfc072182654f163f5f0f9a621d729566c74d10037c4d7bbb0407d1e2c649";
 const ED25519_ADDRESS_INVALID_HEX: &str = "52fdfc072182654f163f5f0f9a621d729566c74d10037c4d7bbb0407d1e2c64x";
-const ED25519_ADDRESS_INVALID_LEN: &str = "52fdfc072182654f163f5f0f9a621d729566c74d10037c4d7bbb0407d1e2c6";
+const ED25519_ADDRESS_INVALID_LEN_TOO_SHORT: &str = "52fdfc072182654f163f5f0f9a621d729566c74d10037c4d7bbb0407d1e2c6";
+const ED25519_ADDRESS_INVALID_LEN_TOO_LONG: &str = "52fdfc072182654f163f5f0f9a621d729566c74d10037c4d7bbb0407d1e2c64900";
 
 #[test]
 fn kind() {
@@ -39,11 +40,20 @@ fn from_str_invalid_hex() {
 }
 
 #[test]
-fn from_str_invalid_len() {
+fn from_str_invalid_len_too_short() {
     assert!(matches!(
-        Ed25519Address::from_str(ED25519_ADDRESS_INVALID_LEN),
+        Ed25519Address::from_str(ED25519_ADDRESS_INVALID_LEN_TOO_SHORT),
         Err(Error::InvalidHexadecimalLength(expected, actual))
             if expected == ED25519_ADDRESS_LENGTH * 2 && actual == ED25519_ADDRESS_LENGTH * 2 - 2
+    ));
+}
+
+#[test]
+fn from_str_invalid_len_too_long() {
+    assert!(matches!(
+        Ed25519Address::from_str(ED25519_ADDRESS_INVALID_LEN_TOO_LONG),
+        Err(Error::InvalidHexadecimalLength(expected, actual))
+            if expected == ED25519_ADDRESS_LENGTH * 2 && actual == ED25519_ADDRESS_LENGTH * 2 + 2
     ));
 }
 
@@ -58,6 +68,14 @@ fn from_to_str() {
 #[test]
 fn packed_len() {
     assert_eq!(Ed25519Address::from_str(ED25519_ADDRESS).unwrap().packed_len(), 32);
+}
+
+#[test]
+fn pack_unpack_valid() {
+    let address = Ed25519Address::from_str(ED25519_ADDRESS).unwrap();
+    let packed_address = address.pack_new();
+    assert_eq!(packed_address.len(), address.packed_len());
+    assert_eq!(address, Packable::unpack(&mut packed_address.as_slice()).unwrap());
 }
 
 #[test]

--- a/bee-message/tests/ed25519_signature.rs
+++ b/bee-message/tests/ed25519_signature.rs
@@ -1,9 +1,32 @@
 // Copyright 2020 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
+use bee_common::packable::Packable;
 use bee_message::prelude::*;
+
+use core::convert::TryInto;
+
+const ED25519_PULIC_KEY: &str = "1DA5DDD11BA3F961ACAB68FAFEE3177D039875EAA94AC5FDBFF8B53F0C50BFB9";
+const ED25519_SIGNATURE: &str = "c6a40edf9a089f42c18f4ebccb35fe4b578d93b879e99b87f63573324a710d3456b03fb6d1fcc027e6401cbd9581f790ee3ed7a3f68e9c225fcb9f1cd7b7110d";
 
 #[test]
 fn kind() {
     assert_eq!(Ed25519Signature::KIND, 0);
+}
+
+#[test]
+fn packed_len() {
+    let pub_key_bytes: [u8; 32] = hex::decode(ED25519_PULIC_KEY).unwrap().try_into().unwrap();
+    let sig_bytes: [u8; 64] = hex::decode(ED25519_SIGNATURE).unwrap().try_into().unwrap();
+    let sig = Ed25519Signature::new(pub_key_bytes, Box::new(sig_bytes));
+    assert_eq!(32 + 64, sig.packed_len());
+}
+
+#[test]
+fn pack_unpack_valid() {
+    let pub_key_bytes: [u8; 32] = hex::decode(ED25519_PULIC_KEY).unwrap().try_into().unwrap();
+    let sig_bytes: [u8; 64] = hex::decode(ED25519_SIGNATURE).unwrap().try_into().unwrap();
+    let sig = Ed25519Signature::new(pub_key_bytes, Box::new(sig_bytes));
+    let sig_packed = sig.pack_new();
+    assert_eq!(sig, Packable::unpack(&mut sig_packed.as_slice()).unwrap());
 }

--- a/bee-message/tests/message.rs
+++ b/bee-message/tests/message.rs
@@ -60,18 +60,16 @@ fn invalid_length() {
 
 #[test]
 fn unpack_valid_no_remaining_bytes() {
-    assert!(
-        Message::unpack(
-            &mut vec![
-                42, 0, 0, 0, 0, 0, 0, 0, 2, 140, 28, 186, 52, 147, 145, 96, 9, 105, 89, 78, 139, 3, 71, 249, 97, 149,
-                190, 63, 238, 168, 202, 82, 140, 227, 66, 173, 19, 110, 93, 117, 34, 225, 202, 251, 10, 156, 58, 144,
-                225, 54, 79, 62, 38, 20, 121, 95, 90, 112, 109, 6, 166, 126, 145, 13, 62, 52, 68, 248, 135, 223, 119,
-                137, 13, 0, 0, 0, 0, 21, 205, 91, 7, 0, 0, 0, 0,
-            ]
-            .as_slice()
-        )
-        .is_ok()
+    assert!(Message::unpack(
+        &mut vec![
+            42, 0, 0, 0, 0, 0, 0, 0, 2, 140, 28, 186, 52, 147, 145, 96, 9, 105, 89, 78, 139, 3, 71, 249, 97, 149, 190,
+            63, 238, 168, 202, 82, 140, 227, 66, 173, 19, 110, 93, 117, 34, 225, 202, 251, 10, 156, 58, 144, 225, 54,
+            79, 62, 38, 20, 121, 95, 90, 112, 109, 6, 166, 126, 145, 13, 62, 52, 68, 248, 135, 223, 119, 137, 13, 0, 0,
+            0, 0, 21, 205, 91, 7, 0, 0, 0, 0,
+        ]
+        .as_slice()
     )
+    .is_ok())
 }
 
 #[test]
@@ -88,4 +86,17 @@ fn unpack_invalid_remaining_bytes() {
         ),
         Err(Error::RemainingBytesAfterMessage)
     ))
+}
+
+// Validate that a `unpack` ∘ `pack` round-trip results in the original message.
+#[test]
+fn pack_unpack_valid() {
+    let message = MessageBuilder::<Miner>::new()
+        .with_network_id(0)
+        .with_parents(Parents::new(rand_message_ids(2)).unwrap())
+        .finish()
+        .unwrap();
+    let packed_message = message.pack_new();
+    assert_eq!(packed_message.len(), message.packed_len());
+    assert_eq!(message, Packable::unpack(&mut packed_message.as_slice()).unwrap());
 }

--- a/bee-message/tests/message_id.rs
+++ b/bee-message/tests/message_id.rs
@@ -8,7 +8,8 @@ use core::str::FromStr;
 
 const MESSAGE_ID: &str = "52fdfc072182654f163f5f0f9a621d729566c74d10037c4d7bbb0407d1e2c649";
 const MESSAGE_ID_INVALID_HEX: &str = "52fdfc072182654f163f5f0f9a621d729566c74d10037c4d7bbb0407d1e2c64x";
-const MESSAGE_ID_INVALID_LEN: &str = "52fdfc072182654f163f5f0f9a621d729566c74d10037c4d7bbb0407d1e2c6";
+const MESSAGE_ID_INVALID_LEN_TOO_SHORT: &str = "52fdfc072182654f163f5f0f9a621d729566c74d10037c4d7bbb0407d1e2c6";
+const MESSAGE_ID_INVALID_LEN_TOO_LONG: &str = "52fdfc072182654f163f5f0f9a621d729566c74d10037c4d7bbb0407d1e2c64900";
 
 #[test]
 fn from_str_valid() {
@@ -25,11 +26,20 @@ fn from_str_invalid_hex() {
 }
 
 #[test]
-fn from_str_invalid_len() {
+fn from_str_invalid_len_too_short() {
     assert!(matches!(
-        MessageId::from_str(MESSAGE_ID_INVALID_LEN),
+        MessageId::from_str(MESSAGE_ID_INVALID_LEN_TOO_SHORT),
         Err(Error::InvalidHexadecimalLength(expected, actual))
             if expected == MESSAGE_ID_LENGTH * 2 && actual == MESSAGE_ID_LENGTH * 2 - 2
+    ));
+}
+
+#[test]
+fn from_str_invalid_len_too_long() {
+    assert!(matches!(
+        MessageId::from_str(MESSAGE_ID_INVALID_LEN_TOO_LONG),
+        Err(Error::InvalidHexadecimalLength(expected, actual))
+            if expected == MESSAGE_ID_LENGTH * 2 && actual == MESSAGE_ID_LENGTH * 2 + 2
     ));
 }
 
@@ -38,7 +48,19 @@ fn from_to_str() {
     assert_eq!(MESSAGE_ID, MessageId::from_str(MESSAGE_ID).unwrap().to_string());
 }
 
+// Validate that the length of a packed `MessageId` matches the declared `packed_len()`.
 #[test]
 fn packed_len() {
-    assert_eq!(MessageId::from_str(MESSAGE_ID).unwrap().packed_len(), 32);
+    let msgid = MessageId::from_str(MESSAGE_ID).unwrap();
+    assert_eq!(msgid.packed_len(), 32);
+    assert_eq!(msgid.pack_new().len(), 32);
+}
+
+// Validate that a `unpack` ∘ `pack` round-trip results in the original message id.
+#[test]
+fn pack_unpack_valid() {
+    let msgid = MessageId::from_str(MESSAGE_ID).unwrap();
+    let packed_msgid = msgid.pack_new();
+    assert_eq!(packed_msgid.len(), msgid.packed_len());
+    assert_eq!(msgid, Packable::unpack(&mut packed_msgid.as_slice()).unwrap());
 }

--- a/bee-message/tests/parents.rs
+++ b/bee-message/tests/parents.rs
@@ -46,7 +46,9 @@ fn new_invalid_not_unique() {
 
 #[test]
 fn packed_len() {
-    assert_eq!(Parents::new(rand_message_ids(5)).unwrap().packed_len(), 1 + 5 * 32);
+    let parents = Parents::new(rand_message_ids(5)).unwrap();
+    assert_eq!(parents.packed_len(), 1 + 5 * 32);
+    assert_eq!(parents.packed_len(), parents.pack_new().len());
 }
 
 #[test]

--- a/bee-message/tests/transaction_id.rs
+++ b/bee-message/tests/transaction_id.rs
@@ -45,3 +45,13 @@ fn from_to_str() {
 fn packed_len() {
     assert_eq!(TransactionId::from_str(TRANSACTION_ID).unwrap().packed_len(), 32);
 }
+
+#[test]
+fn pack_unpack_valid() {
+    let transaction_id = TransactionId::from_str(TRANSACTION_ID).unwrap();
+    let packed_transaction_id = transaction_id.pack_new();
+    assert_eq!(
+        transaction_id,
+        Packable::unpack(&mut packed_transaction_id.as_slice()).unwrap()
+    );
+}

--- a/bee-message/tests/transaction_payload.rs
+++ b/bee-message/tests/transaction_payload.rs
@@ -23,7 +23,7 @@ fn builder_no_essence_error() {
     assert!(matches!(builder.finish(), Err(Error::MissingField("essence"))));
 }
 
-// Validate that attempting to construct a `TransactionPayload` with unlock blocks is an error.
+// Validate that attempting to construct a `TransactionPayload` with no unlock blocks is an error.
 #[test]
 fn builder_no_essence_no_unlock_blocks() {
     // Construct a transaction essence with one input and one output.

--- a/bee-message/tests/transaction_payload.rs
+++ b/bee-message/tests/transaction_payload.rs
@@ -1,9 +1,157 @@
 // Copyright 2020 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
-use bee_message::prelude::*;
+use bee_common::packable::Packable;
+use bee_message::{input::Input, payload::transaction::Essence, prelude::*};
+
+use core::convert::TryInto;
+
+const TRANSACTION_ID: &str = "52fdfc072182654f163f5f0f9a621d729566c74d10037c4d7bbb0407d1e2c649";
+const ED25519_ADDRESS: &str = "52fdfc072182654f163f5f0f9a621d729566c74d10037c4d7bbb0407d1e2c649";
+const ED25519_PULIC_KEY: &str = "1DA5DDD11BA3F961ACAB68FAFEE3177D039875EAA94AC5FDBFF8B53F0C50BFB9";
+const ED25519_SIGNATURE: &str = "c6a40edf9a089f42c18f4ebccb35fe4b578d93b879e99b87f63573324a710d3456b03fb6d1fcc027e6401cbd9581f790ee3ed7a3f68e9c225fcb9f1cd7b7110d";
 
 #[test]
 fn kind() {
     assert_eq!(TransactionPayload::KIND, 0);
+}
+
+// Validate that attempting to construct a `TransactionPayload` with no essence is an error.
+#[test]
+fn builder_no_essence_error() {
+    let builder = TransactionPayload::builder();
+    assert!(matches!(builder.finish(), Err(Error::MissingField("essence"))));
+}
+
+// Validate that attempting to construct a `TransactionPayload` with unlock blocks is an error.
+#[test]
+fn builder_no_essence_no_unlock_blocks() {
+    // Construct a transaction essence with one input and one output.
+    let txid = TransactionId::new(hex::decode(TRANSACTION_ID).unwrap().try_into().unwrap());
+    let input = Input::Utxo(UtxoInput::new(txid, 0).unwrap());
+    let bytes: [u8; 32] = hex::decode(ED25519_ADDRESS).unwrap().try_into().unwrap();
+    let address = Address::from(Ed25519Address::new(bytes));
+    let amount = 1_000_000;
+    let output = Output::SignatureLockedSingle(SignatureLockedSingleOutput::new(address, amount).unwrap());
+    let essence = Essence::Regular(
+        RegularEssence::builder()
+            .with_inputs(vec![input])
+            .with_outputs(vec![output])
+            .finish()
+            .unwrap(),
+    );
+
+    // Initialize the builder but do not set `with_output_block()`.
+    let builder = TransactionPayload::builder().with_essence(essence);
+    assert!(matches!(builder.finish(), Err(Error::MissingField("unlock_blocks"))));
+}
+
+// Validate that attempting to construct a `TransactionPayload` with too few unlock blocks is an
+// error.
+#[test]
+fn builder_no_essence_too_few_unlock_blocks() {
+    // Construct a transaction essence with two inputs and one output.
+    let txid = TransactionId::new(hex::decode(TRANSACTION_ID).unwrap().try_into().unwrap());
+    let input1 = Input::Utxo(UtxoInput::new(txid, 0).unwrap());
+    let input2 = Input::Utxo(UtxoInput::new(txid, 1).unwrap());
+    let bytes: [u8; 32] = hex::decode(ED25519_ADDRESS).unwrap().try_into().unwrap();
+    let address = Address::from(Ed25519Address::new(bytes));
+    let amount = 1_000_000;
+    let output = Output::SignatureLockedSingle(SignatureLockedSingleOutput::new(address, amount).unwrap());
+    let essence = Essence::Regular(
+        RegularEssence::builder()
+            .with_inputs(vec![input1, input2])
+            .with_outputs(vec![output])
+            .finish()
+            .unwrap(),
+    );
+
+    // Construct a list with a single unlock block, whereas we have 2 tx inputs.
+    let pub_key_bytes: [u8; 32] = hex::decode(ED25519_PULIC_KEY).unwrap().try_into().unwrap();
+    let sig_bytes: [u8; 64] = hex::decode(ED25519_SIGNATURE).unwrap().try_into().unwrap();
+    let signature = Ed25519Signature::new(pub_key_bytes, Box::new(sig_bytes));
+    let sig_unlock_block = UnlockBlock::Signature(SignatureUnlock::Ed25519(signature));
+    let unlock_blocks = UnlockBlocks::new(vec![sig_unlock_block]).unwrap();
+
+    let builder = TransactionPayload::builder()
+        .with_essence(essence)
+        .with_unlock_blocks(unlock_blocks);
+    assert!(matches!(
+            builder.finish(),
+            Err(Error::InputUnlockBlockCountMismatch(input_len, unlock_blocks_len))
+            if input_len == 2 && unlock_blocks_len == 1));
+}
+
+// Validate that attempting to construct a `TransactionPayload` with too many unlock blocks is an
+// error.
+#[test]
+fn builder_no_essence_too_many_unlock_blocks() {
+    // Construct a transaction essence with one input and one output.
+    let txid = TransactionId::new(hex::decode(TRANSACTION_ID).unwrap().try_into().unwrap());
+    let input1 = Input::Utxo(UtxoInput::new(txid, 0).unwrap());
+    let bytes: [u8; 32] = hex::decode(ED25519_ADDRESS).unwrap().try_into().unwrap();
+    let address = Address::from(Ed25519Address::new(bytes));
+    let amount = 1_000_000;
+    let output = Output::SignatureLockedSingle(SignatureLockedSingleOutput::new(address, amount).unwrap());
+    let essence = Essence::Regular(
+        RegularEssence::builder()
+            .with_inputs(vec![input1])
+            .with_outputs(vec![output])
+            .finish()
+            .unwrap(),
+    );
+
+    // Construct a list of two unlock blocks, whereas we only have 1 tx input.
+    let pub_key_bytes: [u8; 32] = hex::decode(ED25519_PULIC_KEY).unwrap().try_into().unwrap();
+    let sig_bytes: [u8; 64] = hex::decode(ED25519_SIGNATURE).unwrap().try_into().unwrap();
+    let signature = Ed25519Signature::new(pub_key_bytes, Box::new(sig_bytes));
+    let sig_unlock_block = UnlockBlock::Signature(SignatureUnlock::Ed25519(signature));
+    let ref_unlock_block = UnlockBlock::Reference(ReferenceUnlock::new(0).unwrap());
+
+    let unlock_blocks = UnlockBlocks::new(vec![sig_unlock_block, ref_unlock_block]).unwrap();
+
+    let builder = TransactionPayload::builder()
+        .with_essence(essence)
+        .with_unlock_blocks(unlock_blocks);
+    assert!(matches!(
+            builder.finish(),
+            Err(Error::InputUnlockBlockCountMismatch(input_len, unlock_blocks_len))
+            if input_len == 1 && unlock_blocks_len == 2));
+}
+
+// Validate that a `unpack` ∘ `pack` round-trip results in the original message.
+#[test]
+fn pack_unpack_valid() {
+    // Construct a transaction essence with two inputs and one output.
+    let txid = TransactionId::new(hex::decode(TRANSACTION_ID).unwrap().try_into().unwrap());
+    let input1 = Input::Utxo(UtxoInput::new(txid, 0).unwrap());
+    let input2 = Input::Utxo(UtxoInput::new(txid, 1).unwrap());
+    let bytes: [u8; 32] = hex::decode(ED25519_ADDRESS).unwrap().try_into().unwrap();
+    let address = Address::from(Ed25519Address::new(bytes));
+    let amount = 1_000_000;
+    let output = Output::SignatureLockedSingle(SignatureLockedSingleOutput::new(address, amount).unwrap());
+    let essence = Essence::Regular(
+        RegularEssence::builder()
+            .with_inputs(vec![input1, input2])
+            .with_outputs(vec![output])
+            .finish()
+            .unwrap(),
+    );
+
+    // Construct a list of two unlock blocks, whereas we only have 1 tx input.
+    let pub_key_bytes: [u8; 32] = hex::decode(ED25519_PULIC_KEY).unwrap().try_into().unwrap();
+    let sig_bytes: [u8; 64] = hex::decode(ED25519_SIGNATURE).unwrap().try_into().unwrap();
+    let signature = Ed25519Signature::new(pub_key_bytes, Box::new(sig_bytes));
+    let sig_unlock_block = UnlockBlock::Signature(SignatureUnlock::Ed25519(signature));
+    let ref_unlock_block = UnlockBlock::Reference(ReferenceUnlock::new(0).unwrap());
+    let unlock_blocks = UnlockBlocks::new(vec![sig_unlock_block, ref_unlock_block]).unwrap();
+
+    let tx_payload = TransactionPayload::builder()
+        .with_essence(essence)
+        .with_unlock_blocks(unlock_blocks)
+        .finish()
+        .unwrap();
+    let packed_tx_payload = tx_payload.pack_new();
+    assert_eq!(packed_tx_payload.len(), tx_payload.packed_len());
+    assert_eq!(tx_payload, Packable::unpack(&mut packed_tx_payload.as_slice()).unwrap());
 }


### PR DESCRIPTION
# Description of change

Expand unit test coverage for core message protocol types in `bee-message` crate.

This includes:

- Some missing `kind()` tests
- `pack`/`unpack` round trip tests
- validation tests for `TransactionPayload`
- simplify some setup code in tests where possible

## Type of change

Unit test coverage expansion

## How the change has been tested

```
cargo test
```

## Change checklist

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that new and existing unit tests pass locally with my changes

