### PR TITLE
Synchronize when shutdown is ready

### DIFF
--- a/bee-node/src/plugins/dashboard/mod.rs
+++ b/bee-node/src/plugins/dashboard/mod.rs
@@ -191,11 +191,16 @@ where
 
             server.await;
 
+            let mut readies = Vec::new();
+
             for (_, user) in users.write().await.iter_mut() {
                 if let Some(shutdown) = user.shutdown.take() {
                     let _ = shutdown.send(());
+                    readies.push(user.shutdown_ready.take().unwrap());
                 }
             }
+
+            futures::future::join_all(readies).await;
 
             info!("Stopped.");
         });


### PR DESCRIPTION
# Description of change

This allows to shutdown gracefully when the dashboard is open without holding references to the tangle.

## Type of change

- Bug fix (a non-breaking change which fixes an issue)

## How the change has been tested

Run bee-node with the dashboard feature enabled and open several instances of the dashboard in the browser. Then `Ctrl+C` bee-node and check that there is no reference count errors for the tangle.

## Change checklist

Tick the boxes that are relevant to your changes, and delete any items that are not.

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that new and existing unit tests pass locally with my changes
- [ ] I have updated the CHANGELOG.md, if my changes are significant enough
