### PR TITLE
Use "better" default error types for `Packable`

### DIFF
--- a/bee-common/bee-packable-derive/src/lib.rs
+++ b/bee-common/bee-packable-derive/src/lib.rs
@@ -28,14 +28,14 @@ pub fn packable(input: TokenStream) -> TokenStream {
         ..
     } = parse_macro_input!(input);
     // Parse a `pack_error` attribute if the input has one.
-    let pack_error_type = match packable::parse_attr::<Type>("pack_error", &attrs) {
+    let mut pack_error_type = match packable::parse_attr::<Type>("pack_error", &attrs) {
         Some(Ok(ty)) => Some(ty.into_token_stream()),
         Some(Err(span)) => abort!(span, "The `pack_error` attribute requires a type for its value."),
         None => None,
     };
 
     // Parse an `unpack_error` attribute if the input has one.
-    let unpack_error_type = match packable::parse_attr::<Type>("unpack_error", &attrs) {
+    let mut unpack_error_type = match packable::parse_attr::<Type>("unpack_error", &attrs) {
         Some(Ok(ty)) => Some(ty.into_token_stream()),
         Some(Err(span)) => abort!(span, "The `unpack_error` attribute requires a type for its value."),
         None => None,
@@ -43,12 +43,16 @@ pub fn packable(input: TokenStream) -> TokenStream {
 
     match data {
         Data::Struct(data) => {
-            // Use `Infallible` if there was no pack_error attribute.
-            let pack_error_type = pack_error_type.unwrap_or_else(|| quote!(core::convert::Infallible));
-            // Use `Infallible` if there was no unpack_error attribute.
-            let unpack_error_type = unpack_error_type.unwrap_or_else(|| quote!(core::convert::Infallible));
             // Generate the implementation for the struct.
-            let (pack, packed_len, unpack) = packable::gen_bodies_for_struct(data.fields);
+            let (pack, packed_len, unpack) =
+                packable::gen_bodies_for_struct(data.fields, &mut pack_error_type, &mut unpack_error_type);
+            // Use `Infallible` if there was no pack_error attribute and the struct do not have
+            // fields.
+            let pack_error_type = pack_error_type.unwrap_or_else(|| quote!(core::convert::Infallible));
+            // Use `Infallible` if there was no unpack_error attribute and the struct do not have
+            // fields.
+            let unpack_error_type = unpack_error_type.unwrap_or_else(|| quote!(core::convert::Infallible));
+
             packable::gen_impl(
                 &ident,
                 &generics,
@@ -70,13 +74,26 @@ pub fn packable(input: TokenStream) -> TokenStream {
                     "Enums that derive `Packable` require a `#[packable(tag_type = ...)]` attribute."
                 ),
             };
-            // Use `Infallible` if there was no pack_error attribute.
-            let pack_error_type = pack_error_type.unwrap_or_else(|| quote!(core::convert::Infallible));
-            // Use `UnknownTagError` if there was no unpack_error attribute.
-            let unpack_error_type =
-                unpack_error_type.unwrap_or_else(|| quote!(bee_packable::error::UnknownTagError<#tag_ty>));
+            // Use `UnknownTagError` if there was no unpack_error attribute. We override this first
+            // because it is more reasonable to use `UnknownTagError` than the error provided by
+            // any field.
+            if unpack_error_type.is_none() {
+                unpack_error_type = Some(quote!(bee_packable::error::UnknownTagError<#tag_ty>));
+            }
             // Generate the implementation for the enum.
-            let (pack, packed_len, unpack) = packable::gen_bodies_for_enum(&data.variants, tag_ty);
+            let (pack, packed_len, unpack) = packable::gen_bodies_for_enum(
+                &data.variants,
+                tag_ty,
+                &mut pack_error_type,
+                // This reference will never be used inside `gen_bodies_for_enum`.
+                &mut unpack_error_type,
+            );
+            // Use `Infallible` if there was no pack_error attribute and the variants do not have
+            // fields.
+            let pack_error_type = pack_error_type.unwrap_or_else(|| quote!(core::convert::Infallible));
+            // This unwrap cannot fail Because we set its value before.
+            let unpack_error_type = unpack_error_type.unwrap();
+
             packable::gen_impl(
                 &ident,
                 &generics,

--- a/bee-common/bee-packable-derive/src/lib.rs
+++ b/bee-common/bee-packable-derive/src/lib.rs
@@ -91,7 +91,7 @@ pub fn packable(input: TokenStream) -> TokenStream {
             // Use `Infallible` if there was no pack_error attribute and the variants do not have
             // fields.
             let pack_error_type = pack_error_type.unwrap_or_else(|| quote!(core::convert::Infallible));
-            // This unwrap cannot fail Because we set its value before.
+            // This unwrap cannot fail because we set its value before.
             let unpack_error_type = unpack_error_type.unwrap();
 
             packable::gen_impl(

--- a/bee-common/bee-packable-derive/tests/packable/pass/default_errors.rs
+++ b/bee-common/bee-packable-derive/tests/packable/pass/default_errors.rs
@@ -22,18 +22,30 @@ pub enum Foo {
     Baz { x: i32, y: i32 },
 }
 
+#[derive(Packable)]
+pub struct Bar {
+    foo: Foo,
+}
+
 fn main() {
     assert_eq!(
         TypeId::of::<Infallible>(),
         TypeId::of::<<Point as Packable>::PackError>()
     );
-    assert_eq!(TypeId::of::<Infallible>(), TypeId::of::<<Foo as Packable>::PackError>());
     assert_eq!(
         TypeId::of::<Infallible>(),
         TypeId::of::<<Point as Packable>::UnpackError>()
     );
+
+    assert_eq!(TypeId::of::<Infallible>(), TypeId::of::<<Foo as Packable>::PackError>());
     assert_eq!(
         TypeId::of::<UnknownTagError<u8>>(),
         TypeId::of::<<Foo as Packable>::UnpackError>()
+    );
+
+    assert_eq!(TypeId::of::<Infallible>(), TypeId::of::<<Bar as Packable>::PackError>());
+    assert_eq!(
+        TypeId::of::<UnknownTagError<u8>>(),
+        TypeId::of::<<Bar as Packable>::UnpackError>()
     );
 }

--- a/docs/dev/specs/packable.md
+++ b/docs/dev/specs/packable.md
@@ -255,26 +255,23 @@ the packed version of `Maybe::Nothing` is `[0u8]` and the packed version of
 The `tag_type` and `tag` attributes are mandatory for enums. Additionally the
 `tag` for each variant must be unique inside the enum.
 
-### Invalid tag values and error handling
+### Associated error types
 
-Following the example above, unpacking a `Maybe` value that starts with a `tag`
-value different from `0` or `1` should fail. To represent this kind of error we
-introduced the `UnknownTagError<T>` type. This type is used as
-`Packable::UnpackError` when deriving `Packable` for an enum, the `T` type used is
-the one specified in the `tag_type` attribute. Additionally, we use the
-`core::convert::Infallible` type as `Packable::UnpackError` for structs by
-default. For the `Packable::PackError` type we use `core::convert::Infallible`
-by default for all the types.
+The derive macro provides two optional attributes `#[packable(pack_error = ...)]`
+and `#[packable(unpack_error = ...)]` to specify the `PackError` and
+`UnpackError` associated types. However, the macro provides sensible defaults
+for cases when the attributes are not specified.
 
-However, sometimes it is necessary to use a different error type when deriving
-`Packable`. Two examples where this can happen are when `Packable` is being
-derived for a type that contains a field which has a custom implementation of
-`Packable` or when `Packable` is being derived for a struct whose fields use a
-`Packable::PackError` or `Packable::UnpackError` type different from
-`Infallible`. In that case the user can specify a custom error type using the
-`#[packable(pack_error = ...)]` and `#[packable(unpack_error = ...)]`
-attributes. The type used in these attributes must implement `From<E>` where
-`E` can be the associated error types of any field of the type.
+For structs, we use the `PackError` and `UnpackError` types of any of the
+fields or `core::convert::Infallible` in case the struct has no fields.
+
+For enums, we use the `PackError` type of any of the fields of any of the
+variants or `core::convert::Infallible` if no variant has any fields. For
+`UnpackError` we use `UnknownTagError<T>` where `T` is the type specified with
+the `tag_ty` attribute.
+
+Following the example above, `Maybe::UnpackError` is `UnknownTagError<u8>`
+because no `unpack_error` attribute was specified.
 
 ### Wrapped views
 


### PR DESCRIPTION
# Description of change

This changes the default error types when deriving `Packable` for a type `T`:
- `T::PackError` gets assigned the `PackError` of one of the fields of `T` or `Infallible if `T` has no fields.
-  If `T` is a struct, `T::UnpackError` gets assigned the `UnpackError` of one of the fields of `T` or `Infallible` if `T` has no fields.
- `T::UnpackError` for enums remains unchanged.

This means that the following code

```rust
#[derive(Packable)]
struct Foo(Option<u32>);
```

compiles without specifying the error types.

## Type of change

- Enhancement (a non-breaking change which adds functionality)

## How the change has been tested

The tests for default error types were updated.

Make sure to provide instructions for the maintainer as well as any relevant configurations.

## Change checklist

Tick the boxes that are relevant to your changes, and delete any items that are not.

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that new and existing unit tests pass locally with my changes
- [ ] I have updated the CHANGELOG.md, if my changes are significant enough
