### PR TITLE
Packable wrappers

### DIFF
--- a/bee-common/bee-packable-derive/src/lib.rs
+++ b/bee-common/bee-packable-derive/src/lib.rs
@@ -18,20 +18,38 @@ pub fn packable(input: TokenStream) -> TokenStream {
         generics,
         ..
     } = parse_macro_input!(input);
-    // Parse an `error` attribute if the input has one.
-    let error_type = match packable::parse_attr::<Type>("error", &attrs) {
+    // Parse a `pack_error` attribute if the input has one.
+    let pack_error_type = match packable::parse_attr::<Type>("pack_error", &attrs) {
         Some(Ok(ty)) => Some(ty.into_token_stream()),
-        Some(Err(span)) => abort!(span, "The `error` attribute requires a type for its value."),
+        Some(Err(span)) => abort!(span, "The `pack_error` attribute requires a type for its value."),
+        None => None,
+    };
+
+    // Parse an `unpack_error` attribute if the input has one.
+    let unpack_error_type = match packable::parse_attr::<Type>("unpack_error", &attrs) {
+        Some(Ok(ty)) => Some(ty.into_token_stream()),
+        Some(Err(span)) => abort!(span, "The `unpack_error` attribute requires a type for its value."),
         None => None,
     };
 
     match data {
         Data::Struct(data) => {
-            // Use `Infallible` if there was no error attribute.
-            let error_type = error_type.unwrap_or_else(|| quote!(core::convert::Infallible));
+            // use `infallible` if there was no pack_error attribute.
+            let pack_error_type = pack_error_type.unwrap_or_else(|| quote!(core::convert::Infallible));
+            // Use `Infallible` if there was no unpack_error attribute.
+            let unpack_error_type = unpack_error_type.unwrap_or_else(|| quote!(core::convert::Infallible));
             // Generate the implementation for the struct.
             let (pack, packed_len, unpack) = packable::gen_bodies_for_struct(data.fields);
-            packable::gen_impl(&ident, &generics, error_type, pack, packed_len, unpack).into()
+            packable::gen_impl(
+                &ident,
+                &generics,
+                pack_error_type,
+                unpack_error_type,
+                pack,
+                packed_len,
+                unpack,
+            )
+            .into()
         }
         Data::Enum(data) => {
             // Verify that the enum has a `"tag_type"` attribute for the type of the tag.
@@ -43,11 +61,23 @@ pub fn packable(input: TokenStream) -> TokenStream {
                     "Enums that derive `Packable` require a `#[packable(tag_type = ...)]` attribute."
                 ),
             };
-            // Use `UnknownTagError` if there was no error attribute.
-            let error_type = error_type.unwrap_or_else(|| quote!(bee_packable::error::UnknownTagError<#tag_ty>));
+            // Use `Infallible` if there was no pack_error attribute.
+            let pack_error_type = pack_error_type.unwrap_or_else(|| quote!(core::convert::Infallible));
+            // Use `UnknownTagError` if there was no unpack_error attribute.
+            let unpack_error_type =
+                unpack_error_type.unwrap_or_else(|| quote!(bee_packable::error::UnknownTagError<#tag_ty>));
             // Generate the implementation for the enum.
             let (pack, packed_len, unpack) = packable::gen_bodies_for_enum(&data.variants, tag_ty);
-            packable::gen_impl(&ident, &generics, error_type, pack, packed_len, unpack).into()
+            packable::gen_impl(
+                &ident,
+                &generics,
+                pack_error_type,
+                unpack_error_type,
+                pack,
+                packed_len,
+                unpack,
+            )
+            .into()
         }
         // Unions are not supported.
         Data::Union(..) => abort!(ident.span(), "Unions cannot derive `Packable`."),

--- a/bee-common/bee-packable-derive/src/lib.rs
+++ b/bee-common/bee-packable-derive/src/lib.rs
@@ -1,6 +1,10 @@
 // Copyright 2021 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
+//! This crate provides the `Packable` derive macro.
+
+#![warn(missing_docs)]
+
 mod packable;
 
 use proc_macro::{self, TokenStream};
@@ -8,6 +12,11 @@ use proc_macro_error::{abort, proc_macro_error};
 use quote::{quote, ToTokens};
 use syn::{parse_macro_input, Data, DeriveInput, Type};
 
+/// The `Packable` derive macro.
+///
+/// Please refer to the [`Packable` spec] for how to set this up.
+///
+/// [`Packable` spec]: https://github.com/iotaledger/bee/blob/coordicide/docs/dev/specs/packable.md
 #[proc_macro_error]
 #[proc_macro_derive(Packable, attributes(packable))]
 pub fn packable(input: TokenStream) -> TokenStream {

--- a/bee-common/bee-packable-derive/src/lib.rs
+++ b/bee-common/bee-packable-derive/src/lib.rs
@@ -43,7 +43,7 @@ pub fn packable(input: TokenStream) -> TokenStream {
 
     match data {
         Data::Struct(data) => {
-            // use `infallible` if there was no pack_error attribute.
+            // Use `Infallible` if there was no pack_error attribute.
             let pack_error_type = pack_error_type.unwrap_or_else(|| quote!(core::convert::Infallible));
             // Use `Infallible` if there was no unpack_error attribute.
             let unpack_error_type = unpack_error_type.unwrap_or_else(|| quote!(core::convert::Infallible));

--- a/bee-common/bee-packable-derive/tests/lib.rs
+++ b/bee-common/bee-packable-derive/tests/lib.rs
@@ -60,4 +60,4 @@ macro_rules! make_test {
 #[rustversion::not(nightly)]
 make_test!(packable);
 #[rustversion::nightly]
-make_test!(packable, packable_is_structural);
+make_test!(packable, packable_is_structural, invalid_wrapper);

--- a/bee-common/bee-packable-derive/tests/packable/fail/duplicated_tag_enum.rs
+++ b/bee-common/bee-packable-derive/tests/packable/fail/duplicated_tag_enum.rs
@@ -9,7 +9,8 @@ use core::convert::Infallible;
 
 #[derive(Packable)]
 #[packable(tag_type = u8)]
-#[packable(error = Infallible)]
+#[packable(pack_error = Infallible)]
+#[packable(unpack_error = Infallible)]
 pub enum OptI32 {
     #[packable(tag = 0)]
     None,

--- a/bee-common/bee-packable-derive/tests/packable/fail/duplicated_tag_enum.stderr
+++ b/bee-common/bee-packable-derive/tests/packable/fail/duplicated_tag_enum.stderr
@@ -1,5 +1,5 @@
 error: The tag `0` is already being used for the `None` variant.
-  --> $DIR/duplicated_tag_enum.rs:16:22
+  --> $DIR/duplicated_tag_enum.rs:17:22
    |
-16 |     #[packable(tag = 0)]
+17 |     #[packable(tag = 0)]
    |                      ^

--- a/bee-common/bee-packable-derive/tests/packable/fail/invalid_pack_error_type.rs
+++ b/bee-common/bee-packable-derive/tests/packable/fail/invalid_pack_error_type.rs
@@ -1,0 +1,18 @@
+// Copyright 2021 IOTA Stiftung
+// SPDX-License-Identifier: Apache-2.0
+
+#![allow(unused_imports)]
+
+use bee_packable::Packable;
+
+use core::convert::Infallible;
+
+#[derive(Packable)]
+#[packable(pack_error = 1)]
+#[packable(unpack_error = Infallible)]
+pub struct Point {
+    x: u32,
+    y: u32,
+}
+
+fn main() {}

--- a/bee-common/bee-packable-derive/tests/packable/fail/invalid_pack_error_type.stderr
+++ b/bee-common/bee-packable-derive/tests/packable/fail/invalid_pack_error_type.stderr
@@ -1,0 +1,5 @@
+error: The `pack_error` attribute requires a type for its value.
+  --> $DIR/invalid_pack_error_type.rs:11:11
+   |
+11 | #[packable(pack_error = 1)]
+   |           ^^^^^^^^^^^^^^^^

--- a/bee-common/bee-packable-derive/tests/packable/fail/invalid_tag_enum.rs
+++ b/bee-common/bee-packable-derive/tests/packable/fail/invalid_tag_enum.rs
@@ -9,7 +9,8 @@ use core::convert::Infallible;
 
 #[derive(Packable)]
 #[packable(tag_type = u8)]
-#[packable(error = Infallible)]
+#[packable(pack_error = Infallible)]
+#[packable(unpack_error = Infallible)]
 pub enum OptI32 {
     #[packable(tag = [0; 32])]
     None,

--- a/bee-common/bee-packable-derive/tests/packable/fail/invalid_tag_enum.stderr
+++ b/bee-common/bee-packable-derive/tests/packable/fail/invalid_tag_enum.stderr
@@ -1,5 +1,5 @@
 error: Tags for variants can only be integers without type annotations.
-  --> $DIR/invalid_tag_enum.rs:14:15
+  --> $DIR/invalid_tag_enum.rs:15:15
    |
-14 |     #[packable(tag = [0; 32])]
+15 |     #[packable(tag = [0; 32])]
    |               ^^^^^^^^^^^^^^^

--- a/bee-common/bee-packable-derive/tests/packable/fail/invalid_tag_type_enum.rs
+++ b/bee-common/bee-packable-derive/tests/packable/fail/invalid_tag_type_enum.rs
@@ -9,7 +9,8 @@ use core::convert::Infallible;
 
 #[derive(Packable)]
 #[packable(tag_type = [u8; 32])]
-#[packable(error = Infallible)]
+#[packable(pack_error = Infallible)]
+#[packable(unpack_error = Infallible)]
 pub enum OptI32 {
     #[packable(tag = 0)]
     None,

--- a/bee-common/bee-packable-derive/tests/packable/fail/invalid_unpack_error_type.rs
+++ b/bee-common/bee-packable-derive/tests/packable/fail/invalid_unpack_error_type.rs
@@ -1,0 +1,18 @@
+// Copyright 2021 IOTA Stiftung
+// SPDX-License-Identifier: Apache-2.0
+
+#![allow(unused_imports)]
+
+use bee_packable::Packable;
+
+use core::convert::Infallible;
+
+#[derive(Packable)]
+#[packable(pack_error = Infallible)]
+#[packable(unpack_error = 1)]
+pub struct Point {
+    x: u32,
+    y: u32,
+}
+
+fn main() {}

--- a/bee-common/bee-packable-derive/tests/packable/fail/invalid_unpack_error_type.stderr
+++ b/bee-common/bee-packable-derive/tests/packable/fail/invalid_unpack_error_type.stderr
@@ -1,0 +1,5 @@
+error: The `unpack_error` attribute requires a type for its value.
+  --> $DIR/invalid_unpack_error_type.rs:12:11
+   |
+12 | #[packable(unpack_error = 1)]
+   |           ^^^^^^^^^^^^^^^^^^

--- a/bee-common/bee-packable-derive/tests/packable/fail/invalid_wrapper.rs
+++ b/bee-common/bee-packable-derive/tests/packable/fail/invalid_wrapper.rs
@@ -1,0 +1,19 @@
+// Copyright 2021 IOTA Stiftung
+// SPDX-License-Identifier: Apache-2.0
+
+#![allow(unused_imports)]
+
+use bee_packable::{VecPrefix, Packable};
+
+use core::convert::Infallible;
+
+#[derive(Packable)]
+#[packable(pack_error = Infallible)]
+#[packable(unpack_error = Infallible)]
+pub struct Foo {
+    #[packable(wrapper = VecPrefix<u64, u8>)]
+    inner: Vec<u32>,
+}
+
+fn main() {}
+

--- a/bee-common/bee-packable-derive/tests/packable/fail/invalid_wrapper.stderr
+++ b/bee-common/bee-packable-derive/tests/packable/fail/invalid_wrapper.stderr
@@ -1,0 +1,70 @@
+error[E0277]: the trait bound `Vec<u32>: Wrap<VecPrefix<u64, u8>>` is not satisfied
+  --> $DIR/invalid_wrapper.rs:10:10
+   |
+10 | #[derive(Packable)]
+   |          ^^^^^^^^ the trait `Wrap<VecPrefix<u64, u8>>` is not implemented for `Vec<u32>`
+   |
+   = help: the following implementations were found:
+             <Vec<T> as Wrap<VecPrefix<T, u128>>>
+             <Vec<T> as Wrap<VecPrefix<T, u16>>>
+             <Vec<T> as Wrap<VecPrefix<T, u32>>>
+             <Vec<T> as Wrap<VecPrefix<T, u64>>>
+             <Vec<T> as Wrap<VecPrefix<T, u8>>>
+   = note: required by `wrap`
+   = note: this error originates in a derive macro (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0277]: the trait bound `Vec<u32>: From<VecPrefix<u64, u8>>` is not satisfied
+  --> $DIR/invalid_wrapper.rs:10:10
+   |
+10 | #[derive(Packable)]
+   |          ^^^^^^^^ the trait `From<VecPrefix<u64, u8>>` is not implemented for `Vec<u32>`
+   |
+   = help: the following implementations were found:
+             <Vec<T, A> as From<Box<[T], A>>>
+             <Vec<T> as From<&[T]>>
+             <Vec<T> as From<&mut [T]>>
+             <Vec<T> as From<BinaryHeap<T>>>
+           and 6 others
+   = note: required because of the requirements on the impl of `Into<Vec<u32>>` for `VecPrefix<u64, u8>`
+   = note: required by `wrap`
+   = note: this error originates in a derive macro (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0277]: `?` couldn't convert the error to `PackError<Infallible, <P as bee_packable::Packer>::Error>`
+  --> $DIR/invalid_wrapper.rs:10:17
+   |
+10 | #[derive(Packable)]
+   |                 ^ the trait `From<PackError<PackPrefixError<Infallible, u8>, <P as bee_packable::Packer>::Error>>` is not implemented for `PackError<Infallible, <P as bee_packable::Packer>::Error>`
+   |
+   = note: the question mark operation (`?`) implicitly performs a conversion on the error value using the `From` trait
+   = note: required by `from`
+   = note: this error originates in a derive macro (in Nightly builds, run with -Z macro-backtrace for more info)
+help: consider introducing a `where` bound, but there might be an alternative better way to express this requirement
+   |
+13 | pub struct Foo where PackError<Infallible, <P as bee_packable::Packer>::Error>: From<PackError<PackPrefixError<Infallible, u8>, <P as bee_packable::Packer>::Error>> {
+   |                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error[E0277]: the trait bound `Vec<u32>: From<VecPrefix<u64, u8>>` is not satisfied
+  --> $DIR/invalid_wrapper.rs:10:10
+   |
+10 | #[derive(Packable)]
+   |          ^^^^^^^^ the trait `From<VecPrefix<u64, u8>>` is not implemented for `Vec<u32>`
+   |
+   = help: the following implementations were found:
+             <Vec<T, A> as From<Box<[T], A>>>
+             <Vec<T> as From<&[T]>>
+             <Vec<T> as From<&mut [T]>>
+             <Vec<T> as From<BinaryHeap<T>>>
+           and 6 others
+   = note: required because of the requirements on the impl of `Into<Vec<u32>>` for `VecPrefix<u64, u8>`
+   = note: required by `into`
+   = note: this error originates in a derive macro (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0277]: the trait bound `Infallible: From<UnpackPrefixError<Infallible, u8>>` is not satisfied
+  --> $DIR/invalid_wrapper.rs:10:10
+   |
+10 | #[derive(Packable)]
+   |          ^^^^^^^^ the trait `From<UnpackPrefixError<Infallible, u8>>` is not implemented for `Infallible`
+   |
+   = help: the following implementations were found:
+             <Infallible as From<!>>
+   = note: this error originates in a derive macro (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/bee-common/bee-packable-derive/tests/packable/fail/invalid_wrapper_type.rs
+++ b/bee-common/bee-packable-derive/tests/packable/fail/invalid_wrapper_type.rs
@@ -1,0 +1,19 @@
+// Copyright 2021 IOTA Stiftung
+// SPDX-License-Identifier: Apache-2.0
+
+#![allow(unused_imports)]
+
+use bee_packable::Packable;
+
+use core::convert::Infallible;
+
+#[derive(Packable)]
+#[packable(pack_error = Infallible)]
+#[packable(unpack_error = Infallible)]
+pub struct Point {
+    #[packable(wrapper = 1)]
+    x: u32,
+    y: u32,
+}
+
+fn main() {}

--- a/bee-common/bee-packable-derive/tests/packable/fail/invalid_wrapper_type.stderr
+++ b/bee-common/bee-packable-derive/tests/packable/fail/invalid_wrapper_type.stderr
@@ -1,0 +1,5 @@
+error: The `wrapper` attribute requires a type for its value.
+  --> $DIR/invalid_wrapper_type.rs:14:15
+   |
+14 |     #[packable(wrapper = 1)]
+   |               ^^^^^^^^^^^^^

--- a/bee-common/bee-packable-derive/tests/packable/fail/missing_tag_enum.rs
+++ b/bee-common/bee-packable-derive/tests/packable/fail/missing_tag_enum.rs
@@ -9,7 +9,8 @@ use core::convert::Infallible;
 
 #[derive(Packable)]
 #[packable(tag_type = u32)]
-#[packable(error = Infallible)]
+#[packable(pack_error = Infallible)]
+#[packable(unpack_error = Infallible)]
 pub enum OptI32 {
     None,
     Some(i32),

--- a/bee-common/bee-packable-derive/tests/packable/fail/missing_tag_enum.stderr
+++ b/bee-common/bee-packable-derive/tests/packable/fail/missing_tag_enum.stderr
@@ -1,5 +1,5 @@
 error: All variants of an enum that derives `Packable` require a `#[packable(tag = ...)]` attribute.
-  --> $DIR/missing_tag_enum.rs:14:5
+  --> $DIR/missing_tag_enum.rs:15:5
    |
-14 |     None,
+15 |     None,
    |     ^^^^

--- a/bee-common/bee-packable-derive/tests/packable/fail/missing_tag_type_enum.rs
+++ b/bee-common/bee-packable-derive/tests/packable/fail/missing_tag_type_enum.rs
@@ -8,7 +8,8 @@ use bee_packable::Packable;
 use core::convert::Infallible;
 
 #[derive(Packable)]
-#[packable(error = Infallible)]
+#[packable(pack_error = Infallible)]
+#[packable(unpack_error = Infallible)]
 pub enum OptI32 {
     #[packable(tag = 0)]
     None,

--- a/bee-common/bee-packable-derive/tests/packable/fail/missing_tag_type_enum.stderr
+++ b/bee-common/bee-packable-derive/tests/packable/fail/missing_tag_type_enum.stderr
@@ -1,5 +1,5 @@
 error: Enums that derive `Packable` require a `#[packable(tag_type = ...)]` attribute.
-  --> $DIR/missing_tag_type_enum.rs:12:10
+  --> $DIR/missing_tag_type_enum.rs:13:10
    |
-12 | pub enum OptI32 {
+13 | pub enum OptI32 {
    |          ^^^^^^

--- a/bee-common/bee-packable-derive/tests/packable/fail/packable_is_structural.rs
+++ b/bee-common/bee-packable-derive/tests/packable/fail/packable_is_structural.rs
@@ -10,7 +10,8 @@ use core::convert::Infallible;
 struct NonPackable;
 
 #[derive(Packable)]
-#[packable(error = Infallible)]
+#[packable(pack_error = Infallible)]
+#[packable(unpack_error = Infallible)]
 pub struct Wrapper(NonPackable);
 
 fn main() {}

--- a/bee-common/bee-packable-derive/tests/packable/fail/union.rs
+++ b/bee-common/bee-packable-derive/tests/packable/fail/union.rs
@@ -8,7 +8,8 @@ use bee_packable::Packable;
 use core::convert::Infallible;
 
 #[derive(Packable)]
-#[packable(error = Infallible)]
+#[packable(pack_error = Infallible)]
+#[packable(unpack_error = Infallible)]
 pub union MaybeInt {
     just: u32,
     nothing: (),

--- a/bee-common/bee-packable-derive/tests/packable/fail/union.stderr
+++ b/bee-common/bee-packable-derive/tests/packable/fail/union.stderr
@@ -1,5 +1,5 @@
 error: Unions cannot derive `Packable`.
-  --> $DIR/union.rs:12:11
+  --> $DIR/union.rs:13:11
    |
-12 | pub union MaybeInt {
+13 | pub union MaybeInt {
    |           ^^^^^^^^

--- a/bee-common/bee-packable-derive/tests/packable/pass/default_errors.rs
+++ b/bee-common/bee-packable-derive/tests/packable/pass/default_errors.rs
@@ -23,9 +23,17 @@ pub enum Foo {
 }
 
 fn main() {
-    assert_eq!(TypeId::of::<Infallible>(), TypeId::of::<<Point as Packable>::Error>());
+    assert_eq!(
+        TypeId::of::<Infallible>(),
+        TypeId::of::<<Point as Packable>::PackError>()
+    );
+    assert_eq!(TypeId::of::<Infallible>(), TypeId::of::<<Foo as Packable>::PackError>());
+    assert_eq!(
+        TypeId::of::<Infallible>(),
+        TypeId::of::<<Point as Packable>::UnpackError>()
+    );
     assert_eq!(
         TypeId::of::<UnknownTagError<u8>>(),
-        TypeId::of::<<Foo as Packable>::Error>()
+        TypeId::of::<<Foo as Packable>::UnpackError>()
     );
 }

--- a/bee-common/bee-packable-derive/tests/packable/pass/generic_newtype.rs
+++ b/bee-common/bee-packable-derive/tests/packable/pass/generic_newtype.rs
@@ -6,7 +6,8 @@
 use bee_packable::Packable;
 
 #[derive(Packable)]
-#[packable(error = T::Error)]
+#[packable(pack_error = T::PackError)]
+#[packable(unpack_error = T::UnpackError)]
 pub struct Wrap<T: Packable>(T);
 
 fn main() {}

--- a/bee-common/bee-packable-derive/tests/packable/pass/mixed_enum.rs
+++ b/bee-common/bee-packable-derive/tests/packable/pass/mixed_enum.rs
@@ -5,9 +5,12 @@
 
 use bee_packable::{error::UnknownTagError, Packable};
 
+use core::convert::Infallible;
+
 #[derive(Packable)]
 #[packable(tag_type = u8)]
-#[packable(error = UnknownTagError<u8>)]
+#[packable(pack_error = Infallible)]
+#[packable(unpack_error = UnknownTagError<u8>)]
 pub enum Foo {
     #[packable(tag = 0)]
     Bar(u32),

--- a/bee-common/bee-packable-derive/tests/packable/pass/named_enum.rs
+++ b/bee-common/bee-packable-derive/tests/packable/pass/named_enum.rs
@@ -5,9 +5,12 @@
 
 use bee_packable::{error::UnknownTagError, Packable};
 
+use core::convert::Infallible;
+
 #[derive(Packable)]
 #[packable(tag_type = u8)]
-#[packable(error = UnknownTagError<u8>)]
+#[packable(pack_error = Infallible)]
+#[packable(unpack_error = UnknownTagError<u8>)]
 pub enum OptPoint {
     #[packable(tag = 0)]
     None,

--- a/bee-common/bee-packable-derive/tests/packable/pass/named_struct.rs
+++ b/bee-common/bee-packable-derive/tests/packable/pass/named_struct.rs
@@ -8,7 +8,8 @@ use bee_packable::Packable;
 use core::convert::Infallible;
 
 #[derive(Packable)]
-#[packable(error = Infallible)]
+#[packable(pack_error = Infallible)]
+#[packable(unpack_error = Infallible)]
 pub struct Point {
     x: i32,
     y: i32,

--- a/bee-common/bee-packable-derive/tests/packable/pass/newtype.rs
+++ b/bee-common/bee-packable-derive/tests/packable/pass/newtype.rs
@@ -8,7 +8,8 @@ use bee_packable::Packable;
 use core::convert::Infallible;
 
 #[derive(Packable)]
-#[packable(error = Infallible)]
+#[packable(pack_error = Infallible)]
+#[packable(unpack_error = Infallible)]
 pub struct Num(u32);
 
 fn main() {}

--- a/bee-common/bee-packable-derive/tests/packable/pass/unit_struct.rs
+++ b/bee-common/bee-packable-derive/tests/packable/pass/unit_struct.rs
@@ -8,11 +8,13 @@ use bee_packable::Packable;
 use core::convert::Infallible;
 
 #[derive(Packable)]
-#[packable(error = Infallible)]
+#[packable(pack_error = Infallible)]
+#[packable(unpack_error = Infallible)]
 pub struct Unit;
 
 #[derive(Packable)]
-#[packable(error = Infallible)]
+#[packable(pack_error = Infallible)]
+#[packable(unpack_error = Infallible)]
 pub struct RoundUnit();
 
 fn main() {}

--- a/bee-common/bee-packable-derive/tests/packable/pass/unnamed_enum.rs
+++ b/bee-common/bee-packable-derive/tests/packable/pass/unnamed_enum.rs
@@ -5,9 +5,12 @@
 
 use bee_packable::{error::UnknownTagError, Packable};
 
+use core::convert::Infallible;
+
 #[derive(Packable)]
 #[packable(tag_type = u8)]
-#[packable(error = UnknownTagError<u8>)]
+#[packable(pack_error = Infallible)]
+#[packable(unpack_error = UnknownTagError<u8>)]
 pub enum OptI32 {
     #[packable(tag = 0)]
     None,

--- a/bee-common/bee-packable-derive/tests/packable/pass/unnamed_struct.rs
+++ b/bee-common/bee-packable-derive/tests/packable/pass/unnamed_struct.rs
@@ -8,7 +8,8 @@ use bee_packable::Packable;
 use core::convert::Infallible;
 
 #[derive(Packable)]
-#[packable(error = Infallible)]
+#[packable(pack_error = Infallible)]
+#[packable(unpack_error = Infallible)]
 pub struct Point(i32, i32);
 
 fn main() {}

--- a/bee-common/bee-packable-derive/tests/packable/pass/vec_wrapper.rs
+++ b/bee-common/bee-packable-derive/tests/packable/pass/vec_wrapper.rs
@@ -3,13 +3,17 @@
 
 #![allow(unused_imports)]
 
-use bee_packable::{packer::VecPacker, Packable, VecPrefix, error::PrefixError};
+use bee_packable::{
+    error::{PackPrefixError, UnpackPrefixError},
+    packer::VecPacker,
+    Packable, VecPrefix,
+};
 
-use core::convert::{TryFrom, Infallible};
+use core::convert::Infallible;
 
 #[derive(Packable)]
-#[packable(pack_error = PrefixError<Infallible, <u16 as TryFrom<usize>>::Error>)]
-#[packable(unpack_error = PrefixError<Infallible, <usize as TryFrom<u16>>::Error>)]
+#[packable(pack_error = PackPrefixError<Infallible, u16>)]
+#[packable(unpack_error = UnpackPrefixError<Infallible, u16>)]
 pub struct Foo {
     #[packable(wrapper = VecPrefix<u8, u16>)]
     inner: Vec<u8>,

--- a/bee-common/bee-packable-derive/tests/packable/pass/vec_wrapper.rs
+++ b/bee-common/bee-packable-derive/tests/packable/pass/vec_wrapper.rs
@@ -1,0 +1,27 @@
+// Copyright 2021 IOTA Stiftung
+// SPDX-License-Identifier: Apache-2.0
+
+#![allow(unused_imports)]
+
+use bee_packable::{packer::VecPacker, Packable, VecPrefix, error::PrefixError};
+
+use core::convert::{TryFrom, Infallible};
+
+#[derive(Packable)]
+#[packable(pack_error = PrefixError<Infallible, <u16 as TryFrom<usize>>::Error>)]
+#[packable(unpack_error = PrefixError<Infallible, <usize as TryFrom<u16>>::Error>)]
+pub struct Foo {
+    #[packable(wrapper = VecPrefix<u8, u16>)]
+    inner: Vec<u8>,
+}
+
+fn main() {
+    let mut packer = VecPacker::new();
+    let value = Foo { inner: vec![13, 37] };
+    assert_eq!(
+        value.packed_len(),
+        core::mem::size_of::<u16>() + 2 * core::mem::size_of::<u8>()
+    );
+    value.pack(&mut packer).unwrap();
+    assert_eq!(value.packed_len(), packer.len());
+}

--- a/bee-common/bee-packable/src/error.rs
+++ b/bee-common/bee-packable/src/error.rs
@@ -5,46 +5,6 @@
 
 use core::convert::Infallible;
 
-/// Error type raised when `Packable::unpack` fails.
-#[derive(Debug)]
-pub enum UnpackError<T, U> {
-    /// Semantic error. Typically this is `Packable::UnpackError`.
-    Packable(T),
-    /// Error produced by the unpacker. Typically this is `Unpacker::Error`.
-    Unpacker(U),
-}
-
-impl<T, U> UnpackError<T, U> {
-    /// Maps the `Packable` variant of this enum.
-    pub fn map<V, F: Fn(T) -> V>(self, f: F) -> UnpackError<V, U> {
-        match self {
-            Self::Packable(err) => UnpackError::Packable(f(err)),
-            Self::Unpacker(err) => UnpackError::Unpacker(err),
-        }
-    }
-
-    /// Coerces the value by calling `.into()` for the `Packable` variant.
-    pub fn coerce<V: From<T>>(self) -> UnpackError<V, U> {
-        self.map(|x| x.into())
-    }
-}
-
-impl<T, U> From<U> for UnpackError<T, U> {
-    fn from(err: U) -> Self {
-        Self::Unpacker(err)
-    }
-}
-
-impl<U> UnpackError<Infallible, U> {
-    /// Coerces the value if the `Packable` variant is `Infallible`.
-    pub fn infallible<E>(self) -> UnpackError<E, U> {
-        match self {
-            Self::Packable(err) => match err {},
-            Self::Unpacker(err) => UnpackError::Unpacker(err),
-        }
-    }
-}
-
 /// Error type raised when `Packable::pack` fails.
 #[derive(Debug)]
 pub enum PackError<T, P> {
@@ -81,6 +41,46 @@ impl<P> PackError<Infallible, P> {
         match self {
             Self::Packable(err) => match err {},
             Self::Packer(err) => PackError::Packer(err),
+        }
+    }
+}
+
+/// Error type raised when `Packable::unpack` fails.
+#[derive(Debug)]
+pub enum UnpackError<T, U> {
+    /// Semantic error. Typically this is `Packable::UnpackError`.
+    Packable(T),
+    /// Error produced by the unpacker. Typically this is `Unpacker::Error`.
+    Unpacker(U),
+}
+
+impl<T, U> UnpackError<T, U> {
+    /// Maps the `Packable` variant of this enum.
+    pub fn map<V, F: Fn(T) -> V>(self, f: F) -> UnpackError<V, U> {
+        match self {
+            Self::Packable(err) => UnpackError::Packable(f(err)),
+            Self::Unpacker(err) => UnpackError::Unpacker(err),
+        }
+    }
+
+    /// Coerces the value by calling `.into()` for the `Packable` variant.
+    pub fn coerce<V: From<T>>(self) -> UnpackError<V, U> {
+        self.map(|x| x.into())
+    }
+}
+
+impl<T, U> From<U> for UnpackError<T, U> {
+    fn from(err: U) -> Self {
+        Self::Unpacker(err)
+    }
+}
+
+impl<U> UnpackError<Infallible, U> {
+    /// Coerces the value if the `Packable` variant is `Infallible`.
+    pub fn infallible<E>(self) -> UnpackError<E, U> {
+        match self {
+            Self::Packable(err) => match err {},
+            Self::Unpacker(err) => UnpackError::Unpacker(err),
         }
     }
 }

--- a/bee-common/bee-packable/src/error.rs
+++ b/bee-common/bee-packable/src/error.rs
@@ -94,3 +94,21 @@ impl<T> From<Infallible> for UnknownTagError<T> {
         match err {}
     }
 }
+
+/// Semantic error type for dynamically-sized sequences that use a type different than `usize` for
+/// their length-prefix.
+#[derive(Debug)]
+pub enum PrefixError<T, P> {
+    /// Semantic error for an element of the sequence. Typically this is `Packable::PackError` or
+    /// `Packable::UnpackError`.
+    Packable(T),
+    /// Semantic error for the prefix of the sequence. Typically this is `TryFrom::<usize>::Error`
+    /// or `TryInto::<usize>::Error`.
+    Prefix(P),
+}
+
+impl<T, P> From<T> for PrefixError<T, P> {
+    fn from(err: T) -> Self {
+        Self::Packable(err)
+    }
+}

--- a/bee-common/bee-packable/src/error.rs
+++ b/bee-common/bee-packable/src/error.rs
@@ -95,19 +95,45 @@ impl<T> From<Infallible> for UnknownTagError<T> {
     }
 }
 
-/// Semantic error type for dynamically-sized sequences that use a type different than `usize` for
-/// their length-prefix.
+/// Semantic error raised while packing a dynamically-sized sequences that use a type different
+/// than `usize` for their length-prefix.
 #[derive(Debug)]
-pub enum PrefixError<T, P> {
-    /// Semantic error for an element of the sequence. Typically this is `Packable::PackError` or
-    /// `Packable::UnpackError`.
+pub enum PackPrefixError<T, P>
+where
+    P: core::convert::TryFrom<usize>,
+{
+    /// Semantic error raised while packing an element of the sequence. Typically this is `Packable::PackError`.`
     Packable(T),
-    /// Semantic error for the prefix of the sequence. Typically this is `TryFrom::<usize>::Error`
-    /// or `TryInto::<usize>::Error`.
-    Prefix(P),
+    /// Semantic error raised while packing the prefix of the sequence.
+    Prefix(P::Error),
 }
 
-impl<T, P> From<T> for PrefixError<T, P> {
+impl<T, P> From<T> for PackPrefixError<T, P>
+where
+    P: core::convert::TryFrom<usize>,
+{
+    fn from(err: T) -> Self {
+        Self::Packable(err)
+    }
+}
+
+/// Semantic error raised while unpacking a dynamically-sized sequences that use a type different
+/// than `usize` for their length-prefix.
+#[derive(Debug)]
+pub enum UnpackPrefixError<T, P>
+where
+    P: core::convert::TryInto<usize>,
+{
+    /// Semantic error raised while unpacking an element of the sequence. Typically this is `Packable::UnpackError`.`
+    Packable(T),
+    /// Semantic error raised while unpacking the prefix of the sequence.
+    Prefix(P::Error),
+}
+
+impl<T, P> From<T> for UnpackPrefixError<T, P>
+where
+    P: core::convert::TryInto<usize>,
+{
     fn from(err: T) -> Self {
         Self::Packable(err)
     }

--- a/bee-common/bee-packable/src/lib.rs
+++ b/bee-common/bee-packable/src/lib.rs
@@ -10,5 +10,6 @@ pub mod error;
 pub mod packable;
 pub mod packer;
 pub mod unpacker;
+pub mod wrap;
 
 pub use packable::*;

--- a/bee-common/bee-packable/src/packable/bool.rs
+++ b/bee-common/bee-packable/src/packable/bool.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 pub use crate::{
-    error::{UnknownTagError, UnpackError},
+    error::{PackError, UnknownTagError, UnpackError},
     packer::{Packer, VecPacker},
     unpacker::{SliceUnpacker, UnexpectedEOF, Unpacker},
     Packable,
@@ -11,10 +11,11 @@ pub use crate::{
 use core::convert::Infallible;
 
 impl Packable for bool {
-    type Error = Infallible;
+    type PackError = Infallible;
+    type UnpackError = Infallible;
 
     /// Booleans are packed as `u8` integers following Rust's data layout.
-    fn pack<P: Packer>(&self, packer: &mut P) -> Result<(), P::Error> {
+    fn pack<P: Packer>(&self, packer: &mut P) -> Result<(), PackError<Self::PackError, P::Error>> {
         (*self as u8).pack(packer)
     }
 
@@ -23,7 +24,7 @@ impl Packable for bool {
     }
 
     /// Booleans are unpacked if the byte used to represent them is non-zero.
-    fn unpack<U: Unpacker>(unpacker: &mut U) -> Result<Self, UnpackError<Self::Error, U::Error>> {
+    fn unpack<U: Unpacker>(unpacker: &mut U) -> Result<Self, UnpackError<Self::UnpackError, U::Error>> {
         Ok(u8::unpack(unpacker).map_err(UnpackError::infallible)? != 0)
     }
 }

--- a/bee-common/bee-packable/src/packable/box.rs
+++ b/bee-common/bee-packable/src/packable/box.rs
@@ -4,7 +4,7 @@
 extern crate alloc;
 
 pub use crate::{
-    error::{UnknownTagError, UnpackError},
+    error::{PackError, UnknownTagError, UnpackError},
     packer::{Packer, VecPacker},
     unpacker::{SliceUnpacker, UnexpectedEOF, Unpacker},
     Packable,
@@ -13,11 +13,12 @@ pub use crate::{
 use alloc::{boxed::Box, vec::Vec};
 
 impl<T: Packable> Packable for Box<[T]> {
-    type Error = T::Error;
+    type PackError = T::PackError;
+    type UnpackError = T::UnpackError;
 
-    fn pack<P: Packer>(&self, packer: &mut P) -> Result<(), P::Error> {
+    fn pack<P: Packer>(&self, packer: &mut P) -> Result<(), PackError<Self::PackError, P::Error>> {
         // The length of any dynamically-sized sequence must be prefixed.
-        self.len().pack(packer)?;
+        self.len().pack(packer).map_err(PackError::infallible)?;
 
         for item in self.iter() {
             item.pack(packer)?;
@@ -30,7 +31,7 @@ impl<T: Packable> Packable for Box<[T]> {
         0usize.packed_len() + self.iter().map(T::packed_len).sum::<usize>()
     }
 
-    fn unpack<U: Unpacker>(unpacker: &mut U) -> Result<Self, UnpackError<Self::Error, U::Error>> {
+    fn unpack<U: Unpacker>(unpacker: &mut U) -> Result<Self, UnpackError<Self::UnpackError, U::Error>> {
         Ok(Vec::<T>::unpack(unpacker)?.into_boxed_slice())
     }
 }

--- a/bee-common/bee-packable/src/packable/integer.rs
+++ b/bee-common/bee-packable/src/packable/integer.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 pub use crate::{
-    error::{UnknownTagError, UnpackError},
+    error::{PackError, UnknownTagError, UnpackError},
     packer::{Packer, VecPacker},
     unpacker::{SliceUnpacker, UnexpectedEOF, Unpacker},
     Packable,
@@ -13,17 +13,18 @@ use core::convert::Infallible;
 macro_rules! impl_packable_for_int {
     ($ty:ty) => {
         impl Packable for $ty {
-            type Error = Infallible;
+            type PackError = Infallible;
+            type UnpackError = Infallible;
 
-            fn pack<P: Packer>(&self, packer: &mut P) -> Result<(), P::Error> {
-                packer.pack_bytes(&self.to_le_bytes())
+            fn pack<P: Packer>(&self, packer: &mut P) -> Result<(), PackError<Self::PackError, P::Error>> {
+                Ok(packer.pack_bytes(&self.to_le_bytes())?)
             }
 
             fn packed_len(&self) -> usize {
                 core::mem::size_of::<Self>()
             }
 
-            fn unpack<U: Unpacker>(unpacker: &mut U) -> Result<Self, UnpackError<Self::Error, U::Error>> {
+            fn unpack<U: Unpacker>(unpacker: &mut U) -> Result<Self, UnpackError<Self::UnpackError, U::Error>> {
                 let mut bytes = [0u8; core::mem::size_of::<Self>()];
                 unpacker.unpack_bytes(&mut bytes)?;
                 Ok(Self::from_le_bytes(bytes))
@@ -41,9 +42,10 @@ impl_packable_for_int!(u128);
 
 /// `usize` integers are packed and unpacked as `u64` integers according to the spec.
 impl Packable for usize {
-    type Error = Infallible;
+    type UnpackError = Infallible;
+    type PackError = Infallible;
 
-    fn pack<P: Packer>(&self, packer: &mut P) -> Result<(), P::Error> {
+    fn pack<P: Packer>(&self, packer: &mut P) -> Result<(), PackError<Self::PackError, P::Error>> {
         (*self as u64).pack(packer)
     }
 
@@ -51,7 +53,7 @@ impl Packable for usize {
         core::mem::size_of::<u64>()
     }
 
-    fn unpack<U: Unpacker>(unpacker: &mut U) -> Result<Self, UnpackError<Self::Error, U::Error>> {
+    fn unpack<U: Unpacker>(unpacker: &mut U) -> Result<Self, UnpackError<Self::UnpackError, U::Error>> {
         Ok(u64::unpack(unpacker).map_err(UnpackError::infallible)? as usize)
     }
 }
@@ -65,9 +67,10 @@ impl_packable_for_int!(i128);
 
 /// `isize` integers are packed and unpacked as `i64` integers according to the spec.
 impl Packable for isize {
-    type Error = Infallible;
+    type PackError = Infallible;
+    type UnpackError = Infallible;
 
-    fn pack<P: Packer>(&self, packer: &mut P) -> Result<(), P::Error> {
+    fn pack<P: Packer>(&self, packer: &mut P) -> Result<(), PackError<Self::PackError, P::Error>> {
         (*self as i64).pack(packer)
     }
 
@@ -75,7 +78,7 @@ impl Packable for isize {
         core::mem::size_of::<i64>()
     }
 
-    fn unpack<U: Unpacker>(unpacker: &mut U) -> Result<Self, UnpackError<Self::Error, U::Error>> {
+    fn unpack<U: Unpacker>(unpacker: &mut U) -> Result<Self, UnpackError<Self::UnpackError, U::Error>> {
         Ok(i64::unpack(unpacker).map_err(UnpackError::infallible)? as isize)
     }
 }

--- a/bee-common/bee-packable/src/packable/mod.rs
+++ b/bee-common/bee-packable/src/packable/mod.rs
@@ -17,7 +17,7 @@ pub use option::UnpackOptionError;
 pub use vec_prefix::VecPrefix;
 
 pub use crate::{
-    error::{UnknownTagError, UnpackError},
+    error::{PackError, UnknownTagError, UnpackError},
     packer::{Packer, VecPacker},
     unpacker::{SliceUnpacker, UnexpectedEOF, Unpacker},
 };
@@ -32,28 +32,37 @@ use alloc::vec::Vec;
 /// `bee_common_derive::Packable` macro. If you need to implement this trait manually, use the provided
 /// implementations as a guide.
 pub trait Packable: Sized {
+    /// The error type that can be returned if some semantic error occurs while packing.
+    ///
+    /// It is recommended to use `core::convert::Infallible` if this kind of error cannot happen or
+    /// `UnknownTagError` when implementing this trait for an enum.
+    type PackError;
+
     /// The error type that can be returned if some semantic error occurs while unpacking.
     ///
     /// It is recommended to use `core::convert::Infallible` if this kind of error cannot happen or
     /// `UnknownTagError` when implementing this trait for an enum.
-    type Error;
+    type UnpackError;
 
-    /// Packs this value into the given `Packer`.
-    fn pack<P: Packer>(&self, packer: &mut P) -> Result<(), P::Error>;
+    /// Pack this value into the given `Packer`.
+    fn pack<P: Packer>(&self, packer: &mut P) -> Result<(), PackError<Self::PackError, P::Error>>;
 
-    /// Convenience method that packs this value into a `Vec<u8>`.
-    fn pack_new(&self) -> Vec<u8> {
-        let mut packer = VecPacker::with_capacity(self.packed_len());
-
-        // Packing to bytes will not fail.
-        self.pack(&mut packer).unwrap();
-
-        packer.into_vec()
-    }
-
-    /// Returns the size of the value in bytes after being packed.
+    /// The size of the value in bytes after being packed.
     fn packed_len(&self) -> usize;
 
-    /// Unpacks this value from the given `Unpacker`.
-    fn unpack<U: Unpacker>(unpacker: &mut U) -> Result<Self, UnpackError<Self::Error, U::Error>>;
+    /// Convenience method that packs this value into a `Vec<u8>`.
+    fn pack_new(&self) -> Result<Vec<u8>, Self::PackError> {
+        let mut packer = VecPacker::with_capacity(self.packed_len());
+
+        // Packing to bytes will not fail but packing the value itself might.
+        self.pack(&mut packer).map_err(|err| match err {
+            PackError::Packable(err) => err,
+            PackError::Packer(err) => match err {},
+        })?;
+
+        Ok(packer.into_vec())
+    }
+
+    /// Unpack this value from the given `Unpacker`.
+    fn unpack<U: Unpacker>(unpacker: &mut U) -> Result<Self, UnpackError<Self::UnpackError, U::Error>>;
 }

--- a/bee-common/bee-packable/src/packable/vec.rs
+++ b/bee-common/bee-packable/src/packable/vec.rs
@@ -4,7 +4,7 @@
 extern crate alloc;
 
 pub use crate::{
-    error::{UnknownTagError, UnpackError},
+    error::{PackError, UnknownTagError, UnpackError},
     packer::{Packer, VecPacker},
     unpacker::{SliceUnpacker, UnexpectedEOF, Unpacker},
     Packable,
@@ -13,11 +13,12 @@ pub use crate::{
 use alloc::vec::Vec;
 
 impl<T: Packable> Packable for Vec<T> {
-    type Error = T::Error;
+    type PackError = T::PackError;
+    type UnpackError = T::UnpackError;
 
-    fn pack<P: Packer>(&self, packer: &mut P) -> Result<(), P::Error> {
+    fn pack<P: Packer>(&self, packer: &mut P) -> Result<(), PackError<Self::PackError, P::Error>> {
         // The length of any dynamically-sized sequence must be prefixed.
-        self.len().pack(packer)?;
+        self.len().pack(packer).map_err(PackError::infallible)?;
 
         for item in self.iter() {
             item.pack(packer)?;
@@ -30,7 +31,7 @@ impl<T: Packable> Packable for Vec<T> {
         0usize.packed_len() + self.iter().map(T::packed_len).sum::<usize>()
     }
 
-    fn unpack<U: Unpacker>(unpacker: &mut U) -> Result<Self, UnpackError<Self::Error, U::Error>> {
+    fn unpack<U: Unpacker>(unpacker: &mut U) -> Result<Self, UnpackError<Self::UnpackError, U::Error>> {
         // The length of any dynamically-sized sequence must be prefixed.
         let len = usize::unpack(unpacker).map_err(UnpackError::infallible)?;
 

--- a/bee-common/bee-packable/src/packable/vec_prefix.rs
+++ b/bee-common/bee-packable/src/packable/vec_prefix.rs
@@ -3,11 +3,11 @@
 
 extern crate alloc;
 
-use crate::wrap::Wrap;
-pub use crate::{
-    error::{PackError, PackPrefixError, UnknownTagError, UnpackError, UnpackPrefixError},
-    packer::{Packer, VecPacker},
-    unpacker::{SliceUnpacker, UnexpectedEOF, Unpacker},
+use crate::{
+    error::{PackError, PackPrefixError, UnpackError, UnpackPrefixError},
+    packer::Packer,
+    unpacker::Unpacker,
+    wrap::Wrap,
     Packable,
 };
 
@@ -81,6 +81,10 @@ macro_rules! impl_wrap_for_vec {
     ($ty:ty) => {
         impl<T> Wrap<VecPrefix<T, $ty>> for Vec<T> {
             fn wrap(&self) -> &VecPrefix<T, $ty> {
+                // SAFETY: `VecPrefix` has a transparent representation and it is composed of one
+                // `Vec` field and an additional zero-sized type field. This means that `VecPrefix`
+                // has the same layout as `Vec` and any valid `Vec` reference can be casted into a
+                // valid `VecPrefix` reference.
                 unsafe { &*(self as *const Vec<T> as *const VecPrefix<T, $ty>) }
             }
         }

--- a/bee-common/bee-packable/src/wrap.rs
+++ b/bee-common/bee-packable/src/wrap.rs
@@ -1,0 +1,21 @@
+// Copyright 2021 IOTA Stiftung
+// SPDX-License-Identifier: Apache-2.0
+
+//! A module to wrap `Packable` values.
+
+/// A type whose values can be wrapped in values of type `W`.
+///
+/// In essence, `A: Wrap<B>` means that every value of type `&A` can be converted into a value of
+/// type `&B` (via `Wrap::wrap`), also known as "wrapping", and that every `B` can be converted
+/// into a value of type `A` (via `Into::into`), also known as "unwrapping".
+pub trait Wrap<W: Into<Self>>: Sized {
+    /// Wraps a reference.
+    fn wrap(&self) -> &W;
+}
+
+/// `Wrap` is reflexive.
+impl<T: Sized> Wrap<T> for T {
+    fn wrap(&self) -> &Self {
+        self
+    }
+}

--- a/bee-common/bee-packable/tests/packable.rs
+++ b/bee-common/bee-packable/tests/packable.rs
@@ -11,7 +11,8 @@ use core::{fmt::Debug, mem::size_of};
 fn pack_checked<P>(value: P) -> VecPacker
 where
     P: Packable + Eq + Debug,
-    P::Error: Debug,
+    P::UnpackError: Debug,
+    P::PackError: Debug,
 {
     let mut packer = VecPacker::default();
     value.pack(&mut packer).unwrap();
@@ -90,9 +91,10 @@ fn packable_array() {
 fn pack_new_checked<P>(value: P) -> Vec<u8>
 where
     P: Packable + Eq + Debug,
-    P::Error: Debug,
+    P::PackError: Debug,
+    P::UnpackError: Debug,
 {
-    let bytes = value.pack_new();
+    let bytes = value.pack_new().unwrap();
 
     let mut unpacker = SliceUnpacker::new(&bytes.as_slice());
     let result: P = Packable::unpack(&mut unpacker).unwrap();

--- a/docs/dev/specs/packable.md
+++ b/docs/dev/specs/packable.md
@@ -100,11 +100,13 @@ pub trait Packable: Sized {
 
     fn packed_len(&self) -> usize;
 
+    fn pack_new(&self) -> Result<Vec<u8>, Self::PackError> { ... }
+
     fn unpack<U: Unpacker>(unpacker: &mut U) -> Result<Self, UnpackError<Self::Error, U::Error>>;
 }
 ```
 
-- The `PackError` and `UnpackError` associated type represent a semantic errors
+- The `PackError` and `UnpackError` associated types represent semantic errors
   while packing and unpacking respectively.
 
 - The `pack` method serializes the current value using a `Packer` to write the
@@ -271,13 +273,13 @@ derived for a type that contains a field which has a custom implementation of
 `Packable::PackError` or `Packable::UnpackError` type different from
 `Infallible`. In that case the user can specify a custom error type using the
 `#[packable(pack_error = ...)]` and `#[packable(unpack_error = ...)]`
-attributes. The type used in these attribute must implement `From<E>` where `E`
-can be the associated error types of any field of the type.
+attributes. The type used in these attributes must implement `From<E>` where
+`E` can be the associated error types of any field of the type.
 
 ### Wrapped views
 
 Some types might be packed and unpacked in different ways. An example of this
-are collections with dynamic-lengthas most of them are packed by prefixing
+are collections with dynamic-length as most of them are packed by prefixing
 their length. However, the integer type used to encode the length prefix might
 change according to the context.
 

--- a/docs/dev/specs/packable.md
+++ b/docs/dev/specs/packable.md
@@ -93,9 +93,10 @@ The new `Packable` trait is the following
 
 ```rust
 pub trait Packable: Sized {
-    type Error;
+    type PackError;
+    type UnpackError;
 
-    fn pack<P: Packer>(&self, packer: &mut P) -> Result<(), P::Error>;
+    fn pack<P: Packer>(&self, packer: &mut P) -> Result<(), PackError<Self::Error, P::Error>>;
 
     fn packed_len(&self) -> usize;
 
@@ -103,7 +104,8 @@ pub trait Packable: Sized {
 }
 ```
 
-- The `Error` associated type represents a semantic error.
+- The `PackError` and `UnpackError` associated type represent a semantic errors
+  while packing and unpacking respectively.
 
 - The `pack` method serializes the current value using a `Packer` to write the
   bytes.
@@ -120,19 +122,22 @@ pub trait Packable: Sized {
 In addition to the three `Error` associated types mentioned before, we provide
 two new helper error types:
 
+- The `PackError` type which is an enum wrapping values of either the
+  `Packable::PackError` or `Packer::Error` type.
+
 - The `UnpackError` type which is an enum wrapping values of either the
-  `Packable::Error` or `Unpacker::Error` type.
+  `Packable::UnpackError` or `Unpacker::Error` type.
 
 - The `UnknownTagError` type which can be used if the prefix tag used to
   represent the variant of an enum does not correspond to any variant of such
-  enum. As a convention, any `Packable::Error` type for an enum must implement
-  `From<UnknownTagError>` (this is not enforced in the trait itself because
-  this error is not used for structs).
+  enum. As a convention, any `Packable::UnpackError` type for an enum must
+  implement `From<UnknownTagError>` (this is not enforced in the trait itself
+  because this error is not used for structs).
 
-We also use `core::convert::Infallible` as `Packable::Error` for types whose
-unpacking does not have semantic errors, like integers for example. A more
-grounded explanation of error handling can be found in the *the `derive` macro*
-section.
+We also use `core::convert::Infallible` as `Packable::PackError` and
+`Packable::UnpackError` for types whose unpacking does not have semantic
+errors, like integers for example. A more grounded explanation of error
+handling can be found in the *the `derive` macro* section.
 
 ## `Packable` for basic types
 
@@ -165,16 +170,19 @@ is being packed.
 
 ```rust
 use bee_packable::{
-    error::{UnknownTagError, UnpackError},
+    error::{UnknownTagError, PackError, UnpackError},
     packer::Packer,
     unpacker::Unpacker,
     Packable,
 };
 
-impl Packable for Maybe {
-    type Error = UnknownTagError<u8>;
+use core::convert::Infallible;
 
-    fn pack<P: Packer>(&self, packer: &mut P) -> Result<(), P::Error> {
+impl Packable for Maybe {
+    type PackError = Infallible;
+    type UnpackError = UnknownTagError<u8>;
+
+    fn pack<P: Packer>(&self, packer: &mut P) -> Result<(), PackError<Self::PackError, P::Error>> {
         match self {
             Self::Nothing => 0u8.pack(packer),
             Self::Just(value) => {
@@ -191,7 +199,7 @@ impl Packable for Maybe {
         }
     }
 
-    fn unpack<U: Unpacker>(unpacker: &mut U) -> Result<Self, UnpackError<Self::Error, U::Error>> {
+    fn unpack<U: Unpacker>(unpacker: &mut U) -> Result<Self, UnpackError<Self::UnpackError, U::Error>> {
         match u8::unpack(unpacker).map_err(UnpackError::coerce)? {
             0u8 => Ok(Self::Nothing),
             1u8 => Ok(Self::Just(i32::unpack(unpacker).map_err(UnpackError::coerce)?)),
@@ -208,7 +216,7 @@ provides an implementation equivalent to the one written before.
 
 ```rust
 use bee_packable::{
-    error::{UnknownTagError, UnpackError},
+    error::{UnknownTagError, PackError, UnpackError},
     packer::Packer,
     unpacker::Unpacker,
     Packable,
@@ -250,18 +258,51 @@ The `tag_type` and `tag` attributes are mandatory for enums. Additionally the
 Following the example above, unpacking a `Maybe` value that starts with a `tag`
 value different from `0` or `1` should fail. To represent this kind of error we
 introduced the `UnknownTagError<T>` type. This type is used as
-`Packable::Error` when deriving `Packable` for an enum, the `T` type used is
+`Packable::UnpackError` when deriving `Packable` for an enum, the `T` type used is
 the one specified in the `tag_type` attribute. Additionally, we use the
-`std::convert::Infallible` type as `Packable::Error` for structs by default.
+`core::convert::Infallible` type as `Packable::UnpackError` for structs by
+default. For the `Packable::PackError` type we use `core::convert::Infallible`
+by default for all the types.
 
 However, sometimes it is necessary to use a different error type when deriving
 `Packable`. Two examples where this can happen are when `Packable` is being
 derived for a type that contains a field which has a custom implementation of
 `Packable` or when `Packable` is being derived for a struct whose fields use a
-`Packable::Error` type different from `Infallible`. In that case the user can
-specify a custom error type using the `#[packable(error = ...)]` attribute. The
-type used in this attribute must implement `From<E>` where `E` can be the
-`Packable::Error` associated type of any field of the type.
+`Packable::PackError` or `Packable::UnpackError` type different from
+`Infallible`. In that case the user can specify a custom error type using the
+`#[packable(pack_error = ...)]` and `#[packable(unpack_error = ...)]`
+attributes. The type used in these attribute must implement `From<E>` where `E`
+can be the associated error types of any field of the type.
+
+### Wrapped views
+
+Some types might be packed and unpacked in different ways. An example of this
+are collections with dynamic-lengthas most of them are packed by prefixing
+their length. However, the integer type used to encode the length prefix might
+change according to the context.
+
+To solve this we introduce the `Wrap<W>` trait. We read `A: Wrap<B>` as `B` is
+a wrapper for `A`. This trait has the following form:
+
+```rust
+pub trait Wrap<W: Into<Self>>: Sized {
+    fn wrap(&self) -> &W;
+}
+```
+
+The `Wrap::wrap` method wraps a reference of `Self` into a reference of `W` and
+it is used before packing. Additionally `W` must implement `Into<Self>` so we
+can "unwrap" a value after unpacking it.
+
+Both of these operations are infallible, which means that any error must be
+raised while packing or unpacking the wrapped value itself.
+
+We provide the type `VecPrefix<T, P>` which is a wrapper for `Vec<T>` that
+packs its length-prefix using the type `P` instead of `usize`.
+
+This functionality is intended to be used from the derive macro adding the
+`#[packable(wrapper = ...)]` attribute to the field that the user wants to
+wrap.
 
 ## Optional features
 
@@ -275,10 +316,11 @@ There is only one optional feature for this crate:
 
 ## Error coercion
 
-One disadvantage of using `UnpackError` as the error variant returned by the
-`Packable::unpack` method is that conversions between errors must be explicit.
-As seen in the `Maybe` example, we use the `UnpackError::coerce` method to map
-the error variant to an appropiate type. The signature of this method is
+One disadvantage of using `PackError` and `UnpackError` as the error variant
+returned by the `Packable::pack` and `Packable::unpack` methods is that
+conversions between errors must be explicit.  As seen in the `Maybe` example,
+we use the `UnpackError::coerce` method to map the error variant to an
+appropiate type. The signature of this method is
 
 ```rust
 impl<T, U> UnpackError<T, U> {
@@ -287,9 +329,9 @@ impl<T, U> UnpackError<T, U> {
 ```
 
 and it takes care of mapping the `UnpackError::Packable` variant from `T` to
-`V`. At first sight this could be solved by implementing `From<UnpackError<T,
-U>>` for `UnpackError<V, U>`. However, that implementation would overlap with
-the existing implementations in the standard library.
+`V`. At first sight this could be solved by implementing `From<UnpackError<T, U>>`
+for `UnpackError<V, U>`. However, that implementation would overlap with the
+existing implementations in the standard library.
 
 In a similar fashion we introduced a `UnpackError::infallible` method with the
 following signature
@@ -302,7 +344,7 @@ impl<U> UnpackError<Infallible, U> {
 
 with the same philosophy. It is not possible to provide a single `coerce`
 method for both operations because of the same reasons around using the `From`
-trait.
+trait. These methods also exist for the `PackError` enum.
 
 # Alternatives
 


### PR DESCRIPTION
~~This is a WIP but the core idea is there and it can be reviewed as such.~~
The main changes here are:
1. A new `PackError` associated type was added to `Packable`, which means that packing a value is no longer infallible. An example of this is `VecPrefix<T, P>` where `P` is not large enough to fit a value of type `usize`. 
    - This also include two new errors `PackPrefixError` and `UnpackPrefixError` that can be used for every prefix wrapper. 
    - In the derive macro, we have `pack_error` and `unpack_error` instead of just `error`. `PackError` is `Infallible` by default.
2. A new `Wrap` trait was added that behaves like a combination of `AsRef` in one direction and `Into` in the other. This allows us to "see" every `&Vec<T>` as a `&VecPrefix<T, P>` and convert every `VecPrefix<T, P>`  into a `Vec<T>`.
3. A new `wrapper` attribute was added to the derive macro allowing us to "wrap" a field before packing and "unwrap" it after unpacking.

The MO here is that wrapping and unwrapping are infallible (see 2). But packing and unpacking wrappers takes care of checking that the length-prefix fits in the prefix type (see 1).
