### PR TITLE
Add `unpack_from_slice` method to `Packable`

### DIFF
--- a/bee-common/bee-packable/src/packable/mod.rs
+++ b/bee-common/bee-packable/src/packable/mod.rs
@@ -52,7 +52,7 @@ pub trait Packable: Sized {
     fn packed_len(&self) -> usize;
 
     /// Convenience method that packs this value into a `Vec<u8>`.
-    fn pack_new(&self) -> Result<Vec<u8>, Self::PackError> {
+    fn pack_to_vec(&self) -> Result<Vec<u8>, Self::PackError> {
         let mut packer = VecPacker::with_capacity(self.packed_len());
 
         // Packing to bytes will not fail but packing the value itself might.
@@ -68,7 +68,7 @@ pub trait Packable: Sized {
     fn unpack<U: Unpacker>(unpacker: &mut U) -> Result<Self, UnpackError<Self::UnpackError, U::Error>>;
 
     /// Unpacks this value from a type that implements `AsRef<[u8]>`.
-    fn unpack_from_bytes<T: AsRef<[u8]>>(bytes: T) -> Result<Self, UnpackError<Self::UnpackError, UnexpectedEOF>> {
+    fn unpack_from_slice<T: AsRef<[u8]>>(bytes: T) -> Result<Self, UnpackError<Self::UnpackError, UnexpectedEOF>> {
         let mut unpacker = SliceUnpacker::new(bytes.as_ref());
         Packable::unpack(&mut unpacker)
     }

--- a/bee-common/bee-packable/src/packable/mod.rs
+++ b/bee-common/bee-packable/src/packable/mod.rs
@@ -25,6 +25,7 @@ pub use crate::{
 pub use bee_packable_derive::Packable;
 
 use alloc::vec::Vec;
+use core::convert::AsRef;
 
 /// A type that can be packed and unpacked.
 ///
@@ -56,4 +57,10 @@ pub trait Packable: Sized {
 
     /// Unpacks this value from the given `Unpacker`.
     fn unpack<U: Unpacker>(unpacker: &mut U) -> Result<Self, UnpackError<Self::Error, U::Error>>;
+
+    /// Unpacks this value from a type that implements `AsRef<[u8]>`.
+    fn unpack_from_bytes<T: AsRef<[u8]>>(bytes: T) -> Result<Self, UnpackError<Self::Error, UnexpectedEOF>> {
+        let mut unpacker = SliceUnpacker::new(bytes.as_ref());
+        Packable::unpack(&mut unpacker)
+    }
 }

--- a/bee-common/bee-packable/src/packable/mod.rs
+++ b/bee-common/bee-packable/src/packable/mod.rs
@@ -45,7 +45,7 @@ pub trait Packable: Sized {
     /// `UnknownTagError` when implementing this trait for an enum.
     type UnpackError;
 
-    /// Pack this value into the given `Packer`.
+    /// Packs this value into the given `Packer`.
     fn pack<P: Packer>(&self, packer: &mut P) -> Result<(), PackError<Self::PackError, P::Error>>;
 
     /// The size of the value in bytes after being packed.
@@ -64,7 +64,7 @@ pub trait Packable: Sized {
         Ok(packer.into_vec())
     }
 
-    /// Unpack this value from the given `Unpacker`.
+    /// Unpacks this value from the given `Unpacker`.
     fn unpack<U: Unpacker>(unpacker: &mut U) -> Result<Self, UnpackError<Self::UnpackError, U::Error>>;
 
     /// Unpacks this value from a type that implements `AsRef<[u8]>`.

--- a/bee-common/bee-packable/tests/packable.rs
+++ b/bee-common/bee-packable/tests/packable.rs
@@ -204,9 +204,10 @@ pack_new_vec_prefix!(pack_new_vec_prefix_u128, u128);
 fn round_trip<P>(value: P)
 where
     P: Packable + Eq + Debug,
-    P::Error: Debug,
+    P::PackError: Debug,
+    P::UnpackError: Debug,
 {
-    let bytes = value.pack_new();
+    let bytes = value.pack_new().unwrap();
     let unpacked = Packable::unpack_from_bytes(&bytes).unwrap();
 
     assert_eq!(value, unpacked);

--- a/bee-common/bee-packable/tests/packable.rs
+++ b/bee-common/bee-packable/tests/packable.rs
@@ -198,3 +198,41 @@ pack_new_vec_prefix!(pack_new_vec_prefix_u32, u32);
 pack_new_vec_prefix!(pack_new_vec_prefix_u64, u64);
 #[cfg(has_u128)]
 pack_new_vec_prefix!(pack_new_vec_prefix_u128, u128);
+
+fn round_trip<P>(value: P)
+where
+    P: Packable + Eq + Debug,
+    P::Error: Debug,
+{
+    let bytes = value.pack_new();
+    let unpacked = Packable::unpack_from_bytes(&bytes).unwrap();
+
+    assert_eq!(value, unpacked);
+}
+
+macro_rules! impl_round_trip_test {
+    ($name:ident, $value:expr) => {
+        #[test]
+        fn $name() {
+            round_trip($value);
+        }
+    };
+}
+
+impl_round_trip_test!(round_trip_i8, 0x6Fi8);
+impl_round_trip_test!(round_trip_u8, 0x6Fu8);
+impl_round_trip_test!(round_trip_i16, 0x6F7Bi16);
+impl_round_trip_test!(round_trip_u16, 0x6F7Bu16);
+impl_round_trip_test!(round_trip_i32, 0x6F7BD423i32);
+impl_round_trip_test!(round_trip_u32, 0x6F7BD423u32);
+impl_round_trip_test!(round_trip_i64, 0x6F7BD423100423DBi64);
+impl_round_trip_test!(round_trip_u64, 0x6F7BD423100423DBu64);
+#[cfg(has_i128)]
+impl_round_trip_test!(round_trip_i128, 0x6F7BD423100423DBFF127B91CA0AB123i128);
+#[cfg(has_u128)]
+impl_round_trip_test!(round_trip_u128, 0x6F7BD423100423DBFF127B91CA0AB123u128);
+
+impl_round_trip_test!(round_trip_bool, true);
+impl_round_trip_test!(round_trip_option, Some(42u32));
+impl_round_trip_test!(round_trip_vector, vec![Some(0u32), None]);
+impl_round_trip_test!(round_trip_array, [42u8; 1024]);

--- a/bee-common/bee-packable/tests/packable.rs
+++ b/bee-common/bee-packable/tests/packable.rs
@@ -88,13 +88,13 @@ fn packable_array() {
     assert_eq!(pack_checked([42u8; 1024]).len(), 1024 * size_of::<u8>());
 }
 
-fn pack_new_checked<P>(value: P) -> Vec<u8>
+fn pack_to_vec_checked<P>(value: P) -> Vec<u8>
 where
     P: Packable + Eq + Debug,
     P::PackError: Debug,
     P::UnpackError: Debug,
 {
-    let bytes = value.pack_new().unwrap();
+    let bytes = value.pack_to_vec().unwrap();
 
     let mut unpacker = SliceUnpacker::new(&bytes.as_slice());
     let result: P = Packable::unpack(&mut unpacker).unwrap();
@@ -105,57 +105,57 @@ where
     bytes
 }
 
-macro_rules! impl_pack_new_test_for_num {
+macro_rules! impl_pack_to_vec_test_for_num {
     ($name:ident, $ty:ident, $value:expr) => {
         #[test]
         fn $name() {
             let value: $ty = $value;
-            let bytes = pack_new_checked(value);
+            let bytes = pack_to_vec_checked(value);
             assert_eq!(bytes.len(), size_of::<$ty>());
         }
     };
 }
 
-impl_pack_new_test_for_num!(pack_new_i8, i8, 0x6F);
-impl_pack_new_test_for_num!(pack_new_u8, u8, 0x6F);
-impl_pack_new_test_for_num!(pack_new_i16, i16, 0x6F7B);
-impl_pack_new_test_for_num!(pack_new_u16, u16, 0x6F7B);
-impl_pack_new_test_for_num!(pack_new_i32, i32, 0x6F7BD423);
-impl_pack_new_test_for_num!(pack_new_u32, u32, 0x6F7BD423);
-impl_pack_new_test_for_num!(pack_new_i64, i64, 0x6F7BD423100423DB);
-impl_pack_new_test_for_num!(pack_new_u64, u64, 0x6F7BD423100423DB);
+impl_pack_to_vec_test_for_num!(pack_to_vec_i8, i8, 0x6F);
+impl_pack_to_vec_test_for_num!(pack_to_vec_u8, u8, 0x6F);
+impl_pack_to_vec_test_for_num!(pack_to_vec_i16, i16, 0x6F7B);
+impl_pack_to_vec_test_for_num!(pack_to_vec_u16, u16, 0x6F7B);
+impl_pack_to_vec_test_for_num!(pack_to_vec_i32, i32, 0x6F7BD423);
+impl_pack_to_vec_test_for_num!(pack_to_vec_u32, u32, 0x6F7BD423);
+impl_pack_to_vec_test_for_num!(pack_to_vec_i64, i64, 0x6F7BD423100423DB);
+impl_pack_to_vec_test_for_num!(pack_to_vec_u64, u64, 0x6F7BD423100423DB);
 #[cfg(has_i128)]
-impl_pack_new_test_for_num!(pack_new_i128, i128, 0x6F7BD423100423DBFF127B91CA0AB123);
+impl_pack_to_vec_test_for_num!(pack_to_vec_i128, i128, 0x6F7BD423100423DBFF127B91CA0AB123);
 #[cfg(has_u128)]
-impl_pack_new_test_for_num!(pack_new_u128, u128, 0x6F7BD423100423DBFF127B91CA0AB123);
+impl_pack_to_vec_test_for_num!(pack_to_vec_u128, u128, 0x6F7BD423100423DBFF127B91CA0AB123);
 
 #[test]
-fn pack_new_bool() {
-    assert_eq!(pack_new_checked(false).len(), size_of::<u8>());
-    assert_eq!(pack_new_checked(true).len(), size_of::<u8>());
+fn pack_to_vec_bool() {
+    assert_eq!(pack_to_vec_checked(false).len(), size_of::<u8>());
+    assert_eq!(pack_to_vec_checked(true).len(), size_of::<u8>());
 }
 
 #[test]
-fn pack_new_option() {
-    assert_eq!(pack_new_checked(Option::<u64>::None).len(), size_of::<u8>());
+fn pack_to_vec_option() {
+    assert_eq!(pack_to_vec_checked(Option::<u64>::None).len(), size_of::<u8>());
     assert_eq!(
-        pack_new_checked(Option::<u64>::Some(42)).len(),
+        pack_to_vec_checked(Option::<u64>::Some(42)).len(),
         size_of::<u8>() + size_of::<u64>()
     );
 }
 
 #[test]
-fn pack_new_vector() {
-    assert_eq!(pack_new_checked(Vec::<u32>::new()).len(), size_of::<u64>());
+fn pack_to_vec_vector() {
+    assert_eq!(pack_to_vec_checked(Vec::<u32>::new()).len(), size_of::<u64>());
     assert_eq!(
-        pack_new_checked(vec![Some(0u32), None]).len(),
+        pack_to_vec_checked(vec![Some(0u32), None]).len(),
         size_of::<u64>() + (size_of::<u8>() + size_of::<u32>()) + size_of::<u8>()
     );
 }
 
 #[test]
-fn pack_new_array() {
-    assert_eq!(pack_new_checked([42u8; 1024]).len(), 1024 * size_of::<u8>());
+fn pack_to_vec_array() {
+    assert_eq!(pack_to_vec_checked([42u8; 1024]).len(), 1024 * size_of::<u8>());
 }
 
 macro_rules! packable_vec_prefix {
@@ -178,28 +178,28 @@ packable_vec_prefix!(packable_vec_prefix_u64, u64);
 #[cfg(has_u128)]
 packable_vec_prefix!(packable_vec_prefix_u128, u128);
 
-macro_rules! pack_new_vec_prefix {
+macro_rules! pack_to_vec_vec_prefix {
     ($name:ident, $ty:ty) => {
         #[test]
         fn $name() {
             assert_eq!(
-                pack_new_checked(VecPrefix::<u32, $ty>::new()).len(),
+                pack_to_vec_checked(VecPrefix::<u32, $ty>::new()).len(),
                 size_of::<$ty>()
             );
             assert_eq!(
-                pack_new_checked(VecPrefix::<Option<u32>, $ty>::from(vec![Some(0u32), None])).len(),
+                pack_to_vec_checked(VecPrefix::<Option<u32>, $ty>::from(vec![Some(0u32), None])).len(),
                 size_of::<$ty>() + (size_of::<u8>() + size_of::<u32>()) + size_of::<u8>()
             );
         }
     };
 }
 
-pack_new_vec_prefix!(pack_new_vec_prefix_u8, u8);
-pack_new_vec_prefix!(pack_new_vec_prefix_u16, u16);
-pack_new_vec_prefix!(pack_new_vec_prefix_u32, u32);
-pack_new_vec_prefix!(pack_new_vec_prefix_u64, u64);
+pack_to_vec_vec_prefix!(pack_to_vec_vec_prefix_u8, u8);
+pack_to_vec_vec_prefix!(pack_to_vec_vec_prefix_u16, u16);
+pack_to_vec_vec_prefix!(pack_to_vec_vec_prefix_u32, u32);
+pack_to_vec_vec_prefix!(pack_to_vec_vec_prefix_u64, u64);
 #[cfg(has_u128)]
-pack_new_vec_prefix!(pack_new_vec_prefix_u128, u128);
+pack_to_vec_vec_prefix!(pack_to_vec_vec_prefix_u128, u128);
 
 fn round_trip<P>(value: P)
 where
@@ -207,8 +207,8 @@ where
     P::PackError: Debug,
     P::UnpackError: Debug,
 {
-    let bytes = value.pack_new().unwrap();
-    let unpacked = Packable::unpack_from_bytes(&bytes).unwrap();
+    let bytes = value.pack_to_vec().unwrap();
+    let unpacked = Packable::unpack_from_slice(&bytes).unwrap();
 
     assert_eq!(value, unpacked);
 }

--- a/docs/dev/specs/packable.md
+++ b/docs/dev/specs/packable.md
@@ -100,11 +100,11 @@ pub trait Packable: Sized {
 
     fn packed_len(&self) -> usize;
 
-    fn pack_new(&self) -> Result<Vec<u8>, Self::PackError> { ... }
+    fn pack_to_vec(&self) -> Result<Vec<u8>, Self::PackError> { ... }
 
     fn unpack<U: Unpacker>(unpacker: &mut U) -> Result<Self, UnpackError<Self::Error, U::Error>>;
 
-    fn unpack_from_bytes<T: AsRef<[u8]>>(bytes: T) -> Result<Self, UnpackError<Self::Error, UnexpectedEOF>> { ... }
+    fn unpack_from_slice<T: AsRef<[u8]>>(bytes: T) -> Result<Self, UnpackError<Self::Error, UnexpectedEOF>> { ... }
 }
 ```
 
@@ -118,12 +118,12 @@ pub trait Packable: Sized {
   This has to match the number of bytes written using `pack` to avoid
   inconsistencies.
 
-- The `pack_new` method provides convenience functionality to easily serialize the current value into a `Vec<u8>`.
+- The `pack_to_vec` method provides convenience functionality to easily serialize the current value into a `Vec<u8>`.
 
 - The `unpack` method deserializes a value using an `Unpacker` to read the
   bytes.
 
-- The `unpack_from_bytes` method provides convenience functionality to deserialize a value from any type that implements `AsRef<[u8]>`.
+- The `unpack_from_slice` method provides convenience functionality to deserialize a value from any type that implements `AsRef<[u8]>`.
 
 ## Error handling
 

--- a/docs/dev/specs/packable.md
+++ b/docs/dev/specs/packable.md
@@ -103,6 +103,8 @@ pub trait Packable: Sized {
     fn pack_new(&self) -> Result<Vec<u8>, Self::PackError> { ... }
 
     fn unpack<U: Unpacker>(unpacker: &mut U) -> Result<Self, UnpackError<Self::Error, U::Error>>;
+
+    fn unpack_from_bytes<T: AsRef<[u8]>>(bytes: T) -> Result<Self, UnpackError<Self::Error, UnexpectedEOF>> { ... }
 }
 ```
 
@@ -116,8 +118,12 @@ pub trait Packable: Sized {
   This has to match the number of bytes written using `pack` to avoid
   inconsistencies.
 
+- The `pack_new` method provides convenience functionality to easily serialize the current value into a `Vec<u8>`.
+
 - The `unpack` method deserializes a value using an `Unpacker` to read the
   bytes.
+
+- The `unpack_from_bytes` method provides convenience functionality to deserialize a value from any type that implements `AsRef<[u8]>`.
 
 ## Error handling
 


### PR DESCRIPTION
# Description of change

Adds an `unpack_from_slice` method to the `Packable` trait, to conveniently unpack anything that implements `AsRef<[u8]>` in one call, without exposing any `Packable` internals.

## Type of change

- Enhancement (a non-breaking change which adds functionality)

## How the change has been tested

Added round-trip tests using this functionality for primitive types.

## Change checklist

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that new and existing unit tests pass locally with my changes
- [ ] I have updated the CHANGELOG.md, if my changes are significant enough
