### PR TITLE
Add sled support for `bee-node`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -203,7 +203,7 @@ checksum = "6c7f7096bc256f5e5cb960f60dfc4f4ef979ca65abe7fb9d5a4f77150d3783d4"
 [[package]]
 name = "bee-common"
 version = "0.4.1"
-source = "git+https://github.com/iotaledger/bee.git?branch=dev#3ad357134aa6c798760d99aed3ef42517877e17e"
+source = "git+https://github.com/iotaledger/bee.git?branch=dev#12e4962ee579deebd4f93354d9eda7ab4c0fd945"
 dependencies = [
  "autocfg",
  "chrono",
@@ -219,7 +219,7 @@ dependencies = [
 [[package]]
 name = "bee-crypto"
 version = "0.2.1-alpha"
-source = "git+https://github.com/iotaledger/bee.git?branch=dev#3ad357134aa6c798760d99aed3ef42517877e17e"
+source = "git+https://github.com/iotaledger/bee.git?branch=dev#12e4962ee579deebd4f93354d9eda7ab4c0fd945"
 dependencies = [
  "bee-ternary",
  "byteorder",
@@ -231,7 +231,7 @@ dependencies = [
 [[package]]
 name = "bee-ledger"
 version = "0.4.0"
-source = "git+https://github.com/iotaledger/bee.git?branch=dev#3ad357134aa6c798760d99aed3ef42517877e17e"
+source = "git+https://github.com/iotaledger/bee.git?branch=dev#12e4962ee579deebd4f93354d9eda7ab4c0fd945"
 dependencies = [
  "async-trait",
  "bee-common",
@@ -256,7 +256,7 @@ dependencies = [
 [[package]]
 name = "bee-message"
 version = "0.1.5"
-source = "git+https://github.com/iotaledger/bee.git?branch=dev#3ad357134aa6c798760d99aed3ef42517877e17e"
+source = "git+https://github.com/iotaledger/bee.git?branch=dev#12e4962ee579deebd4f93354d9eda7ab4c0fd945"
 dependencies = [
  "bech32",
  "bee-common",
@@ -273,7 +273,7 @@ dependencies = [
 [[package]]
 name = "bee-network"
 version = "0.2.1"
-source = "git+https://github.com/iotaledger/bee.git?branch=dev#3ad357134aa6c798760d99aed3ef42517877e17e"
+source = "git+https://github.com/iotaledger/bee.git?branch=dev#12e4962ee579deebd4f93354d9eda7ab4c0fd945"
 dependencies = [
  "async-trait",
  "bee-runtime",
@@ -306,6 +306,7 @@ dependencies = [
  "bee-runtime",
  "bee-storage",
  "bee-storage-rocksdb",
+ "bee-storage-sled",
  "bee-tangle",
  "cap",
  "chrono",
@@ -338,7 +339,7 @@ dependencies = [
 [[package]]
 name = "bee-pow"
 version = "0.1.0"
-source = "git+https://github.com/iotaledger/bee.git?branch=dev#3ad357134aa6c798760d99aed3ef42517877e17e"
+source = "git+https://github.com/iotaledger/bee.git?branch=dev#12e4962ee579deebd4f93354d9eda7ab4c0fd945"
 dependencies = [
  "bee-crypto",
  "bee-ternary",
@@ -412,7 +413,7 @@ dependencies = [
 [[package]]
 name = "bee-runtime"
 version = "0.1.1-alpha"
-source = "git+https://github.com/iotaledger/bee.git?branch=dev#3ad357134aa6c798760d99aed3ef42517877e17e"
+source = "git+https://github.com/iotaledger/bee.git?branch=dev#12e4962ee579deebd4f93354d9eda7ab4c0fd945"
 dependencies = [
  "async-trait",
  "bee-storage",
@@ -424,7 +425,7 @@ dependencies = [
 [[package]]
 name = "bee-storage"
 version = "0.5.0"
-source = "git+https://github.com/iotaledger/bee.git?branch=dev#3ad357134aa6c798760d99aed3ef42517877e17e"
+source = "git+https://github.com/iotaledger/bee.git?branch=dev#12e4962ee579deebd4f93354d9eda7ab4c0fd945"
 dependencies = [
  "async-trait",
  "bee-common",
@@ -436,7 +437,7 @@ dependencies = [
 [[package]]
 name = "bee-storage-rocksdb"
 version = "0.2.0"
-source = "git+https://github.com/iotaledger/bee.git?branch=dev#3ad357134aa6c798760d99aed3ef42517877e17e"
+source = "git+https://github.com/iotaledger/bee.git?branch=dev#12e4962ee579deebd4f93354d9eda7ab4c0fd945"
 dependencies = [
  "async-trait",
  "bee-common",
@@ -453,9 +454,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "bee-storage-sled"
+version = "0.1.0"
+source = "git+https://github.com/iotaledger/bee.git?branch=dev#12e4962ee579deebd4f93354d9eda7ab4c0fd945"
+dependencies = [
+ "async-trait",
+ "bee-common",
+ "bee-ledger",
+ "bee-message",
+ "bee-storage",
+ "bee-tangle",
+ "futures",
+ "num_cpus",
+ "pin-project 1.0.7",
+ "serde",
+ "sled",
+ "thiserror",
+]
+
+[[package]]
 name = "bee-tangle"
 version = "0.1.2"
-source = "git+https://github.com/iotaledger/bee.git?branch=dev#3ad357134aa6c798760d99aed3ef42517877e17e"
+source = "git+https://github.com/iotaledger/bee.git?branch=dev#12e4962ee579deebd4f93354d9eda7ab4c0fd945"
 dependencies = [
  "async-trait",
  "bee-common",
@@ -479,7 +499,7 @@ dependencies = [
 [[package]]
 name = "bee-ternary"
 version = "0.4.2-alpha"
-source = "git+https://github.com/iotaledger/bee.git?branch=dev#3ad357134aa6c798760d99aed3ef42517877e17e"
+source = "git+https://github.com/iotaledger/bee.git?branch=dev#12e4962ee579deebd4f93354d9eda7ab4c0fd945"
 dependencies = [
  "autocfg",
  "num-traits",
@@ -808,6 +828,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "crc32fast"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "81156fece84ab6a9f2afdb109ce3ae577e42b1228441eded99bd77f627953b1a"
+dependencies = [
+ "cfg-if 1.0.0",
+]
+
+[[package]]
+name = "crossbeam-epoch"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ec02e091aa634e2c3ada4a392989e7c3116673ef0ac5b72232439094d73b7fd"
+dependencies = [
+ "cfg-if 1.0.0",
+ "crossbeam-utils",
+ "lazy_static",
+ "memoffset",
+ "scopeguard",
+]
+
+[[package]]
 name = "crossbeam-utils"
 version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1040,6 +1082,16 @@ checksum = "5fc25a87fa4fd2094bffb06925852034d90a17f0d1e05197d4956d3555752191"
 dependencies = [
  "matches",
  "percent-encoding",
+]
+
+[[package]]
+name = "fs2"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9564fc758e15025b46aa6643b1b77d047d1a56a1aea6e01002ac0c7026876213"
+dependencies = [
+ "libc",
+ "winapi",
 ]
 
 [[package]]
@@ -1844,6 +1896,15 @@ name = "memchr"
 version = "2.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b16bd47d9e329435e309c58469fe0791c2d0d1ba96ec0954152a5ae2b04387dc"
+
+[[package]]
+name = "memoffset"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59accc507f1338036a0477ef61afdae33cde60840f4dfe481319ce3ad116ddf9"
+dependencies = [
+ "autocfg",
+]
 
 [[package]]
 name = "mime"
@@ -2934,6 +2995,23 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f173ac3d1a7e3b28003f40de0b5ce7fe2710f9b9dc3fc38664cebee46b3b6527"
 
 [[package]]
+name = "sled"
+version = "0.34.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d0132f3e393bcb7390c60bb45769498cf4550bcb7a21d7f95c02b69f6362cdc"
+dependencies = [
+ "crc32fast",
+ "crossbeam-epoch",
+ "crossbeam-utils",
+ "fs2",
+ "fxhash",
+ "libc",
+ "log",
+ "parking_lot",
+ "zstd",
+]
+
+[[package]]
 name = "smallvec"
 version = "1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3884,4 +3962,35 @@ dependencies = [
  "quote",
  "syn",
  "synstructure",
+]
+
+[[package]]
+name = "zstd"
+version = "0.5.4+zstd.1.4.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69996ebdb1ba8b1517f61387a883857818a66c8a295f487b1ffd8fd9d2c82910"
+dependencies = [
+ "zstd-safe",
+]
+
+[[package]]
+name = "zstd-safe"
+version = "2.0.6+zstd.1.4.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "98aa931fb69ecee256d44589d19754e61851ae4769bf963b385119b1cc37a49e"
+dependencies = [
+ "libc",
+ "zstd-sys",
+]
+
+[[package]]
+name = "zstd-sys"
+version = "1.4.18+zstd.1.4.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1e6e8778706838f43f771d80d37787cb2fe06dafe89dd3aebaf6721b9eaec81"
+dependencies = [
+ "cc",
+ "glob",
+ "itertools",
+ "libc",
 ]

--- a/bee-node/Cargo.toml
+++ b/bee-node/Cargo.toml
@@ -1,13 +1,13 @@
 [package]
 name = "bee-node"
 version = "0.1.2"
-authors = ["IOTA Stiftung"]
+authors = [ "IOTA Stiftung" ]
 edition = "2018"
 description = ""
 readme = "README.md"
 repository = "https://github.com/iotaledger/bee"
 license = "Apache-2.0"
-keywords = ["iota", "tangle", "bee", "framework", "node"]
+keywords = [ "iota", "tangle", "bee", "framework", "node" ]
 homepage = "https://www.iota.org"
 
 [dependencies]
@@ -49,7 +49,7 @@ tokio-stream = "0.1"
 toml = "0.5"
 tracing = { version = "0.1.26", optional = true }
 tracing-futures = { version = "0.2.5", optional = true }
-tracing-subscriber = { version = "0.2.18", features = ["fmt", "registry", "env-filter"], optional = true }
+tracing-subscriber = { version = "0.2.18", features = [ "fmt", "registry", "env-filter" ], optional = true }
 warp = "0.3"
 warp-reverse-proxy = { version = "0.3", optional = true }
 
@@ -62,9 +62,9 @@ name = "bee"
 path = "src/main.rs"
 
 [features]
-default = ["rocksdb"]
+default = [ "rocksdb" ]
 
-console = ["console-subscriber", "tokio/tracing", "tracing", "tracing-futures", "tracing-subscriber"]
+console = [ "console-subscriber", "tokio/tracing", "tracing", "tracing-futures", "tracing-subscriber" ]
 dashboard = [ "cap", "mime_guess", "rust-embed", "serde_repr", "warp-reverse-proxy" ]
-rocksdb = ["bee-storage-rocksdb"]
-sled = ["bee-storage-sled"]
+rocksdb = [ "bee-storage-rocksdb" ]
+sled = [ "bee-storage-sled" ]

--- a/bee-node/Cargo.toml
+++ b/bee-node/Cargo.toml
@@ -20,8 +20,8 @@ bee-protocol = { path = "../bee-protocol" }
 bee-rest-api = { path = "../bee-api/bee-rest-api", features = [ "endpoints" ] }
 bee-runtime = { git = "https://github.com/iotaledger/bee.git", branch = "dev" }
 bee-storage = { git = "https://github.com/iotaledger/bee.git", branch = "dev" }
-bee-storage-rocksdb = { git = "https://github.com/iotaledger/bee.git", branch = "dev" }
-bee-storage-sled = { git = "https://github.com/iotaledger/bee.git", branch = "dev" }
+bee-storage-rocksdb = { git = "https://github.com/iotaledger/bee.git", branch = "dev", optional = true }
+bee-storage-sled = { git = "https://github.com/iotaledger/bee.git", branch = "dev", optional = true }
 bee-tangle = { git = "https://github.com/iotaledger/bee.git", branch = "dev" }
 
 anymap = "0.12"
@@ -62,5 +62,9 @@ name = "bee"
 path = "src/main.rs"
 
 [features]
+default = ["rocksdb"]
+
 console = ["console-subscriber", "tokio/tracing", "tracing", "tracing-futures", "tracing-subscriber"]
 dashboard = [ "cap", "mime_guess", "rust-embed", "serde_repr", "warp-reverse-proxy" ]
+rocksdb = ["bee-storage-rocksdb"]
+sled = ["bee-storage-sled"]

--- a/bee-node/Cargo.toml
+++ b/bee-node/Cargo.toml
@@ -21,6 +21,7 @@ bee-rest-api = { path = "../bee-api/bee-rest-api", features = [ "endpoints" ] }
 bee-runtime = { git = "https://github.com/iotaledger/bee.git", branch = "dev" }
 bee-storage = { git = "https://github.com/iotaledger/bee.git", branch = "dev" }
 bee-storage-rocksdb = { git = "https://github.com/iotaledger/bee.git", branch = "dev" }
+bee-storage-sled = { git = "https://github.com/iotaledger/bee.git", branch = "dev" }
 bee-tangle = { git = "https://github.com/iotaledger/bee.git", branch = "dev" }
 
 anymap = "0.12"

--- a/bee-node/src/main.rs
+++ b/bee-node/src/main.rs
@@ -5,7 +5,7 @@ use bee_node::{plugins, print_banner_and_version, tools, CliArgs, NodeBuilder, N
 use bee_runtime::node::NodeBuilder as _;
 #[cfg(feature = "rocksdb")]
 use bee_storage_rocksdb::storage::Storage as RocksDb;
-#[cfg(feature = "sled")]
+#[cfg(all(feature = "sled", not(feature = "rocksdb")))]
 use bee_storage_sled::storage::Storage as Sled;
 
 use log::error;

--- a/bee-node/src/main.rs
+++ b/bee-node/src/main.rs
@@ -3,7 +3,7 @@
 
 use bee_node::{plugins, print_banner_and_version, tools, CliArgs, NodeBuilder, NodeConfigBuilder};
 use bee_runtime::node::NodeBuilder as _;
-use bee_storage_rocksdb::storage::Storage as Rocksdb;
+use bee_storage_sled::storage::Storage as Sled;
 
 use log::error;
 
@@ -66,7 +66,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
         return Ok(());
     }
 
-    match NodeBuilder::<Rocksdb>::new(config) {
+    match NodeBuilder::<Sled>::new(config) {
         Ok(builder) => match builder.with_plugin::<plugins::Mps>().finish().await {
             Ok(node) => {
                 #[cfg(feature = "console")]

--- a/bee-node/src/tools/mod.rs
+++ b/bee-node/src/tools/mod.rs
@@ -5,6 +5,7 @@ mod ed25519;
 mod p2p_identity;
 mod password;
 mod rocksdb;
+mod sled;
 mod snapshot_info;
 
 use structopt::StructOpt;
@@ -19,6 +20,8 @@ pub enum Tool {
     P2pIdentity(p2p_identity::P2pIdentityTool),
     /// Rocksdb database analyser.
     Rocksdb(rocksdb::RocksdbTool),
+    /// Sled database analyser.
+    Sled(sled::SledTool),
     /// Outputs information about a snapshot file.
     SnapshotInfo(snapshot_info::SnapshotInfoTool),
     /// Generates password salt and hash.
@@ -32,6 +35,8 @@ pub enum ToolError {
     #[error("{0}")]
     Rocksdb(#[from] rocksdb::RocksdbError),
     #[error("{0}")]
+    Sled(#[from] sled::SledError),
+    #[error("{0}")]
     SnapshotInfo(#[from] snapshot_info::SnapshotInfoError),
     #[error("{0}")]
     Password(#[from] password::PasswordError),
@@ -42,6 +47,7 @@ pub fn exec(tool: &Tool) -> Result<(), ToolError> {
         Tool::Ed25519(tool) => ed25519::exec(tool)?,
         Tool::P2pIdentity(tool) => p2p_identity::exec(tool),
         Tool::Rocksdb(tool) => rocksdb::exec(tool)?,
+        Tool::Sled(tool) => sled::exec(tool)?,
         Tool::SnapshotInfo(tool) => snapshot_info::exec(tool)?,
         Tool::Password(tool) => password::exec(tool)?,
     }

--- a/bee-node/src/tools/mod.rs
+++ b/bee-node/src/tools/mod.rs
@@ -4,7 +4,9 @@
 mod ed25519;
 mod p2p_identity;
 mod password;
+#[cfg(feature = "rocksdb")]
 mod rocksdb;
+#[cfg(feature = "sled")]
 mod sled;
 mod snapshot_info;
 
@@ -19,8 +21,10 @@ pub enum Tool {
     /// Generates a p2p identity.
     P2pIdentity(p2p_identity::P2pIdentityTool),
     /// Rocksdb database analyser.
+    #[cfg(feature = "rocksdb")]
     Rocksdb(rocksdb::RocksdbTool),
     /// Sled database analyser.
+    #[cfg(feature = "sled")]
     Sled(sled::SledTool),
     /// Outputs information about a snapshot file.
     SnapshotInfo(snapshot_info::SnapshotInfoTool),
@@ -32,8 +36,10 @@ pub enum Tool {
 pub enum ToolError {
     #[error("{0}")]
     Ed25519(#[from] ed25519::Ed25519Error),
+    #[cfg(feature = "rocksdb")]
     #[error("{0}")]
     Rocksdb(#[from] rocksdb::RocksdbError),
+    #[cfg(feature = "sled")]
     #[error("{0}")]
     Sled(#[from] sled::SledError),
     #[error("{0}")]
@@ -46,7 +52,9 @@ pub fn exec(tool: &Tool) -> Result<(), ToolError> {
     match tool {
         Tool::Ed25519(tool) => ed25519::exec(tool)?,
         Tool::P2pIdentity(tool) => p2p_identity::exec(tool),
+        #[cfg(feature = "rocksdb")]
         Tool::Rocksdb(tool) => rocksdb::exec(tool)?,
+        #[cfg(feature = "sled")]
         Tool::Sled(tool) => sled::exec(tool)?,
         Tool::SnapshotInfo(tool) => snapshot_info::exec(tool)?,
         Tool::Password(tool) => password::exec(tool)?,

--- a/bee-node/src/tools/sled.rs
+++ b/bee-node/src/tools/sled.rs
@@ -35,7 +35,7 @@ use std::str::FromStr;
 pub enum SledCommand {
     /// Fetches a value by its key.
     Fetch { key: String },
-    /// Streams a column family.
+    /// Streams a tree.
     Stream,
 }
 
@@ -45,8 +45,8 @@ pub enum SledError {
     StorageBackend(#[from] BackendError),
     #[error("Invalid key: {0}")]
     InvalidKey(String),
-    #[error("Unknown column family: {0}")]
-    UnknownColumnFamily(String),
+    #[error("Unknown tree: {0}")]
+    UnknownTree(String),
     #[error("Unsupported command")]
     UnsupportedCommand,
 }
@@ -54,13 +54,13 @@ pub enum SledError {
 #[derive(Clone, Debug, StructOpt)]
 pub struct SledTool {
     path: String,
-    column_family: String,
+    tree: String,
     #[structopt(subcommand)]
     command: SledCommand,
 }
 
 async fn exec_inner(tool: &SledTool, storage: &Storage) -> Result<(), SledError> {
-    match &tool.column_family[..] {
+    match &tool.tree[..] {
         TREE_MESSAGE_ID_TO_MESSAGE => match &tool.command {
             SledCommand::Fetch { key } => {
                 let key = MessageId::from_str(key).map_err(|_| SledError::InvalidKey(key.clone()))?;
@@ -330,7 +330,7 @@ async fn exec_inner(tool: &SledTool, storage: &Storage) -> Result<(), SledError>
             }
         },
 
-        _ => return Err(SledError::UnknownColumnFamily(tool.column_family[..].to_owned())),
+        _ => return Err(SledError::UnknownTree(tool.tree[..].to_owned())),
     }
 
     Ok(())

--- a/bee-node/src/tools/sled.rs
+++ b/bee-node/src/tools/sled.rs
@@ -16,11 +16,10 @@ use bee_storage::{
     access::{AsStream, Exist, Fetch},
     backend::StorageBackend,
 };
-use bee_storage_rocksdb::{
-    column_families::*,
-    config::RocksDbConfigBuilder,
-    error::Error as BackendError,
-    storage::{Storage, System},
+use bee_storage_sled::{
+    config::SledConfigBuilder,
+    storage::{Error as BackendError, Storage},
+    trees::*,
 };
 use bee_tangle::{
     metadata::MessageMetadata, solid_entry_point::SolidEntryPoint, unreferenced_message::UnreferencedMessage,
@@ -33,7 +32,7 @@ use thiserror::Error;
 use std::str::FromStr;
 
 #[derive(Clone, Debug, StructOpt)]
-pub enum RocksdbCommand {
+pub enum SledCommand {
     /// Fetches a value by its key.
     Fetch { key: String },
     /// Streams a column family.
@@ -41,7 +40,7 @@ pub enum RocksdbCommand {
 }
 
 #[derive(Debug, Error)]
-pub enum RocksdbError {
+pub enum SledError {
     #[error("Storage backend error: {0}")]
     StorageBackend(#[from] BackendError),
     #[error("Invalid key: {0}")]
@@ -53,39 +52,23 @@ pub enum RocksdbError {
 }
 
 #[derive(Clone, Debug, StructOpt)]
-pub struct RocksdbTool {
+pub struct SledTool {
     path: String,
     column_family: String,
     #[structopt(subcommand)]
-    command: RocksdbCommand,
+    command: SledCommand,
 }
 
-async fn exec_inner(tool: &RocksdbTool, storage: &Storage) -> Result<(), RocksdbError> {
+async fn exec_inner(tool: &SledTool, storage: &Storage) -> Result<(), SledError> {
     match &tool.column_family[..] {
-        CF_SYSTEM => match &tool.command {
-            RocksdbCommand::Fetch { key } => {
-                let key = u8::from_str(key).map_err(|_| RocksdbError::InvalidKey(key.clone()))?;
-                let value = Fetch::<u8, System>::fetch(storage, &key).await?;
-
-                println!("Key: {:?}\nValue: {:?}\n", key, value);
-            }
-            RocksdbCommand::Stream => {
-                let mut stream = AsStream::<u8, System>::stream(storage).await?;
-
-                while let Some(result) = stream.next().await {
-                    let (key, value) = result?;
-                    println!("Key: {:?}\nValue: {:?}\n", key, value);
-                }
-            }
-        },
-        CF_MESSAGE_ID_TO_MESSAGE => match &tool.command {
-            RocksdbCommand::Fetch { key } => {
-                let key = MessageId::from_str(key).map_err(|_| RocksdbError::InvalidKey(key.clone()))?;
+        TREE_MESSAGE_ID_TO_MESSAGE => match &tool.command {
+            SledCommand::Fetch { key } => {
+                let key = MessageId::from_str(key).map_err(|_| SledError::InvalidKey(key.clone()))?;
                 let value = Fetch::<MessageId, Message>::fetch(storage, &key).await?;
 
                 println!("Key: {:?}\nValue: {:?}\n", key, value);
             }
-            RocksdbCommand::Stream => {
+            SledCommand::Stream => {
                 let mut stream = AsStream::<MessageId, Message>::stream(storage).await?;
 
                 while let Some(result) = stream.next().await {
@@ -94,14 +77,14 @@ async fn exec_inner(tool: &RocksdbTool, storage: &Storage) -> Result<(), Rocksdb
                 }
             }
         },
-        CF_MESSAGE_ID_TO_METADATA => match &tool.command {
-            RocksdbCommand::Fetch { key } => {
-                let key = MessageId::from_str(key).map_err(|_| RocksdbError::InvalidKey(key.clone()))?;
+        TREE_MESSAGE_ID_TO_METADATA => match &tool.command {
+            SledCommand::Fetch { key } => {
+                let key = MessageId::from_str(key).map_err(|_| SledError::InvalidKey(key.clone()))?;
                 let value = Fetch::<MessageId, MessageMetadata>::fetch(storage, &key).await?;
 
                 println!("Key: {:?}\nValue: {:?}\n", key, value);
             }
-            RocksdbCommand::Stream => {
+            SledCommand::Stream => {
                 let mut stream = AsStream::<MessageId, MessageMetadata>::stream(storage).await?;
 
                 while let Some(result) = stream.next().await {
@@ -110,14 +93,14 @@ async fn exec_inner(tool: &RocksdbTool, storage: &Storage) -> Result<(), Rocksdb
                 }
             }
         },
-        CF_MESSAGE_ID_TO_MESSAGE_ID => match &tool.command {
-            RocksdbCommand::Fetch { key } => {
-                let key = MessageId::from_str(key).map_err(|_| RocksdbError::InvalidKey(key.clone()))?;
+        TREE_MESSAGE_ID_TO_MESSAGE_ID => match &tool.command {
+            SledCommand::Fetch { key } => {
+                let key = MessageId::from_str(key).map_err(|_| SledError::InvalidKey(key.clone()))?;
                 let value = Fetch::<MessageId, Vec<MessageId>>::fetch(storage, &key).await?;
 
                 println!("Key: {:?}\nValue: {:?}\n", key, value);
             }
-            RocksdbCommand::Stream => {
+            SledCommand::Stream => {
                 let mut stream = AsStream::<(MessageId, MessageId), ()>::stream(storage).await?;
 
                 while let Some(result) = stream.next().await {
@@ -126,19 +109,19 @@ async fn exec_inner(tool: &RocksdbTool, storage: &Storage) -> Result<(), Rocksdb
                 }
             }
         },
-        CF_INDEX_TO_MESSAGE_ID => match &tool.command {
-            RocksdbCommand::Fetch { key } => {
+        TREE_INDEX_TO_MESSAGE_ID => match &tool.command {
+            SledCommand::Fetch { key } => {
                 let key = IndexationPayload::new(
-                    &hex::decode(key.clone()).map_err(|_| RocksdbError::InvalidKey(key.clone()))?,
+                    &hex::decode(key.clone()).map_err(|_| SledError::InvalidKey(key.clone()))?,
                     &[],
                 )
-                .map_err(|_| RocksdbError::InvalidKey(key.clone()))?
+                .map_err(|_| SledError::InvalidKey(key.clone()))?
                 .padded_index();
                 let value = Fetch::<PaddedIndex, Vec<MessageId>>::fetch(storage, &key).await?;
 
                 println!("Key: {:?}\nValue: {:?}\n", key, value);
             }
-            RocksdbCommand::Stream => {
+            SledCommand::Stream => {
                 let mut stream = AsStream::<(PaddedIndex, MessageId), ()>::stream(storage).await?;
 
                 while let Some(result) = stream.next().await {
@@ -147,14 +130,14 @@ async fn exec_inner(tool: &RocksdbTool, storage: &Storage) -> Result<(), Rocksdb
                 }
             }
         },
-        CF_OUTPUT_ID_TO_CREATED_OUTPUT => match &tool.command {
-            RocksdbCommand::Fetch { key } => {
-                let key = OutputId::from_str(key).map_err(|_| RocksdbError::InvalidKey(key.clone()))?;
+        TREE_OUTPUT_ID_TO_CREATED_OUTPUT => match &tool.command {
+            SledCommand::Fetch { key } => {
+                let key = OutputId::from_str(key).map_err(|_| SledError::InvalidKey(key.clone()))?;
                 let value = Fetch::<OutputId, CreatedOutput>::fetch(storage, &key).await?;
 
                 println!("Key: {:?}\nValue: {:?}\n", key, value);
             }
-            RocksdbCommand::Stream => {
+            SledCommand::Stream => {
                 let mut stream = AsStream::<OutputId, CreatedOutput>::stream(storage).await?;
 
                 while let Some(result) = stream.next().await {
@@ -163,14 +146,14 @@ async fn exec_inner(tool: &RocksdbTool, storage: &Storage) -> Result<(), Rocksdb
                 }
             }
         },
-        CF_OUTPUT_ID_TO_CONSUMED_OUTPUT => match &tool.command {
-            RocksdbCommand::Fetch { key } => {
-                let key = OutputId::from_str(key).map_err(|_| RocksdbError::InvalidKey(key.clone()))?;
+        TREE_OUTPUT_ID_TO_CONSUMED_OUTPUT => match &tool.command {
+            SledCommand::Fetch { key } => {
+                let key = OutputId::from_str(key).map_err(|_| SledError::InvalidKey(key.clone()))?;
                 let value = Fetch::<OutputId, ConsumedOutput>::fetch(storage, &key).await?;
 
                 println!("Key: {:?}\nValue: {:?}\n", key, value);
             }
-            RocksdbCommand::Stream => {
+            SledCommand::Stream => {
                 let mut stream = AsStream::<OutputId, ConsumedOutput>::stream(storage).await?;
 
                 while let Some(result) = stream.next().await {
@@ -179,14 +162,14 @@ async fn exec_inner(tool: &RocksdbTool, storage: &Storage) -> Result<(), Rocksdb
                 }
             }
         },
-        CF_OUTPUT_ID_UNSPENT => match &tool.command {
-            RocksdbCommand::Fetch { key } => {
-                let key = Unspent::from(OutputId::from_str(key).map_err(|_| RocksdbError::InvalidKey(key.clone()))?);
+        TREE_OUTPUT_ID_UNSPENT => match &tool.command {
+            SledCommand::Fetch { key } => {
+                let key = Unspent::from(OutputId::from_str(key).map_err(|_| SledError::InvalidKey(key.clone()))?);
                 let value = Exist::<Unspent, ()>::exist(storage, &key).await?;
 
                 println!("Key: {:?}\nValue: {:?}\n", key, value);
             }
-            RocksdbCommand::Stream => {
+            SledCommand::Stream => {
                 let mut stream = AsStream::<Unspent, ()>::stream(storage).await?;
 
                 while let Some(result) = stream.next().await {
@@ -195,14 +178,14 @@ async fn exec_inner(tool: &RocksdbTool, storage: &Storage) -> Result<(), Rocksdb
                 }
             }
         },
-        CF_ED25519_ADDRESS_TO_OUTPUT_ID => match &tool.command {
-            RocksdbCommand::Fetch { key } => {
-                let key = Ed25519Address::from_str(key).map_err(|_| RocksdbError::InvalidKey(key.clone()))?;
+        TREE_ED25519_ADDRESS_TO_OUTPUT_ID => match &tool.command {
+            SledCommand::Fetch { key } => {
+                let key = Ed25519Address::from_str(key).map_err(|_| SledError::InvalidKey(key.clone()))?;
                 let value = Fetch::<Ed25519Address, Vec<OutputId>>::fetch(storage, &key).await?;
 
                 println!("Key: {:?}\nValue: {:?}\n", key, value);
             }
-            RocksdbCommand::Stream => {
+            SledCommand::Stream => {
                 let mut stream = AsStream::<(Ed25519Address, OutputId), ()>::stream(storage).await?;
 
                 while let Some(result) = stream.next().await {
@@ -211,9 +194,9 @@ async fn exec_inner(tool: &RocksdbTool, storage: &Storage) -> Result<(), Rocksdb
                 }
             }
         },
-        CF_LEDGER_INDEX => match &tool.command {
-            RocksdbCommand::Fetch { key: _key } => return Err(RocksdbError::UnsupportedCommand),
-            RocksdbCommand::Stream => {
+        TREE_LEDGER_INDEX => match &tool.command {
+            SledCommand::Fetch { key: _key } => return Err(SledError::UnsupportedCommand),
+            SledCommand::Stream => {
                 let mut stream = AsStream::<(), LedgerIndex>::stream(storage).await?;
 
                 while let Some(result) = stream.next().await {
@@ -222,14 +205,14 @@ async fn exec_inner(tool: &RocksdbTool, storage: &Storage) -> Result<(), Rocksdb
                 }
             }
         },
-        CF_MILESTONE_INDEX_TO_MILESTONE => match &tool.command {
-            RocksdbCommand::Fetch { key } => {
-                let key = MilestoneIndex(u32::from_str(key).map_err(|_| RocksdbError::InvalidKey(key.clone()))?);
+        TREE_MILESTONE_INDEX_TO_MILESTONE => match &tool.command {
+            SledCommand::Fetch { key } => {
+                let key = MilestoneIndex(u32::from_str(key).map_err(|_| SledError::InvalidKey(key.clone()))?);
                 let value = Fetch::<MilestoneIndex, Milestone>::fetch(storage, &key).await?;
 
                 println!("Key: {:?}\nValue: {:?}\n", key, value);
             }
-            RocksdbCommand::Stream => {
+            SledCommand::Stream => {
                 let mut stream = AsStream::<MilestoneIndex, Milestone>::stream(storage).await?;
 
                 while let Some(result) = stream.next().await {
@@ -238,9 +221,9 @@ async fn exec_inner(tool: &RocksdbTool, storage: &Storage) -> Result<(), Rocksdb
                 }
             }
         },
-        CF_SNAPSHOT_INFO => match &tool.command {
-            RocksdbCommand::Fetch { key: _key } => return Err(RocksdbError::UnsupportedCommand),
-            RocksdbCommand::Stream => {
+        TREE_SNAPSHOT_INFO => match &tool.command {
+            SledCommand::Fetch { key: _key } => return Err(SledError::UnsupportedCommand),
+            SledCommand::Stream => {
                 let mut stream = AsStream::<(), SnapshotInfo>::stream(storage).await?;
 
                 while let Some(result) = stream.next().await {
@@ -249,15 +232,15 @@ async fn exec_inner(tool: &RocksdbTool, storage: &Storage) -> Result<(), Rocksdb
                 }
             }
         },
-        CF_SOLID_ENTRY_POINT_TO_MILESTONE_INDEX => match &tool.command {
-            RocksdbCommand::Fetch { key } => {
+        TREE_SOLID_ENTRY_POINT_TO_MILESTONE_INDEX => match &tool.command {
+            SledCommand::Fetch { key } => {
                 let key =
-                    SolidEntryPoint::from(MessageId::from_str(key).map_err(|_| RocksdbError::InvalidKey(key.clone()))?);
+                    SolidEntryPoint::from(MessageId::from_str(key).map_err(|_| SledError::InvalidKey(key.clone()))?);
                 let value = Fetch::<SolidEntryPoint, MilestoneIndex>::fetch(storage, &key).await?;
 
                 println!("Key: {:?}\nValue: {:?}\n", key, value);
             }
-            RocksdbCommand::Stream => {
+            SledCommand::Stream => {
                 let mut stream = AsStream::<SolidEntryPoint, MilestoneIndex>::stream(storage).await?;
 
                 while let Some(result) = stream.next().await {
@@ -266,14 +249,14 @@ async fn exec_inner(tool: &RocksdbTool, storage: &Storage) -> Result<(), Rocksdb
                 }
             }
         },
-        CF_MILESTONE_INDEX_TO_OUTPUT_DIFF => match &tool.command {
-            RocksdbCommand::Fetch { key } => {
-                let key = MilestoneIndex(u32::from_str(key).map_err(|_| RocksdbError::InvalidKey(key.clone()))?);
+        TREE_MILESTONE_INDEX_TO_OUTPUT_DIFF => match &tool.command {
+            SledCommand::Fetch { key } => {
+                let key = MilestoneIndex(u32::from_str(key).map_err(|_| SledError::InvalidKey(key.clone()))?);
                 let value = Fetch::<MilestoneIndex, OutputDiff>::fetch(storage, &key).await?;
 
                 println!("Key: {:?}\nValue: {:?}\n", key, value);
             }
-            RocksdbCommand::Stream => {
+            SledCommand::Stream => {
                 let mut stream = AsStream::<MilestoneIndex, OutputDiff>::stream(storage).await?;
 
                 while let Some(result) = stream.next().await {
@@ -282,15 +265,14 @@ async fn exec_inner(tool: &RocksdbTool, storage: &Storage) -> Result<(), Rocksdb
                 }
             }
         },
-        CF_ADDRESS_TO_BALANCE => match &tool.command {
-            RocksdbCommand::Fetch { key } => {
-                let key =
-                    Address::from(Ed25519Address::from_str(key).map_err(|_| RocksdbError::InvalidKey(key.clone()))?);
+        TREE_ADDRESS_TO_BALANCE => match &tool.command {
+            SledCommand::Fetch { key } => {
+                let key = Address::from(Ed25519Address::from_str(key).map_err(|_| SledError::InvalidKey(key.clone()))?);
                 let value = Fetch::<Address, Balance>::fetch(storage, &key).await?;
 
                 println!("Key: {:?}\nValue: {:?}\n", key, value);
             }
-            RocksdbCommand::Stream => {
+            SledCommand::Stream => {
                 let mut stream = AsStream::<Address, Balance>::stream(storage).await?;
 
                 while let Some(result) = stream.next().await {
@@ -299,14 +281,14 @@ async fn exec_inner(tool: &RocksdbTool, storage: &Storage) -> Result<(), Rocksdb
                 }
             }
         },
-        CF_MILESTONE_INDEX_TO_UNREFERENCED_MESSAGE => match &tool.command {
-            RocksdbCommand::Fetch { key } => {
-                let key = MilestoneIndex(u32::from_str(key).map_err(|_| RocksdbError::InvalidKey(key.clone()))?);
+        TREE_MILESTONE_INDEX_TO_UNREFERENCED_MESSAGE => match &tool.command {
+            SledCommand::Fetch { key } => {
+                let key = MilestoneIndex(u32::from_str(key).map_err(|_| SledError::InvalidKey(key.clone()))?);
                 let value = Fetch::<MilestoneIndex, Vec<UnreferencedMessage>>::fetch(storage, &key).await?;
 
                 println!("Key: {:?}\nValue: {:?}\n", key, value);
             }
-            RocksdbCommand::Stream => {
+            SledCommand::Stream => {
                 let mut stream = AsStream::<(MilestoneIndex, UnreferencedMessage), ()>::stream(storage).await?;
 
                 while let Some(result) = stream.next().await {
@@ -315,14 +297,14 @@ async fn exec_inner(tool: &RocksdbTool, storage: &Storage) -> Result<(), Rocksdb
                 }
             }
         },
-        CF_MILESTONE_INDEX_TO_RECEIPT => match &tool.command {
-            RocksdbCommand::Fetch { key } => {
-                let key = MilestoneIndex(u32::from_str(key).map_err(|_| RocksdbError::InvalidKey(key.clone()))?);
+        TREE_MILESTONE_INDEX_TO_RECEIPT => match &tool.command {
+            SledCommand::Fetch { key } => {
+                let key = MilestoneIndex(u32::from_str(key).map_err(|_| SledError::InvalidKey(key.clone()))?);
                 let value = Fetch::<MilestoneIndex, Vec<Receipt>>::fetch(storage, &key).await?;
 
                 println!("Key: {:?}\nValue: {:?}\n", key, value);
             }
-            RocksdbCommand::Stream => {
+            SledCommand::Stream => {
                 let mut stream = AsStream::<(MilestoneIndex, Receipt), ()>::stream(storage).await?;
 
                 while let Some(result) = stream.next().await {
@@ -331,14 +313,14 @@ async fn exec_inner(tool: &RocksdbTool, storage: &Storage) -> Result<(), Rocksdb
                 }
             }
         },
-        CF_SPENT_TO_TREASURY_OUTPUT => match &tool.command {
-            RocksdbCommand::Fetch { key } => {
-                let key = bool::from_str(key).map_err(|_| RocksdbError::InvalidKey(key.clone()))?;
+        TREE_SPENT_TO_TREASURY_OUTPUT => match &tool.command {
+            SledCommand::Fetch { key } => {
+                let key = bool::from_str(key).map_err(|_| SledError::InvalidKey(key.clone()))?;
                 let value = Fetch::<bool, Vec<TreasuryOutput>>::fetch(storage, &key).await?;
 
                 println!("Key: {:?}\nValue: {:?}\n", key, value);
             }
-            RocksdbCommand::Stream => {
+            SledCommand::Stream => {
                 let mut stream = AsStream::<(bool, TreasuryOutput), ()>::stream(storage).await?;
 
                 while let Some(result) = stream.next().await {
@@ -348,15 +330,15 @@ async fn exec_inner(tool: &RocksdbTool, storage: &Storage) -> Result<(), Rocksdb
             }
         },
 
-        _ => return Err(RocksdbError::UnknownColumnFamily(tool.column_family[..].to_owned())),
+        _ => return Err(SledError::UnknownColumnFamily(tool.column_family[..].to_owned())),
     }
 
     Ok(())
 }
 
-pub fn exec(tool: &RocksdbTool) -> Result<(), RocksdbError> {
+pub fn exec(tool: &SledTool) -> Result<(), SledError> {
     executor::block_on(async {
-        let storage = Storage::start(RocksDbConfigBuilder::default().with_path(tool.path.clone()).finish()).await?;
+        let storage = Storage::start(SledConfigBuilder::default().finish()).await?;
         let res = exec_inner(tool, &storage).await;
 
         storage.shutdown().await?;


### PR DESCRIPTION
This PR adds two features, `rocksdb` and `sled`, which behave as following:
- if `rocksdb` is enabled. `bee-node` will use `bee-storage-rocksdb` as the storage backend.
- if `sled` is enabled. `bee-node` will use `bee-storage-sled` as the storage backend.
- if both `rocksdb` and `sled` are enabled, `bee-node` will use `bee-storage-rocksdb` as the storage backend but it will compile `bee-storage-sled` as a dependency anyway.
- `rocksdb` is a default feature, which means that: 
  - `cargo build` will enable `rocksdb` by default.
  - `cargo build --features="sled"` will enable both `rocksdb` and `sled`.
  - `cargo build --no-default-features --features="sled"` will enable `sled`.
  
This arrangement guarantees that compiling `bee` with all features enabled still works without issue.

Blocked on #601.