### PR TITLE
Add docs to transaction data types in bee-message crate.

### DIFF
--- a/bee-message/src/address/ed25519.rs
+++ b/bee-message/src/address/ed25519.rs
@@ -12,6 +12,8 @@ use crypto::{
 
 use core::{convert::TryInto, str::FromStr};
 
+/// The number of bytes in an Ed25519 address.
+/// See <https://en.wikipedia.org/wiki/EdDSA#Ed25519> for more information.
 pub const ED25519_ADDRESS_LENGTH: usize = 32;
 
 #[derive(Clone, Copy, Eq, PartialEq, Ord, PartialOrd, Hash)]

--- a/bee-message/src/input/utxo.rs
+++ b/bee-message/src/input/utxo.rs
@@ -7,16 +7,26 @@ use bee_common::packable::{Packable, Read, Write};
 
 use core::{convert::From, str::FromStr};
 
+/// An `UtxoInput` represents an input block within a transaction payload, and references
+/// the output from a previous transaction.
+///
+/// It is part of the transaction [Essense](crate::payload::transaction::Essence).
+///
+/// Spec: #iota-protocol-rfc-draft
+/// <https://github.com/luca-moser/protocol-rfcs/blob/signed-tx-payload/text/0000-transaction-payload/0000-transaction-payload.md#serialized-layout>
 #[derive(Clone, Eq, PartialEq, Hash, Ord, PartialOrd)]
 pub struct UtxoInput(OutputId);
 
 impl UtxoInput {
+    /// The kind of transaction input: `0` as defined by the protocol.
     pub const KIND: u8 = 0;
 
+    /// Construct an `UtxoInput` from a previous transaction ID, and the index of the output block.
     pub fn new(id: TransactionId, index: u16) -> Result<Self, Error> {
         Ok(Self(OutputId::new(id, index)?))
     }
 
+    /// Return the underlying `OutputId` that this `UtxoInput` references.
     pub fn output_id(&self) -> &OutputId {
         &self.0
     }

--- a/bee-message/src/lib.rs
+++ b/bee-message/src/lib.rs
@@ -1,6 +1,11 @@
 // Copyright 2020-2021 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
+//! Core data types for messages in the tangle.
+//!
+//! This crate defines the core data types used by the Bee node to process
+//! messages and transactions in the tangle.
+
 extern crate alloc;
 
 #[cfg(feature = "serde")]

--- a/bee-message/src/payload/transaction/essence/mod.rs
+++ b/bee-message/src/payload/transaction/essence/mod.rs
@@ -11,6 +11,9 @@ use bee_common::packable::{Packable, Read, Write};
 
 use crypto::hashes::{blake2b::Blake2b256, Digest};
 
+/// The essence of a transaction describes the data making up the transaction.
+///
+/// See enum entries for specific types of transaction essences.
 #[non_exhaustive]
 #[derive(Clone, Debug, Eq, PartialEq)]
 #[cfg_attr(
@@ -19,16 +22,19 @@ use crypto::hashes::{blake2b::Blake2b256, Digest};
     serde(tag = "type", content = "data")
 )]
 pub enum Essence {
+    /// A regular transaction essence.
     Regular(RegularEssence),
 }
 
 impl Essence {
+    /// The kind of transaction essence, defined by the underlying essence type.
     pub fn kind(&self) -> u8 {
         match self {
             Self::Regular(_) => RegularEssence::KIND,
         }
     }
 
+    /// Return the Blake2b hash of the essence.
     pub fn hash(&self) -> [u8; 32] {
         Blake2b256::digest(&self.pack_new()).into()
     }

--- a/bee-message/src/payload/transaction/essence/regular.rs
+++ b/bee-message/src/payload/transaction/essence/regular.rs
@@ -16,6 +16,13 @@ use bee_common::{
 
 use alloc::{boxed::Box, vec::Vec};
 
+/// A regular transaction. It includes:
+/// * inputs
+/// * outputs
+/// * (optional) payload
+///
+/// Spec: #iota-protocol-rfc-draft
+/// <https://github.com/luca-moser/protocol-rfcs/blob/signed-tx-payload/text/0000-transaction-payload/0000-transaction-payload.md#serialized-layout>
 #[derive(Clone, Debug, Eq, PartialEq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct RegularEssence {
@@ -25,20 +32,25 @@ pub struct RegularEssence {
 }
 
 impl RegularEssence {
+    /// The kind of essence: `0` as defined by the protocol.
     pub const KIND: u8 = 0;
 
+    /// Create a new builder for constructing a `RegularEssence`.
     pub fn builder() -> RegularEssenceBuilder {
         RegularEssenceBuilder::new()
     }
 
+    /// Return the inputs to the transaction.
     pub fn inputs(&self) -> &[Input] {
         &self.inputs
     }
 
+    /// Return the outputs from the transaction.
     pub fn outputs(&self) -> &[Output] {
         &self.outputs
     }
 
+    /// Return the (optional) payload from the transaction.
     pub fn payload(&self) -> &Option<Payload> {
         &self.payload
     }

--- a/bee-message/src/payload/transaction/mod.rs
+++ b/bee-message/src/payload/transaction/mod.rs
@@ -15,6 +15,21 @@ use crypto::hashes::{blake2b::Blake2b256, Digest};
 
 /// A transaction message on the tangle.
 ///
+/// A transaction consists of two parts:
+/// 1. The transaction essence (inputs, outputs, optional payload)
+/// 2. Unlock blocks, which unlock the input UTXOs consumed by the transaction
+///
+/// As of April 2021 (RFC draft stage) the possible input and output types are:
+/// * [`UtxoInput`](crate::input::UtxoInput) - the output block from a previous transaction
+/// * [`SignatureLockedSingleOutput`](crate::output::SignatureLockedSingleOutput) - deposit to a
+///   single address which is unlocked via a signature
+/// * [`SignatureLockedDustAllowanceOutput`](crate::output::SignatureLockedDustAllowanceOutput) -
+///   deposit to a single address which also alters the dust allowance of the target address
+///
+/// And there are two types of unlock blocks:
+/// * [`SignatureUnlock`](crate::unlock::SignatureUnlock)
+/// * [`ReferenceUnlock`](crate::unlock::ReferenceUnlock)
+///
 /// Spec: #iota-protocol-rfc-draft
 /// <https://github.com/luca-moser/protocol-rfcs/blob/signed-tx-payload/text/0000-transaction-payload/0000-transaction-payload.md>
 #[derive(Clone, Debug, Eq, PartialEq)]
@@ -27,9 +42,10 @@ pub struct TransactionPayload {
 }
 
 impl TransactionPayload {
-    /// The kind of payload, defined by the protocol.
+    /// The kind of payload, `0` as defined by the protocol.
     pub const KIND: u32 = 0;
 
+    /// Return a new builder for a transaction payload.
     pub fn builder() -> TransactionPayloadBuilder {
         TransactionPayloadBuilder::default()
     }
@@ -46,10 +62,12 @@ impl TransactionPayload {
         TransactionId::new(hasher.finalize().into())
     }
 
+    /// Return the essence (inputs, outputs, payload) for this transaction.
     pub fn essence(&self) -> &Essence {
         &self.essence
     }
 
+    /// Return the blocks used to unlock the inputs to this transaction.
     pub fn unlock_blocks(&self) -> &UnlockBlocks {
         &self.unlock_blocks
     }

--- a/bee-message/src/payload/transaction/mod.rs
+++ b/bee-message/src/payload/transaction/mod.rs
@@ -13,20 +13,30 @@ use bee_common::packable::{Packable, Read, Write};
 
 use crypto::hashes::{blake2b::Blake2b256, Digest};
 
+/// A transaction message on the tangle.
+///
+/// Spec: #iota-protocol-rfc-draft
+/// <https://github.com/luca-moser/protocol-rfcs/blob/signed-tx-payload/text/0000-transaction-payload/0000-transaction-payload.md>
 #[derive(Clone, Debug, Eq, PartialEq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct TransactionPayload {
+    /// The inputs, outputs, and an optional embedded payload.
     essence: Essence,
+    /// Unlocks the `essence`'s inputs.
     unlock_blocks: UnlockBlocks,
 }
 
 impl TransactionPayload {
+    /// The kind of payload, defined by the protocol.
     pub const KIND: u32 = 0;
 
     pub fn builder() -> TransactionPayloadBuilder {
         TransactionPayloadBuilder::default()
     }
 
+    /// Compute and return the identifier for this payload.
+    ///
+    /// Computed by taking the Blake2b256 hash of the payload content.
     pub fn id(&self) -> TransactionId {
         let mut hasher = Blake2b256::new();
 

--- a/bee-message/src/payload/transaction/transaction_id.rs
+++ b/bee-message/src/payload/transaction/transaction_id.rs
@@ -7,12 +7,18 @@ use bee_common::packable::{Packable, Read, Write};
 
 use core::{convert::TryInto, str::FromStr};
 
+/// The number of bytes used to represent a [TransactionId].
+///
+/// IDs are computed by taking the Blake2b256 hash which is 256 bits (32 bytes).
 pub const TRANSACTION_ID_LENGTH: usize = 32;
 
+/// A `TransactionId` is the Blacke2b256 of a
+/// [`TransactionPayload`](crate::payload::transaction::TransactionPayload).
 #[derive(Clone, Copy, Eq, Hash, PartialEq, Ord, PartialOrd)]
 pub struct TransactionId([u8; TRANSACTION_ID_LENGTH]);
 
 impl TransactionId {
+    /// Construct a `TransactionId` from a hash value.
     pub fn new(bytes: [u8; TRANSACTION_ID_LENGTH]) -> Self {
         bytes.into()
     }

--- a/bee-message/src/signature/ed25519.rs
+++ b/bee-message/src/signature/ed25519.rs
@@ -19,9 +19,10 @@ pub struct Ed25519Signature {
 }
 
 impl Ed25519Signature {
-    /// The kind of unlock signature, defined by the protocol.
+    /// The kind of unlock signature: `0` as defined by the protocol.
     pub const KIND: u8 = 0;
 
+    /// Construct a signature from it's public key and signature.
     pub fn new(public_key: [u8; ED25519_PUBLIC_KEY_LENGTH], signature: Box<[u8]>) -> Self {
         Self { public_key, signature }
     }

--- a/bee-message/src/signature/ed25519.rs
+++ b/bee-message/src/signature/ed25519.rs
@@ -19,6 +19,7 @@ pub struct Ed25519Signature {
 }
 
 impl Ed25519Signature {
+    /// The kind of unlock signature, defined by the protocol.
     pub const KIND: u8 = 0;
 
     pub fn new(public_key: [u8; ED25519_PUBLIC_KEY_LENGTH], signature: Box<[u8]>) -> Self {

--- a/bee-message/src/signature/mod.rs
+++ b/bee-message/src/signature/mod.rs
@@ -31,10 +31,11 @@ pub enum SignatureUnlock {
 }
 
 impl SignatureUnlock {
-    /// The kind of unlock block used to unlock an input (defined by spec).
+    /// The kind of unlock block used to unlock an input: `0` as defined by the protocol.
     pub const KIND: u8 = 0;
 
-    /// The kind of the signature used to unlock a transaction input.
+    /// The kind of the signature used to unlock a transaction input. Defined by the underlying
+    /// signature type.
     pub fn kind(&self) -> u8 {
         match self {
             Self::Ed25519(_) => Ed25519Signature::KIND,

--- a/bee-message/src/signature/mod.rs
+++ b/bee-message/src/signature/mod.rs
@@ -9,6 +9,15 @@ use crate::Error;
 
 use bee_common::packable::{Packable, Read, Write};
 
+/// A `SignatureUnlock` contains a signature which is used to unlock a transaction input.
+///
+/// This is defined as part of the Unspent Transaction Output (UTXO) transaction protocol. The other
+/// signature type is a [ReferenceUnlock](crate::unlock::ReferenceUnlock) which refers to a previous
+/// `SignatureUnlock` in the [UnlockBlocks](crate::unlock::UnlockBlocks) list when the same
+/// signature can be used to unlock multiple inputs.
+///
+/// Spec: #iota-protocol-rfc-draft
+/// <https://github.com/luca-moser/protocol-rfcs/blob/signed-tx-payload/text/0000-transaction-payload/0000-transaction-payload.md#signature-unlock-block>
 #[non_exhaustive]
 #[derive(Clone, Debug, Eq, PartialEq, Hash)]
 #[cfg_attr(
@@ -17,12 +26,15 @@ use bee_common::packable::{Packable, Read, Write};
     serde(tag = "type", content = "data")
 )]
 pub enum SignatureUnlock {
+    /// An Ed25519 signature which unlocks a transaction input.
     Ed25519(Ed25519Signature),
 }
 
 impl SignatureUnlock {
+    /// The kind of unlock block used to unlock an input (defined by spec).
     pub const KIND: u8 = 0;
 
+    /// The kind of the signature used to unlock a transaction input.
     pub fn kind(&self) -> u8 {
         match self {
             Self::Ed25519(_) => Ed25519Signature::KIND,

--- a/bee-message/src/unlock/mod.rs
+++ b/bee-message/src/unlock/mod.rs
@@ -13,6 +13,19 @@ use core::ops::Deref;
 // TODO no_std
 use std::collections::HashSet;
 
+/// An UnlockBlock defines the mechanism by which a transaction input is
+/// validated for spending.
+///
+/// Unlock blocks are the mechanism by which the inputs to a transaction are
+/// verified. There are two types of unlock blocks:
+/// * [SignatureUnlock] - The signature of the address which owns an input UTXO to
+///   the transaction, validating that the UTXO can be spent in this transaction.
+/// * [ReferenceUnlock] - A reference (via index) to a previous [SignatureUnlock]
+///   if the same unlock can be used for multiple inputs (removing duplication
+///   in the protocol).
+///
+/// Spec: #iota-protocol-rfc-draft
+/// <https://github.com/luca-moser/protocol-rfcs/blob/signed-tx-payload/text/0000-transaction-payload/0000-transaction-payload.md>
 #[non_exhaustive]
 #[derive(Clone, Debug, Eq, PartialEq, Hash)]
 #[cfg_attr(
@@ -21,11 +34,14 @@ use std::collections::HashSet;
     serde(tag = "type", content = "data")
 )]
 pub enum UnlockBlock {
+    /// The signature of the address which 'owns' an input UTXO.
     Signature(SignatureUnlock),
+    /// A reference (via index) to a previous [SignatureUnlock].
     Reference(ReferenceUnlock),
 }
 
 impl UnlockBlock {
+    /// The kind of unlock block, as defined by the protocol.
     pub fn kind(&self) -> u8 {
         match self {
             Self::Signature(_) => SignatureUnlock::KIND,

--- a/bee-message/src/unlock/reference.rs
+++ b/bee-message/src/unlock/reference.rs
@@ -7,13 +7,29 @@ use bee_common::packable::{Packable, Read, Write};
 
 use core::convert::TryFrom;
 
+/// A ReferenceUnlock is an UnlockBlock that refers to a SignatureUnlock.
+///
+/// It consists of an index to a previous UnlockBlock which MUST be a
+/// SignatureUnlock. Referring to another ReferenceUnlock is invalid and
+/// will be rejected by the node.
+///
+/// Spec: #iota-protocol-rfc-draft
+/// <https://github.com/luca-moser/protocol-rfcs/blob/signed-tx-payload/text/0000-transaction-payload/0000-transaction-payload.md#reference-unlock-block>
 #[derive(Clone, Debug, Eq, PartialEq, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct ReferenceUnlock(u16);
 
 impl ReferenceUnlock {
+    /// The kind of UnlockBlock, defined by the protocol.
     pub const KIND: u8 = 1;
 
+    /// Create a new ReferenceUnlock from an index.
+    ///
+    /// The index must within the range of valid indices as defined by the protocol.
+    ///
+    /// Validation that the referenced block does not refer to another ReferenceUnlock is not
+    /// performed at this point, thus it is the responsibility of the caller to ensure that
+    /// the reference is semantically valid.
     pub fn new(index: u16) -> Result<Self, Error> {
         if !INPUT_OUTPUT_INDEX_RANGE.contains(&index) {
             return Err(Error::InvalidReferenceIndex(index));
@@ -22,6 +38,7 @@ impl ReferenceUnlock {
         Ok(Self(index))
     }
 
+    /// Return the underlying UnlockBlock index that this ReferenceUnlock refers to.
     pub fn index(&self) -> u16 {
         self.0
     }

--- a/bee-message/src/unlock/reference.rs
+++ b/bee-message/src/unlock/reference.rs
@@ -7,11 +7,12 @@ use bee_common::packable::{Packable, Read, Write};
 
 use core::convert::TryFrom;
 
-/// A ReferenceUnlock is an UnlockBlock that refers to a SignatureUnlock.
+/// A `ReferenceUnlock` is an [`UnlockBlock`](crate::unlock::UnlockBlock) that refers to a
+/// [`SignatureUnlock`](crate::unlock::SignatureUnlock).
 ///
-/// It consists of an index to a previous UnlockBlock which MUST be a
-/// SignatureUnlock. Referring to another ReferenceUnlock is invalid and
-/// will be rejected by the node.
+/// It consists of an index to a previous `UnlockBlock` which **must** be a `SignatureUnlock`.
+/// Referring to another `ReferenceUnlock` is invalid and will be rejected by the node's protocol
+/// validation.
 ///
 /// Spec: #iota-protocol-rfc-draft
 /// <https://github.com/luca-moser/protocol-rfcs/blob/signed-tx-payload/text/0000-transaction-payload/0000-transaction-payload.md#reference-unlock-block>
@@ -20,16 +21,16 @@ use core::convert::TryFrom;
 pub struct ReferenceUnlock(u16);
 
 impl ReferenceUnlock {
-    /// The kind of UnlockBlock, defined by the protocol.
+    /// The kind of UnlockBlock: `1` as defined by the protocol.
     pub const KIND: u8 = 1;
 
-    /// Create a new ReferenceUnlock from an index.
+    /// Create a new `ReferenceUnlock` from an index.
     ///
-    /// The index must within the range of valid indices as defined by the protocol.
+    /// The index must within the range of valid indices as defined by the protocol, and must refer
+    /// to a *previous* unlock block (not a later one).
     ///
-    /// Validation that the referenced block does not refer to another ReferenceUnlock is not
-    /// performed at this point, thus it is the responsibility of the caller to ensure that
-    /// the reference is semantically valid.
+    /// The caller is responsible for validating that the referenced block is a previous
+    /// `SignatureUnlock` block.
     pub fn new(index: u16) -> Result<Self, Error> {
         if !INPUT_OUTPUT_INDEX_RANGE.contains(&index) {
             return Err(Error::InvalidReferenceIndex(index));
@@ -38,7 +39,7 @@ impl ReferenceUnlock {
         Ok(Self(index))
     }
 
-    /// Return the underlying UnlockBlock index that this ReferenceUnlock refers to.
+    /// Return the underlying UnlockBlock index that this `ReferenceUnlock` refers to.
     pub fn index(&self) -> u16 {
         self.0
     }


### PR DESCRIPTION
# Description of change

Adds high level documentation to the core types for transaction messages.

## Type of change

- Documentation Fix

## How the change has been tested

N/A - documentation change only.

## Change checklist

Tick the boxes that are relevant to your changes, and delete any items that are not.

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
