### PR TITLE
Propagate errors while iterating storage

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -302,7 +302,7 @@ dependencies = [
 
 [[package]]
 name = "bee-storage"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "async-trait",
  "bee-common",

--- a/bee-ledger/Cargo.toml
+++ b/bee-ledger/Cargo.toml
@@ -14,7 +14,7 @@ homepage = "https://www.iota.org"
 bee-common = { version = "0.4.1", path = "../bee-common/bee-common" }
 bee-message = { version = "0.1.5", path = "../bee-message" }
 bee-runtime = { version = "0.1.1-alpha", path = "../bee-runtime", optional = true }
-bee-storage = { version = "0.4.0", path = "../bee-storage/bee-storage", optional = true }
+bee-storage = { version = "0.5.0", path = "../bee-storage/bee-storage", optional = true }
 bee-tangle = { version = "0.1.1", path = "../bee-tangle", optional = true }
 bee-ternary = { version = "0.4.2-alpha", path = "../bee-ternary", optional = true }
 

--- a/bee-ledger/src/workers/consensus/state.rs
+++ b/bee-ledger/src/workers/consensus/state.rs
@@ -24,7 +24,8 @@ async fn validate_ledger_unspent_state<B: StorageBackend>(storage: &B, treasury:
         .await
         .map_err(|e| Error::Storage(Box::new(e)))?;
 
-    while let Some((output_id, _)) = stream.next().await {
+    while let Some(result) = stream.next().await {
+        let (output_id, _) = result.map_err(|e| Error::Storage(Box::new(e)))?;
         let output = storage::fetch_output(storage, &*output_id)
             .await?
             .ok_or(Error::MissingUnspentOutput(output_id))?;
@@ -57,7 +58,8 @@ async fn validate_ledger_balance_state<B: StorageBackend>(storage: &B, treasury:
         .await
         .map_err(|e| Error::Storage(Box::new(e)))?;
 
-    while let Some((address, balance)) = stream.next().await {
+    while let Some(result) = stream.next().await {
+        let (address, balance) = result.map_err(|e| Error::Storage(Box::new(e)))?;
         if balance.dust_outputs() > dust_outputs_max(balance.dust_allowance()) {
             return Err(Error::InvalidLedgerDustState(address, balance));
         }

--- a/bee-runtime/Cargo.toml
+++ b/bee-runtime/Cargo.toml
@@ -11,7 +11,7 @@ keywords = ["iota", "tangle", "bee", "framework", "runtime"]
 homepage = "https://www.iota.org"
 
 [dependencies]
-bee-storage = { version = "0.4.0", path = "../bee-storage/bee-storage" }
+bee-storage = { version = "0.5.0", path = "../bee-storage/bee-storage" }
 
 async-trait = "0.1"
 dashmap = "4.0"

--- a/bee-storage/bee-storage-rocksdb/CHANGELOG.md
+++ b/bee-storage/bee-storage-rocksdb/CHANGELOG.md
@@ -19,11 +19,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Security -->
 
-## 0.2.0 - 2021-05-25
+## 0.2.0 - 2021-05-27
 
 ### Added
 
-- Implementation of the `MultiFetch` tarit for all bee storable types;
+- Implementation of the `MultiFetch` trait for all bee storable types;
+
+### Changed
+
+- `AsStream::Stream`
+  - from  `Stream<Item = (K, V)> + Send + Sync + Unpin;`
+  - to    `Stream<Item = Result<(K, V), Self::Error>> + Send + Sync + Unpin;`
 
 ## 0.1.0 - 2021-04-27
 

--- a/bee-storage/bee-storage-rocksdb/Cargo.toml
+++ b/bee-storage/bee-storage-rocksdb/Cargo.toml
@@ -14,7 +14,7 @@ homepage = "https://www.iota.org"
 bee-common = { version = "0.4.1", path = "../../bee-common/bee-common" }
 bee-ledger = { version = "0.3.0", path = "../../bee-ledger" }
 bee-message = { version = "0.1.3", path = "../../bee-message" }
-bee-storage = { version = "0.4.0", path = "../bee-storage" }
+bee-storage = { version = "0.5.0", path = "../bee-storage" }
 bee-tangle = { version = "0.1.0", path = "../../bee-tangle" }
 
 async-trait = "0.1"

--- a/bee-storage/bee-storage-test/Cargo.toml
+++ b/bee-storage/bee-storage-test/Cargo.toml
@@ -14,7 +14,7 @@ homepage = "https://www.iota.org"
 bee-common = { version = "0.4.1", path = "../../bee-common/bee-common" }
 bee-ledger = { version = "0.3.0", path = "../../bee-ledger" }
 bee-message = { version = "0.1.3", path = "../../bee-message" }
-bee-storage = { version = "0.4.0", path = "../bee-storage" }
+bee-storage = { version = "0.5.0", path = "../bee-storage" }
 bee-tangle = { version = "0.1.0", path = "../../bee-tangle" }
 bee-test = { version = "0.1.0", path = "../../bee-test" }
 

--- a/bee-storage/bee-storage-test/src/address_to_balance.rs
+++ b/bee-storage/bee-storage-test/src/address_to_balance.rs
@@ -116,7 +116,8 @@ pub async fn address_to_balance_access<B: StorageBackend>(storage: &B) {
     let mut stream = AsStream::<Address, Balance>::stream(storage).await.unwrap();
     let mut count = 0;
 
-    while let Some((address, balance)) = stream.next().await {
+    while let Some(result) = stream.next().await {
+        let (address, balance) = result.unwrap();
         assert!(balances.contains(&(address, Some(balance))));
         count += 1;
     }

--- a/bee-storage/bee-storage-test/src/ed25519_address_to_output_id.rs
+++ b/bee-storage/bee-storage-test/src/ed25519_address_to_output_id.rs
@@ -117,7 +117,8 @@ pub async fn ed25519_address_to_output_id_access<B: StorageBackend>(storage: &B)
         .unwrap();
     let mut count = 0;
 
-    while let Some(((address, output_id), _)) = stream.next().await {
+    while let Some(result) = stream.next().await {
+        let ((address, output_id), _) = result.unwrap();
         assert!(output_ids.get(&address).unwrap().contains(&output_id));
         count += 1;
     }

--- a/bee-storage/bee-storage-test/src/index_to_message_id.rs
+++ b/bee-storage/bee-storage-test/src/index_to_message_id.rs
@@ -115,7 +115,8 @@ pub async fn index_to_message_id_access<B: StorageBackend>(storage: &B) {
     let mut stream = AsStream::<(PaddedIndex, MessageId), ()>::stream(storage).await.unwrap();
     let mut count = 0;
 
-    while let Some(((index, message_id), _)) = stream.next().await {
+    while let Some(result) = stream.next().await {
+        let ((index, message_id), _) = result.unwrap();
         assert!(message_ids.get(&index).unwrap().contains(&message_id));
         count += 1;
     }

--- a/bee-storage/bee-storage-test/src/ledger_index.rs
+++ b/bee-storage/bee-storage-test/src/ledger_index.rs
@@ -81,7 +81,8 @@ pub async fn ledger_index_access<B: StorageBackend>(storage: &B) {
     let mut stream = AsStream::<(), LedgerIndex>::stream(storage).await.unwrap();
     let mut count = 0;
 
-    while let Some((_, ledger_index)) = stream.next().await {
+    while let Some(result) = stream.next().await {
+        let (_, ledger_index) = result.unwrap();
         assert_eq!(ledger_index, index);
         count += 1;
     }

--- a/bee-storage/bee-storage-test/src/message_id_to_message.rs
+++ b/bee-storage/bee-storage-test/src/message_id_to_message.rs
@@ -115,7 +115,8 @@ pub async fn message_id_to_message_access<B: StorageBackend>(storage: &B) {
     let mut stream = AsStream::<MessageId, Message>::stream(storage).await.unwrap();
     let mut count = 0;
 
-    while let Some((message_id, message)) = stream.next().await {
+    while let Some(result) = stream.next().await {
+        let (message_id, message) = result.unwrap();
         assert!(messages.contains(&(message_id, Some(message))));
         count += 1;
     }

--- a/bee-storage/bee-storage-test/src/message_id_to_message_id.rs
+++ b/bee-storage/bee-storage-test/src/message_id_to_message_id.rs
@@ -114,7 +114,8 @@ pub async fn message_id_to_message_id_access<B: StorageBackend>(storage: &B) {
     let mut stream = AsStream::<(MessageId, MessageId), ()>::stream(storage).await.unwrap();
     let mut count = 0;
 
-    while let Some(((parent, child), _)) = stream.next().await {
+    while let Some(result) = stream.next().await {
+        let ((parent, child), _) = result.unwrap();
         assert!(edges.get(&parent).unwrap().contains(&child));
         count += 1;
     }

--- a/bee-storage/bee-storage-test/src/message_id_to_metadata.rs
+++ b/bee-storage/bee-storage-test/src/message_id_to_metadata.rs
@@ -128,7 +128,8 @@ pub async fn message_id_to_metadata_access<B: StorageBackend>(storage: &B) {
     let mut stream = AsStream::<MessageId, MessageMetadata>::stream(storage).await.unwrap();
     let mut count = 0;
 
-    while let Some((message_id, metadata)) = stream.next().await {
+    while let Some(result) = stream.next().await {
+        let (message_id, metadata) = result.unwrap();
         assert!(metadatas.contains(&(message_id, Some(metadata))));
         count += 1;
     }

--- a/bee-storage/bee-storage-test/src/milestone_index_to_milestone.rs
+++ b/bee-storage/bee-storage-test/src/milestone_index_to_milestone.rs
@@ -127,7 +127,8 @@ pub async fn milestone_index_to_milestone_access<B: StorageBackend>(storage: &B)
     let mut stream = AsStream::<MilestoneIndex, Milestone>::stream(storage).await.unwrap();
     let mut count = 0;
 
-    while let Some((index, milestone)) = stream.next().await {
+    while let Some(result) = stream.next().await {
+        let (index, milestone) = result.unwrap();
         assert!(milestones.contains(&(index, Some(milestone))));
         count += 1;
     }

--- a/bee-storage/bee-storage-test/src/milestone_index_to_output_diff.rs
+++ b/bee-storage/bee-storage-test/src/milestone_index_to_output_diff.rs
@@ -130,7 +130,8 @@ pub async fn milestone_index_to_output_diff_access<B: StorageBackend>(storage: &
     let mut stream = AsStream::<MilestoneIndex, OutputDiff>::stream(storage).await.unwrap();
     let mut count = 0;
 
-    while let Some((index, output_diff)) = stream.next().await {
+    while let Some(result) = stream.next().await {
+        let (index, output_diff) = result.unwrap();
         assert!(output_diffs.contains(&(index, Some(output_diff))));
         count += 1;
     }

--- a/bee-storage/bee-storage-test/src/milestone_index_to_receipt.rs
+++ b/bee-storage/bee-storage-test/src/milestone_index_to_receipt.rs
@@ -118,7 +118,8 @@ pub async fn milestone_index_to_receipt_access<B: StorageBackend>(storage: &B) {
         .unwrap();
     let mut count = 0;
 
-    while let Some(((index, message_id), _)) = stream.next().await {
+    while let Some(result) = stream.next().await {
+        let ((index, message_id), _) = result.unwrap();
         assert!(receipts.get(&index).unwrap().contains(&message_id));
         count += 1;
     }

--- a/bee-storage/bee-storage-test/src/milestone_index_to_unreferenced_message.rs
+++ b/bee-storage/bee-storage-test/src/milestone_index_to_unreferenced_message.rs
@@ -131,7 +131,8 @@ pub async fn milestone_index_to_unreferenced_message_access<B: StorageBackend>(s
         .unwrap();
     let mut count = 0;
 
-    while let Some(((index, message_id), _)) = stream.next().await {
+    while let Some(result) = stream.next().await {
+        let ((index, message_id), _) = result.unwrap();
         assert!(unreferenced_messages.get(&index).unwrap().contains(&message_id));
         count += 1;
     }

--- a/bee-storage/bee-storage-test/src/output_id_to_consumed_output.rs
+++ b/bee-storage/bee-storage-test/src/output_id_to_consumed_output.rs
@@ -128,7 +128,8 @@ pub async fn output_id_to_consumed_output_access<B: StorageBackend>(storage: &B)
     let mut stream = AsStream::<OutputId, ConsumedOutput>::stream(storage).await.unwrap();
     let mut count = 0;
 
-    while let Some((output_id, consumed_output)) = stream.next().await {
+    while let Some(result) = stream.next().await {
+        let (output_id, consumed_output) = result.unwrap();
         assert!(consumed_outputs.contains(&(output_id, Some(consumed_output))));
         count += 1;
     }

--- a/bee-storage/bee-storage-test/src/output_id_to_created_output.rs
+++ b/bee-storage/bee-storage-test/src/output_id_to_created_output.rs
@@ -128,7 +128,8 @@ pub async fn output_id_to_created_output_access<B: StorageBackend>(storage: &B) 
     let mut stream = AsStream::<OutputId, CreatedOutput>::stream(storage).await.unwrap();
     let mut count = 0;
 
-    while let Some((output_id, created_output)) = stream.next().await {
+    while let Some(result) = stream.next().await {
+        let (output_id, created_output) = result.unwrap();
         assert!(created_outputs.contains(&(output_id, Some(created_output))));
         count += 1;
     }

--- a/bee-storage/bee-storage-test/src/output_id_unspent.rs
+++ b/bee-storage/bee-storage-test/src/output_id_unspent.rs
@@ -68,7 +68,8 @@ pub async fn output_id_unspent_access<B: StorageBackend>(storage: &B) {
     let mut stream = AsStream::<Unspent, ()>::stream(storage).await.unwrap();
     let mut count = 0;
 
-    while let Some((unspent, ())) = stream.next().await {
+    while let Some(result) = stream.next().await {
+        let (unspent, ()) = result.unwrap();
         assert!(unspents.contains(&unspent));
         count += 1;
     }

--- a/bee-storage/bee-storage-test/src/snapshot_info.rs
+++ b/bee-storage/bee-storage-test/src/snapshot_info.rs
@@ -85,7 +85,8 @@ pub async fn snapshot_info_access<B: StorageBackend>(storage: &B) {
     let mut stream = AsStream::<(), SnapshotInfo>::stream(storage).await.unwrap();
     let mut count = 0;
 
-    while let Some((_, info)) = stream.next().await {
+    while let Some(result) = stream.next().await {
+        let (_, info) = result.unwrap();
         assert_eq!(snapshot_info, info);
         count += 1;
     }

--- a/bee-storage/bee-storage-test/src/solid_entry_point_to_milestone_index.rs
+++ b/bee-storage/bee-storage-test/src/solid_entry_point_to_milestone_index.rs
@@ -130,7 +130,8 @@ pub async fn solid_entry_point_to_milestone_index_access<B: StorageBackend>(stor
         .unwrap();
     let mut count = 0;
 
-    while let Some((sep, index)) = stream.next().await {
+    while let Some(result) = stream.next().await {
+        let (sep, index) = result.unwrap();
         assert!(seps.contains(&(sep, Some(index))));
         count += 1;
     }

--- a/bee-storage/bee-storage-test/src/spent_to_treasury_output.rs
+++ b/bee-storage/bee-storage-test/src/spent_to_treasury_output.rs
@@ -121,7 +121,8 @@ pub async fn spent_to_treasury_output_access<B: StorageBackend>(storage: &B) {
     let mut stream = AsStream::<(bool, TreasuryOutput), ()>::stream(storage).await.unwrap();
     let mut count = 0;
 
-    while let Some(((spent, treasury_output), _)) = stream.next().await {
+    while let Some(result) = stream.next().await {
+        let ((spent, treasury_output), _) = result.unwrap();
         assert!(treasury_outputs.get(&spent).unwrap().contains(&treasury_output));
         count += 1;
     }

--- a/bee-storage/bee-storage/CHANGELOG.md
+++ b/bee-storage/bee-storage/CHANGELOG.md
@@ -19,6 +19,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Security -->
 
+## 0.5.0 - 2021-05-27
+
+### Changed
+
+- `AsStream::Stream`
+  - from  `Stream<Item = (K, V)> + Send + Sync + Unpin;`
+  - to    `Stream<Item = Result<(K, V), Self::Error>> + Send + Sync + Unpin;`
+
 ## 0.4.0 - 2021-05-25
 
 ### Added

--- a/bee-storage/bee-storage/Cargo.toml
+++ b/bee-storage/bee-storage/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bee-storage"
-version = "0.4.0"
+version = "0.5.0"
 authors = ["IOTA Stiftung"]
 edition = "2018"
 description = "A general purpose storage backend crate with key value abstraction API"

--- a/bee-storage/bee-storage/src/access/stream.rs
+++ b/bee-storage/bee-storage/src/access/stream.rs
@@ -10,7 +10,7 @@ use futures::stream::Stream;
 #[async_trait::async_trait]
 pub trait AsStream<'a, K, V>: StorageBackend {
     /// Type to iterate through the <K, V> collection.
-    type Stream: Stream<Item = (K, V)> + Send + Sync + Unpin;
+    type Stream: Stream<Item = Result<(K, V), Self::Error>> + Send + Sync + Unpin;
 
     /// Returns a `Stream` object for the provided <K, V> collection.
     async fn stream(&'a self) -> Result<Self::Stream, Self::Error>;

--- a/bee-tangle/Cargo.toml
+++ b/bee-tangle/Cargo.toml
@@ -14,7 +14,7 @@ homepage = "https://www.iota.org"
 bee-common = { version = "0.4.1", path = "../bee-common/bee-common" }
 bee-message = { version = "0.1.3", path = "../bee-message", features = [ "serde" ] }
 bee-runtime = { version = "0.1.1-alpha", path = "../bee-runtime" }
-bee-storage = { version = "0.4.0", path = "../bee-storage/bee-storage" }
+bee-storage = { version = "0.5.0", path = "../bee-storage/bee-storage" }
 
 async-trait = "0.1"
 bitflags = "1.2"


### PR DESCRIPTION
# Description of change

This changes the `AsStream` trait inside `bee-storage` to handle errors while iterating the stream. It also updates the `bee-storage-rocksdb` crate so it compiles with the new trait.

## Type of change

- Bug fix (a non-breaking change which fixes an issue)

## How the change has been tested

Describe the tests that you ran to verify your changes.

Make sure to provide instructions for the maintainer as well as any relevant configurations.

## Change checklist

Tick the boxes that are relevant to your changes, and delete any items that are not.

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that new and existing unit tests pass locally with my changes
- [ ] I have updated the CHANGELOG.md, if my changes are significant enough
