### PR TITLE
Further improve bee-message test coverage

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -5,6 +5,7 @@ on:
     branches:
       - dev
       - stable
+      - dev-message-coverage
     paths:
       - '**.rs'
       - '**.toml'

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -5,7 +5,6 @@ on:
     branches:
       - dev
       - stable
-      - dev-message-coverage
     paths:
       - '**.rs'
       - '**.toml'

--- a/bee-message/tests/address.rs
+++ b/bee-message/tests/address.rs
@@ -7,6 +7,7 @@ use bee_message::prelude::*;
 use core::convert::TryInto;
 
 const ED25519_ADDRESS: &str = "52fdfc072182654f163f5f0f9a621d729566c74d10037c4d7bbb0407d1e2c649";
+const ED25519_ADDRESS_BAD: &str = "52fdfc072182654f163f5f0f9a621d729566c74d10037c4d7bbb0407d1e2c64x";
 
 // The kind of an `Address` is the kind of the underlying address.
 #[test]
@@ -58,6 +59,12 @@ fn bech32_string_to_address() {
     } else {
         panic!("Expecting an Ed25519 address");
     }
+}
+
+#[test]
+fn invalid_bech32_string_to_address() {
+    let address = Address::try_from_bech32(ED25519_ADDRESS_BAD);
+    assert!(matches!(address, Err(Error::InvalidAddress)));
 }
 
 #[test]

--- a/bee-message/tests/indexation_payload.rs
+++ b/bee-message/tests/indexation_payload.rs
@@ -28,22 +28,26 @@ fn debug_impl() {
 #[test]
 fn new_valid() {
     let index = rand_bytes(64);
+    let index_array: [u8; 64] = index.as_slice().try_into().unwrap();
     let data = [0x42, 0xff, 0x84, 0xa2, 0x42, 0xff, 0x84, 0xa2];
     let indexation = IndexationPayload::new(&index, &data).unwrap();
 
     assert_eq!(indexation.index(), &index);
     assert_eq!(indexation.padded_index().as_ref(), index.as_slice());
+    assert_eq!(*indexation.padded_index(), index_array);
     assert_eq!(indexation.data(), &data);
 }
 
 #[test]
 fn new_valid_empty_data() {
     let index = rand_bytes(64);
+    let index_array: [u8; 64] = index.as_slice().try_into().unwrap();
     let data = [];
     let indexation = IndexationPayload::new(&index, &data).unwrap();
 
     assert_eq!(indexation.index(), &index);
     assert_eq!(indexation.padded_index().as_ref(), index.as_slice());
+    assert_eq!(*indexation.padded_index(), index_array);
     assert_eq!(indexation.data(), &data);
 }
 

--- a/bee-message/tests/milestone_id.rs
+++ b/bee-message/tests/milestone_id.rs
@@ -23,6 +23,14 @@ fn debug_impl() {
 }
 
 #[test]
+fn as_ref() {
+    let id_bytes = hex::decode(MILESTONE_ID).unwrap().try_into().unwrap();
+    let milestone = MilestoneId::new(id_bytes);
+
+    assert_eq!(milestone.as_ref(), &id_bytes);
+}
+
+#[test]
 fn from_str_valid() {
     MilestoneId::from_str(MILESTONE_ID).unwrap();
 }

--- a/bee-message/tests/milestone_index.rs
+++ b/bee-message/tests/milestone_index.rs
@@ -10,6 +10,11 @@ fn debug_impl() {
 }
 
 #[test]
+fn display_impl() {
+    assert_eq!(format!("{}", MilestoneIndex::new(0)), "0");
+}
+
+#[test]
 fn unpack() {
     let packed = 0u32.pack_new();
     assert_eq!(

--- a/bee-message/tests/milestone_payload.rs
+++ b/bee-message/tests/milestone_payload.rs
@@ -117,6 +117,30 @@ fn packed_len() {
 }
 
 #[test]
+fn pack_unpack_valid() {
+    let payload = MilestonePayload::new(
+        MilestonePayloadEssence::new(
+            MilestoneIndex(0),
+            0,
+            rand_parents(),
+            [0; MILESTONE_MERKLE_PROOF_LENGTH],
+            0,
+            0,
+            vec![[0; 32]],
+            None,
+        )
+        .unwrap(),
+        vec![[0; 64]],
+    )
+    .unwrap();
+
+    let packed = payload.pack_new();
+
+    assert_eq!(payload.packed_len(), packed.len());
+    assert_eq!(payload, Packable::unpack(&mut packed.as_slice()).unwrap())
+}
+
+#[test]
 fn getters() {
     let essence = MilestonePayloadEssence::new(
         rand::milestone::rand_milestone_index(),

--- a/bee-message/tests/payload.rs
+++ b/bee-message/tests/payload.rs
@@ -43,8 +43,8 @@ fn transaction() {
     let unlock_blocks = UnlockBlocks::new(vec![sig_unlock_block, ref_unlock_block]).unwrap();
 
     let tx_payload = TransactionPayloadBuilder::new()
-        .with_essence(essence.clone())
-        .with_unlock_blocks(unlock_blocks.clone())
+        .with_essence(essence)
+        .with_unlock_blocks(unlock_blocks)
         .finish()
         .unwrap();
 
@@ -123,7 +123,7 @@ fn receipt() {
     .into();
 
     let packed = payload.pack_new();
-    
+
     assert_eq!(payload.kind(), 3);
     assert_eq!(payload.packed_len(), packed.len());
     assert!(matches!(payload, Payload::Receipt(_)));
@@ -133,7 +133,7 @@ fn receipt() {
 #[test]
 fn treasury_transaction() {
     let payload: Payload = TreasuryTransactionPayload::new(
-        Input::from(TreasuryInput::from_str(MESSAGE_ID).unwrap()), 
+        Input::from(TreasuryInput::from_str(MESSAGE_ID).unwrap()),
         Output::from(TreasuryOutput::new(1_000_000).unwrap()),
     )
     .unwrap()

--- a/bee-message/tests/payload.rs
+++ b/bee-message/tests/payload.rs
@@ -1,0 +1,148 @@
+// Copyright 2020-2021 IOTA Stiftung
+// SPDX-License-Identifier: Apache-2.0
+
+use bee_common::packable::Packable;
+use bee_message::prelude::*;
+use bee_test::rand::{bytes::rand_bytes_32, parents::rand_parents};
+
+use std::{convert::TryInto, str::FromStr};
+
+const TRANSACTION_ID: &str = "24a1f46bdb6b2bf38f1c59f73cdd4ae5b418804bb231d76d06fbf246498d5883";
+const ED25519_ADDRESS: &str = "e594f9a895c0e0a6760dd12cffc2c3d1e1cbf7269b328091f96ce3d0dd550b75";
+const ED25519_PUBLIC_KEY: &str = "1da5ddd11ba3f961acab68fafee3177d039875eaa94ac5fdbff8b53f0c50bfb9";
+const ED25519_SIGNATURE: &str = "c6a40edf9a089f42c18f4ebccb35fe4b578d93b879e99b87f63573324a710d3456b03fb6d1fcc027e6401cbd9581f790ee3ed7a3f68e9c225fcb9f1cd7b7110d";
+const MESSAGE_ID: &str = "b0212bde21643a8b719f398fe47545c4275b52c1f600e255caa53d77a91bb46d";
+const MILESTONE_ID: &str = "40498d437a95fe67c1ed467e6ee85567833c36bf91e71742ea2c71e0633146b9";
+const TAIL_TRANSACTION_HASH_BYTES: [u8; 49] = [
+    222, 235, 107, 67, 2, 173, 253, 93, 165, 90, 166, 45, 102, 91, 19, 137, 71, 146, 156, 180, 248, 31, 56, 25, 68,
+    154, 98, 100, 64, 108, 203, 48, 76, 75, 114, 150, 34, 153, 203, 35, 225, 120, 194, 175, 169, 207, 80, 229, 10,
+];
+
+#[test]
+fn transaction() {
+    let txid = TransactionId::new(hex::decode(TRANSACTION_ID).unwrap().try_into().unwrap());
+    let input1 = Input::Utxo(UtxoInput::new(txid, 0).unwrap());
+    let input2 = Input::Utxo(UtxoInput::new(txid, 1).unwrap());
+    let bytes: [u8; 32] = hex::decode(ED25519_ADDRESS).unwrap().try_into().unwrap();
+    let address = Address::from(Ed25519Address::new(bytes));
+    let amount = 1_000_000;
+    let output = Output::SignatureLockedSingle(SignatureLockedSingleOutput::new(address, amount).unwrap());
+    let essence = Essence::Regular(
+        RegularEssenceBuilder::new()
+            .with_inputs(vec![input1, input2])
+            .with_outputs(vec![output])
+            .finish()
+            .unwrap(),
+    );
+
+    let pub_key_bytes: [u8; 32] = hex::decode(ED25519_PUBLIC_KEY).unwrap().try_into().unwrap();
+    let sig_bytes: [u8; 64] = hex::decode(ED25519_SIGNATURE).unwrap().try_into().unwrap();
+    let signature = Ed25519Signature::new(pub_key_bytes, sig_bytes);
+    let sig_unlock_block = UnlockBlock::Signature(SignatureUnlock::Ed25519(signature));
+    let ref_unlock_block = UnlockBlock::Reference(ReferenceUnlock::new(0).unwrap());
+    let unlock_blocks = UnlockBlocks::new(vec![sig_unlock_block, ref_unlock_block]).unwrap();
+
+    let tx_payload = TransactionPayloadBuilder::new()
+        .with_essence(essence.clone())
+        .with_unlock_blocks(unlock_blocks.clone())
+        .finish()
+        .unwrap();
+
+    let payload: Payload = tx_payload.into();
+    let packed = payload.pack_new();
+
+    assert_eq!(payload.kind(), 0);
+    assert_eq!(payload.packed_len(), packed.len());
+    assert!(matches!(payload, Payload::Transaction(_)));
+    assert_eq!(payload, Packable::unpack(&mut packed.as_slice()).unwrap());
+}
+
+#[test]
+fn milestone() {
+    let payload: Payload = MilestonePayload::new(
+        MilestonePayloadEssence::new(
+            MilestoneIndex(0),
+            0,
+            rand_parents(),
+            [0; MILESTONE_MERKLE_PROOF_LENGTH],
+            0,
+            0,
+            vec![[0; 32]],
+            None,
+        )
+        .unwrap(),
+        vec![[0; 64]],
+    )
+    .unwrap()
+    .into();
+
+    let packed = payload.pack_new();
+
+    assert_eq!(payload.kind(), 1);
+    assert_eq!(payload.packed_len(), packed.len());
+    assert!(matches!(payload, Payload::Milestone(_)));
+    assert_eq!(payload, Packable::unpack(&mut packed.as_slice()).unwrap());
+}
+
+#[test]
+fn indexation() {
+    let payload: Payload = IndexationPayload::new(&rand_bytes_32(), &[]).unwrap().into();
+
+    let packed = payload.pack_new();
+
+    assert_eq!(payload.kind(), 2);
+    assert_eq!(payload.packed_len(), packed.len());
+    assert!(matches!(payload, Payload::Indexation(_)));
+}
+
+#[test]
+fn receipt() {
+    let payload: Payload = ReceiptPayload::new(
+        MilestoneIndex::new(0),
+        true,
+        vec![
+            MigratedFundsEntry::new(
+                TailTransactionHash::new(TAIL_TRANSACTION_HASH_BYTES).unwrap(),
+                SignatureLockedSingleOutput::new(
+                    Address::from(Ed25519Address::from_str(ED25519_ADDRESS).unwrap()),
+                    1_000_000,
+                )
+                .unwrap(),
+            )
+            .unwrap(),
+        ],
+        Payload::TreasuryTransaction(Box::new(
+            TreasuryTransactionPayload::new(
+                Input::Treasury(TreasuryInput::new(MilestoneId::from_str(MILESTONE_ID).unwrap())),
+                Output::Treasury(TreasuryOutput::new(1_000_000).unwrap()),
+            )
+            .unwrap(),
+        )),
+    )
+    .unwrap()
+    .into();
+
+    let packed = payload.pack_new();
+    
+    assert_eq!(payload.kind(), 3);
+    assert_eq!(payload.packed_len(), packed.len());
+    assert!(matches!(payload, Payload::Receipt(_)));
+    assert_eq!(payload, Packable::unpack(&mut packed.as_slice()).unwrap());
+}
+
+#[test]
+fn treasury_transaction() {
+    let payload: Payload = TreasuryTransactionPayload::new(
+        Input::from(TreasuryInput::from_str(MESSAGE_ID).unwrap()), 
+        Output::from(TreasuryOutput::new(1_000_000).unwrap()),
+    )
+    .unwrap()
+    .into();
+
+    let packed = payload.pack_new();
+
+    assert_eq!(payload.kind(), 4);
+    assert_eq!(payload.packed_len(), packed.len());
+    assert!(matches!(payload, Payload::TreasuryTransaction(_)));
+    assert_eq!(payload, Packable::unpack(&mut packed.as_slice()).unwrap());
+}

--- a/bee-message/tests/receipt_payload.rs
+++ b/bee-message/tests/receipt_payload.rs
@@ -245,13 +245,7 @@ fn getters() {
     .unwrap()
     .into();
 
-    let receipt = ReceiptPayload::new(
-        migrated_at,
-        last,
-        funds.clone(),
-        payload.clone(),
-    )
-    .unwrap();
+    let receipt = ReceiptPayload::new(migrated_at, last, funds.clone(), payload.clone()).unwrap();
 
     assert_eq!(receipt.migrated_at(), migrated_at);
     assert_eq!(receipt.last(), last);

--- a/bee-message/tests/receipt_payload.rs
+++ b/bee-message/tests/receipt_payload.rs
@@ -3,7 +3,7 @@
 
 use bee_common::packable::Packable;
 use bee_message::prelude::*;
-use bee_test::rand::bytes::rand_bytes_32;
+use bee_test::rand::{bytes::rand_bytes_32, number::rand_number};
 
 use std::str::FromStr;
 
@@ -221,4 +221,41 @@ fn pack_unpack_valid() {
 
     assert_eq!(packed_receipt.len(), receipt.packed_len());
     assert_eq!(receipt, Packable::unpack(&mut packed_receipt.as_slice()).unwrap());
+}
+
+#[test]
+fn getters() {
+    let migrated_at = MilestoneIndex::new(rand_number());
+    let last = true;
+    let funds = vec![
+        MigratedFundsEntry::new(
+            TailTransactionHash::new(TAIL_TRANSACTION_HASH_BYTES).unwrap(),
+            SignatureLockedSingleOutput::new(
+                Address::from(Ed25519Address::from_str(ED25519_ADDRESS).unwrap()),
+                AMOUNT,
+            )
+            .unwrap(),
+        )
+        .unwrap(),
+    ];
+    let payload: Payload = TreasuryTransactionPayload::new(
+        Input::Treasury(TreasuryInput::new(MilestoneId::from_str(MILESTONE_ID).unwrap())),
+        Output::Treasury(TreasuryOutput::new(AMOUNT).unwrap()),
+    )
+    .unwrap()
+    .into();
+
+    let receipt = ReceiptPayload::new(
+        migrated_at,
+        last,
+        funds.clone(),
+        payload.clone(),
+    )
+    .unwrap();
+
+    assert_eq!(receipt.migrated_at(), migrated_at);
+    assert_eq!(receipt.last(), last);
+    assert_eq!(receipt.funds(), funds.as_slice());
+    assert_eq!(*receipt.transaction(), payload);
+    assert_eq!(receipt.amount(), AMOUNT);
 }

--- a/bee-message/tests/transaction_payload.rs
+++ b/bee-message/tests/transaction_payload.rs
@@ -187,7 +187,7 @@ fn getters() {
     let ref_unlock_block = UnlockBlock::Reference(ReferenceUnlock::new(0).unwrap());
     let unlock_blocks = UnlockBlocks::new(vec![sig_unlock_block, ref_unlock_block]).unwrap();
 
-    let tx_payload = TransactionPayload::builder()
+    let tx_payload = TransactionPayloadBuilder::new()
         .with_essence(essence.clone())
         .with_unlock_blocks(unlock_blocks.clone())
         .finish()

--- a/bee-message/tests/transaction_payload.rs
+++ b/bee-message/tests/transaction_payload.rs
@@ -160,3 +160,39 @@ fn pack_unpack_valid() {
     assert_eq!(packed_tx_payload.len(), tx_payload.packed_len());
     assert_eq!(tx_payload, Packable::unpack(&mut packed_tx_payload.as_slice()).unwrap());
 }
+
+#[test]
+fn getters() {
+    // Construct a transaction essence with two inputs and one output.
+    let txid = TransactionId::new(hex::decode(TRANSACTION_ID).unwrap().try_into().unwrap());
+    let input1 = Input::Utxo(UtxoInput::new(txid, 0).unwrap());
+    let input2 = Input::Utxo(UtxoInput::new(txid, 1).unwrap());
+    let bytes: [u8; 32] = hex::decode(ED25519_ADDRESS).unwrap().try_into().unwrap();
+    let address = Address::from(Ed25519Address::new(bytes));
+    let amount = 1_000_000;
+    let output = Output::SignatureLockedSingle(SignatureLockedSingleOutput::new(address, amount).unwrap());
+    let essence = Essence::Regular(
+        RegularEssenceBuilder::new()
+            .with_inputs(vec![input1, input2])
+            .with_outputs(vec![output])
+            .finish()
+            .unwrap(),
+    );
+
+    // Construct a list of two unlock blocks, whereas we only have 1 tx input.
+    let pub_key_bytes: [u8; 32] = hex::decode(ED25519_PUBLIC_KEY).unwrap().try_into().unwrap();
+    let sig_bytes: [u8; 64] = hex::decode(ED25519_SIGNATURE).unwrap().try_into().unwrap();
+    let signature = Ed25519Signature::new(pub_key_bytes, sig_bytes);
+    let sig_unlock_block = UnlockBlock::Signature(SignatureUnlock::Ed25519(signature));
+    let ref_unlock_block = UnlockBlock::Reference(ReferenceUnlock::new(0).unwrap());
+    let unlock_blocks = UnlockBlocks::new(vec![sig_unlock_block, ref_unlock_block]).unwrap();
+
+    let tx_payload = TransactionPayload::builder()
+        .with_essence(essence.clone())
+        .with_unlock_blocks(unlock_blocks.clone())
+        .finish()
+        .unwrap();
+
+    assert_eq!(*tx_payload.essence(), essence);
+    assert_eq!(*tx_payload.unlock_blocks(), unlock_blocks);
+}

--- a/bee-message/tests/transaction_regular_essence.rs
+++ b/bee-message/tests/transaction_regular_essence.rs
@@ -301,3 +301,25 @@ fn build_invalid_accumulated_output() {
 
     assert!(matches!(essence, Err(Error::InvalidAccumulatedOutput(_))));
 }
+
+#[test]
+fn getters() {
+    let txid = TransactionId::new(hex::decode(TRANSACTION_ID).unwrap().try_into().unwrap());
+    let input1 = Input::Utxo(UtxoInput::new(txid, 0).unwrap());
+    let input2 = Input::Utxo(UtxoInput::new(txid, 1).unwrap());
+    let bytes: [u8; 32] = hex::decode(ED25519_ADDRESS_1).unwrap().try_into().unwrap();
+    let address = Address::from(Ed25519Address::new(bytes));
+    let amount = 1_000_000;
+    let outputs = vec![Output::SignatureLockedSingle(SignatureLockedSingleOutput::new(address, amount).unwrap())];
+    let payload = Payload::from(rand_indexation_payload());
+
+    let essence = RegularEssence::builder()
+        .with_inputs(vec![input1, input2])
+        .with_outputs(outputs.clone())
+        .with_payload(payload.clone())
+        .finish()
+        .unwrap();
+
+    assert_eq!(essence.outputs(), outputs.as_slice());
+    assert_eq!(*essence.payload().as_ref().unwrap(), payload);
+}

--- a/bee-message/tests/transaction_regular_essence.rs
+++ b/bee-message/tests/transaction_regular_essence.rs
@@ -310,7 +310,9 @@ fn getters() {
     let bytes: [u8; 32] = hex::decode(ED25519_ADDRESS_1).unwrap().try_into().unwrap();
     let address = Address::from(Ed25519Address::new(bytes));
     let amount = 1_000_000;
-    let outputs = vec![Output::SignatureLockedSingle(SignatureLockedSingleOutput::new(address, amount).unwrap())];
+    let outputs = vec![Output::SignatureLockedSingle(
+        SignatureLockedSingleOutput::new(address, amount).unwrap(),
+    )];
     let payload = Payload::from(rand_indexation_payload());
 
     let essence = RegularEssence::builder()


### PR DESCRIPTION
# Description of change

Increases bee-message test coverage to ~84% by implementing tests for all functionality aside from hashing and address verification.

## Type of change

- Enhancement (a non-breaking change which adds functionality)

## How the change has been tested

Tests have been run locally and coverage workflow run on my fork.

## Change checklist

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that new and existing unit tests pass locally with my changes
