### PR TITLE
Remove mutually exclusive feature flags

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -297,6 +297,7 @@ dependencies = [
  "once_cell",
  "rand 0.8.3",
  "serde",
+ "serial_test",
  "thiserror",
  "tokio",
  "tokio-stream",
@@ -2847,6 +2848,28 @@ dependencies = [
  "itoa",
  "ryu",
  "serde",
+]
+
+[[package]]
+name = "serial_test"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e0bccbcf40c8938196944a3da0e133e031a33f4d6b72db3bda3cc556e361905d"
+dependencies = [
+ "lazy_static",
+ "parking_lot",
+ "serial_test_derive",
+]
+
+[[package]]
+name = "serial_test_derive"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2acd6defeddb41eb60bb468f8825d0cfd0c2a76bc03bfd235b6a1dc4f6a1ad5"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]

--- a/bee-network/Cargo.toml
+++ b/bee-network/Cargo.toml
@@ -32,9 +32,6 @@ full = [
     "tokio",
     "tokio-stream",
 ]
-standalone = ["full"]
-integrated = ["full"]
-integration_tests = ["standalone"] # Required to run integration tests with `MemoryTransport` instead of regular.
 
 [dependencies]
 bee-runtime = { git = "https://github.com/iotaledger/bee.git", branch = "dev", optional = true }
@@ -56,5 +53,6 @@ bee-storage = { git = "https://github.com/iotaledger/bee.git", branch = "dev" }
 
 env_logger = "0.8"
 fern = "0.6"
-hex = "0.4.3"
+hex = "0.4"
+serial_test = "0.5"
 tokio = { version = "1.4", features = ["rt", "rt-multi-thread", "macros", "signal", "time", "io-std", "io-util"] }

--- a/bee-network/src/lib.rs
+++ b/bee-network/src/lib.rs
@@ -14,6 +14,9 @@ mod service;
 mod swarm;
 mod types;
 
+#[cfg(test)]
+mod tests;
+
 // Always exported
 pub use self::types::{PeerInfo, PeerRelation};
 #[doc(inline)]
@@ -23,7 +26,6 @@ pub use libp2p_core::{
 };
 
 // Exported only with "full" feature flag.
-// TODO: Do not restrict to Ed25519 keypairs
 #[cfg(feature = "full")]
 #[doc(inline)]
 pub use libp2p::core::identity::{ed25519::Keypair, PublicKey};
@@ -31,21 +33,14 @@ pub use libp2p::core::identity::{ed25519::Keypair, PublicKey};
 #[cfg(feature = "full")]
 pub use crate::{
     config::{NetworkConfig, NetworkConfigBuilder},
+    init::{integrated, standalone},
+    network::host::integrated::NetworkHost,
     network::meta::Origin,
     service::{
         command::Command,
         controller::{NetworkCommandSender, NetworkEventReceiver},
         event::Event,
+        service::integrated::NetworkService,
     },
     swarm::protocols::gossip::{GossipReceiver, GossipSender},
-};
-
-// Exported only with "standalone" feature flag.
-#[cfg(all(feature = "standalone", not(feature = "integrated")))]
-pub use crate::init::standalone::init;
-
-// Exported only with "integrated" feature flag.
-#[cfg(all(feature = "integrated", not(feature = "standalone")))]
-pub use crate::{
-    init::integrated::init, network::host::integrated::NetworkHost, service::service::integrated::NetworkService,
 };

--- a/bee-network/src/network/host.rs
+++ b/bee-network/src/network/host.rs
@@ -27,7 +27,6 @@ pub struct NetworkHostConfig {
     pub peerlist: PeerList,
 }
 
-#[cfg(all(feature = "integrated", not(feature = "standalone")))]
 pub mod integrated {
     use super::*;
     use crate::service::service::integrated::NetworkService;
@@ -91,10 +90,8 @@ pub mod integrated {
     }
 }
 
-#[cfg(all(feature = "standalone", not(feature = "integrated")))]
 pub mod standalone {
     use super::*;
-    use crate::service::service::standalone::NetworkService;
 
     use futures::channel::oneshot;
 

--- a/bee-network/src/peer/list.rs
+++ b/bee-network/src/peer/list.rs
@@ -441,18 +441,6 @@ mod tests {
         pl.accepts_incoming_peer(&peer_id, &peer_info).unwrap();
     }
 
-    #[test]
-    #[ignore]
-    fn deny_incoming_banned_peer() {
-        todo!()
-    }
-
-    #[test]
-    #[ignore]
-    fn deny_incoming_banned_addr() {
-        todo!()
-    }
-
     // =======================================================
     // utils
     // =======================================================

--- a/bee-network/src/service/service.rs
+++ b/bee-network/src/service/service.rs
@@ -44,7 +44,6 @@ pub struct Receivers {
 
 type Shutdown = oneshot::Receiver<()>;
 
-#[cfg(all(feature = "integrated", not(feature = "standalone")))]
 pub mod integrated {
     use super::*;
 
@@ -96,7 +95,6 @@ pub mod integrated {
     }
 }
 
-#[cfg(all(feature = "standalone", not(feature = "integrated")))]
 pub mod standalone {
     use super::*;
 
@@ -128,11 +126,11 @@ pub mod standalone {
             let (shutdown_tx3, shutdown_rx3) = oneshot::channel::<()>();
 
             tokio::spawn(async move {
-                shutdown.await;
+                shutdown.await.expect("receiving shutdown signal");
 
-                shutdown_tx1.send(());
-                shutdown_tx2.send(());
-                shutdown_tx3.send(());
+                shutdown_tx1.send(()).expect("receiving shutdown signal");
+                shutdown_tx2.send(()).expect("receiving shutdown signal");
+                shutdown_tx3.send(()).expect("receiving shutdown signal");
             });
             tokio::spawn(command_processor(
                 shutdown_rx1,

--- a/bee-network/src/swarm/builder.rs
+++ b/bee-network/src/swarm/builder.rs
@@ -36,7 +36,7 @@ pub async fn build_swarm(
     let mpx_config = mplex::MplexConfig::default();
     let ymx_config = yamux::YamuxConfig::default();
 
-    let transport = if cfg!(feature = "integration_tests") {
+    let transport = if cfg!(test) {
         use libp2p_core::transport::MemoryTransport;
 
         MemoryTransport::default()

--- a/bee-network/src/tests/add_peer.rs
+++ b/bee-network/src/tests/add_peer.rs
@@ -1,15 +1,13 @@
 // Copyright 2020 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
-#![cfg(feature = "standalone")]
+use super::common::{await_events::*, keys_and_ids::*, network_config::*, shutdown::*};
 
-mod common;
-use common::{await_events::*, keys_and_ids::*, network_config::*, shutdown::*};
-
-use bee_network::{init, Command, PeerRelation};
+use crate::{standalone::init, Command, PeerRelation};
 
 #[tokio::test]
-async fn connect_peer() {
+#[serial_test::serial]
+async fn add_peer() {
     let config1 = get_in_memory_network_config(1337);
     let keys1 = gen_random_keys();
 
@@ -19,25 +17,25 @@ async fn connect_peer() {
     let network_id = gen_constant_net_id();
 
     let (tx1, mut rx1) = init(config1, keys1, network_id, shutdown(10)).await;
-    let (tx2, mut rx2) = init(config2, keys2, network_id, shutdown(10)).await;
+    let (_, mut rx2) = init(config2, keys2, network_id, shutdown(10)).await;
 
-    let peer_id1 = get_local_id(&mut rx1).await;
-    let address1 = get_bind_address(&mut rx1).await;
-    println!("(1) Peer Id: {}", peer_id1);
-    println!("(1) Bound to: {}", address1);
+    let _peer_id1 = get_local_id(&mut rx1).await;
+    let _address1 = get_bind_address(&mut rx1).await;
+    // println!("(1) Peer Id: {}", peer_id1);
+    // println!("(1) Bound to: {}", address1);
 
     let peer_id2 = get_local_id(&mut rx2).await;
     let address2 = get_bind_address(&mut rx2).await;
-
-    println!("(2) Peer Id: {}", peer_id2);
-    println!("(2) Bound to: {}", address2);
+    // println!("(2) Peer Id: {}", peer_id2);
+    // println!("(2) Bound to: {}", address2);
 
     tx1.send(Command::AddPeer {
         alias: Some("2".into()),
         multiaddr: address2,
         relation: PeerRelation::Known,
         peer_id: peer_id2,
-    });
+    })
+    .expect("send command");
 
-    assert_eq!(get_connected_peer_id(&mut rx1).await, peer_id2);
+    assert_eq!(get_added_peer_id(&mut rx1).await, peer_id2);
 }

--- a/bee-network/src/tests/alias.rs
+++ b/bee-network/src/tests/alias.rs
@@ -1,10 +1,9 @@
 // Copyright 2020 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
-mod common;
-use common::keys_and_ids::gen_constant_peer_id;
+use super::common::keys_and_ids::gen_constant_peer_id;
 
-use bee_network::alias;
+use crate::alias;
 
 #[test]
 fn alias_default() {

--- a/bee-network/src/tests/common/await_events.rs
+++ b/bee-network/src/tests/common/await_events.rs
@@ -3,7 +3,7 @@
 
 #![cfg(feature = "full")]
 
-use bee_network::{Event, GossipReceiver, GossipSender, Multiaddr, NetworkEventReceiver, PeerId};
+use crate::{Event, GossipReceiver, GossipSender, Multiaddr, NetworkEventReceiver, PeerId};
 
 use tokio::time::{self, Duration};
 

--- a/bee-network/src/tests/common/keys_and_ids.rs
+++ b/bee-network/src/tests/common/keys_and_ids.rs
@@ -1,9 +1,7 @@
 // Copyright 2020 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
-#![allow(dead_code)]
-
-use libp2p_core::PeerId;
+use crate::PeerId;
 
 pub fn gen_constant_peer_id() -> PeerId {
     "12D3KooWJWEKvSFbben74C7H4YtKjhPMTDxd7gP7zxWSUEeF27st".parse().unwrap()

--- a/bee-network/src/tests/common/mod.rs
+++ b/bee-network/src/tests/common/mod.rs
@@ -1,8 +1,6 @@
 // Copyright 2020 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
-#![allow(dead_code)]
-
 pub mod await_events;
 pub mod keys_and_ids;
 pub mod network_config;

--- a/bee-network/src/tests/common/network_config.rs
+++ b/bee-network/src/tests/common/network_config.rs
@@ -3,7 +3,7 @@
 
 #![cfg(feature = "full")]
 
-use bee_network::{Multiaddr, NetworkConfig, Protocol};
+use crate::{Multiaddr, NetworkConfig, Protocol};
 
 pub fn get_network_config_with_port(port: u16) -> NetworkConfig {
     let mut config = NetworkConfig::default();

--- a/bee-network/src/tests/common/shutdown.rs
+++ b/bee-network/src/tests/common/shutdown.rs
@@ -1,8 +1,6 @@
 // Copyright 2020 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
-#![cfg(feature = "standalone")]
-
 use tokio::time::{self, Duration};
 
 use std::future::Future;

--- a/bee-network/src/tests/connect_peer.rs
+++ b/bee-network/src/tests/connect_peer.rs
@@ -1,15 +1,13 @@
 // Copyright 2020 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
-#![cfg(feature = "standalone")]
+use super::common::{await_events::*, keys_and_ids::*, network_config::*, shutdown::*};
 
-mod common;
-use common::{await_events::*, keys_and_ids::*, network_config::*, shutdown::*};
-
-use bee_network::{init, Command, PeerRelation};
+use crate::{standalone::init, Command, PeerRelation};
 
 #[tokio::test]
-async fn add_peer() {
+#[serial_test::serial]
+async fn connect_peer() {
     let config1 = get_in_memory_network_config(1337);
     let keys1 = gen_random_keys();
 
@@ -19,24 +17,26 @@ async fn add_peer() {
     let network_id = gen_constant_net_id();
 
     let (tx1, mut rx1) = init(config1, keys1, network_id, shutdown(10)).await;
-    let (_, mut rx2) = init(config2, keys2, network_id, shutdown(10)).await;
+    let (_tx2, mut rx2) = init(config2, keys2, network_id, shutdown(10)).await;
 
     let peer_id1 = get_local_id(&mut rx1).await;
     let address1 = get_bind_address(&mut rx1).await;
-    // println!("(1) Peer Id: {}", peer_id1);
-    // println!("(1) Bound to: {}", address1);
+    println!("(1) Peer Id: {}", peer_id1);
+    println!("(1) Bound to: {}", address1);
 
     let peer_id2 = get_local_id(&mut rx2).await;
     let address2 = get_bind_address(&mut rx2).await;
-    // println!("(2) Peer Id: {}", peer_id2);
-    // println!("(2) Bound to: {}", address2);
+
+    println!("(2) Peer Id: {}", peer_id2);
+    println!("(2) Bound to: {}", address2);
 
     tx1.send(Command::AddPeer {
         alias: Some("2".into()),
         multiaddr: address2,
         relation: PeerRelation::Known,
         peer_id: peer_id2,
-    });
+    })
+    .expect("send command");
 
-    assert_eq!(get_added_peer_id(&mut rx1).await, peer_id2);
+    assert_eq!(get_connected_peer_id(&mut rx1).await, peer_id2);
 }

--- a/bee-network/src/tests/initialize.rs
+++ b/bee-network/src/tests/initialize.rs
@@ -1,16 +1,12 @@
 // Copyright 2020 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
-#![cfg(feature = "standalone")]
+use super::common::{await_events::*, keys_and_ids::*, network_config::*, shutdown::*};
 
-mod common;
-use common::{await_events::*, keys_and_ids::*, network_config::*, shutdown::*};
-
-use bee_network::{init, PeerId};
-
-use std::str::FromStr;
+use crate::standalone::init;
 
 #[tokio::test]
+#[serial_test::serial]
 async fn initialize() {
     let config = get_in_memory_network_config(1337);
     let config_bind_multiaddr = config.bind_multiaddr().clone();
@@ -28,7 +24,9 @@ async fn initialize() {
 
     assert_eq!(
         local_id,
-        PeerId::from_str("12D3KooWNXQuYwdb9yjefEHf1cLKPihaUsLZ2biApnJcFrSEY5pc").expect("from_str")
+        "12D3KooWNXQuYwdb9yjefEHf1cLKPihaUsLZ2biApnJcFrSEY5pc"
+            .parse()
+            .expect("parse")
     );
     assert_eq!(bind_multiaddr, config_bind_multiaddr);
 }

--- a/bee-network/src/tests/mod.rs
+++ b/bee-network/src/tests/mod.rs
@@ -1,0 +1,12 @@
+// Copyright 2020 IOTA Stiftung
+// SPDX-License-Identifier: Apache-2.0
+
+#![cfg(test)]
+#![allow(dead_code)]
+
+mod add_peer;
+mod alias;
+mod common;
+mod connect_peer;
+mod initialize;
+mod send_recv;

--- a/bee-node/Cargo.toml
+++ b/bee-node/Cargo.toml
@@ -15,7 +15,7 @@ bee-common = { git = "https://github.com/iotaledger/bee.git", branch = "dev", fe
 bee-crypto = { git = "https://github.com/iotaledger/bee.git", branch = "dev" }
 bee-ledger = { path = "../bee-ledger", features = [ "workers" ] }
 bee-message = { git = "https://github.com/iotaledger/bee.git", branch = "dev" }
-bee-network = { path = "../bee-network", features = ["integrated"] }
+bee-network = { path = "../bee-network", features = ["full"] }
 bee-protocol = { path = "../bee-protocol" }
 bee-rest-api = { path = "../bee-api/bee-rest-api", features = ["endpoints"] }
 bee-runtime = { git = "https://github.com/iotaledger/bee.git", branch = "dev" }

--- a/bee-node/src/node/builder.rs
+++ b/bee-node/src/node/builder.rs
@@ -207,7 +207,8 @@ impl<B: StorageBackend> NodeBuilder<BeeNode<B>> for BeeNodeBuilder<B> {
         let this = self.with_resource(config.clone()); // TODO: Remove clone
 
         info!("Initializing network layer...");
-        let (this, events) = bee_network::init::<BeeNode<B>>(network_config, local_keys, network_id, this).await;
+        let (this, events) =
+            bee_network::integrated::init::<BeeNode<B>>(network_config, local_keys, network_id, this).await;
 
         #[cfg(unix)]
         let this = this.with_resource(shutdown_listener(vec![

--- a/bee-protocol/Cargo.toml
+++ b/bee-protocol/Cargo.toml
@@ -46,7 +46,7 @@ workers = [
   "bee-common",
   "bee-crypto",
   "bee-ledger",
-  "bee-network/integrated",
+  "bee-network/full",
   "bee-runtime",
   "bee-storage",
   "bee-tangle",


### PR DESCRIPTION
Fixes CI issues with mutually exclusive features. I removed all those to prevent this. There are some disadvanates now:
(1) bee-network binary is bigger than it could be
(2) integration tests are now run as unit tests. Since they cannot use the network in parallel I had to "serialize" such tests.