### PR TITLE
Use constant nonce provider in bee-message accessor test

### DIFF
--- a/bee-message/tests/message.rs
+++ b/bee-message/tests/message.rs
@@ -123,7 +123,7 @@ fn pack_unpack_valid() {
 fn getters() {
     let parents = rand_parents();
     let payload: Payload = rand_indexation_payload().into();
-    let nonce = rand_number();
+    let nonce: u64 = rand_number();
 
     let message = MessageBuilder::new()
         .with_network_id(1)

--- a/bee-message/tests/message.rs
+++ b/bee-message/tests/message.rs
@@ -12,6 +12,7 @@ use bee_pow::{
 };
 use bee_test::rand::{
     message::rand_message_ids,
+    number::rand_number,
     parents::rand_parents,
     payload::{rand_indexation_payload, rand_treasury_transaction_payload},
 };
@@ -122,15 +123,18 @@ fn pack_unpack_valid() {
 fn getters() {
     let parents = rand_parents();
     let payload: Payload = rand_indexation_payload().into();
+    let nonce = rand_number();
 
-    let message = Message::builder()
+    let message = MessageBuilder::new()
         .with_network_id(1)
         .with_parents(parents.clone())
         .with_payload(payload.clone())
+        .with_nonce_provider(nonce, 10000f64)
         .finish()
         .unwrap();
 
     assert_eq!(message.network_id(), 1);
     assert_eq!(*message.parents(), parents);
     assert_eq!(*message.payload().as_ref().unwrap(), payload);
+    assert_eq!(message.nonce(), nonce);
 }


### PR DESCRIPTION
# Description of change

Switch to constant nonce provider in the `getters` test of `bee-message/tests/message.rs`.

## Type of change

- Bug fix (a non-breaking change which fixes an issue)

## How the change has been tested

Tested locally with release and debug.

## Change checklist

Tick the boxes that are relevant to your changes, and delete any items that are not.

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that new and existing unit tests pass locally with my changes
