### PR TITLE
Re-run build script if git commit changes

### DIFF
--- a/bee-node/build.rs
+++ b/bee-node/build.rs
@@ -24,7 +24,7 @@ fn main() -> Result<(), BuildError> {
         Ok(output) => {
             println!("cargo:rerun-if-changed=../.git/HEAD");
             println!(
-                "cargo:rerun-if-changed=../.git/heads/{}",
+                "cargo:rerun-if-changed=../.git/refs/heads/{}",
                 String::from_utf8(output.stdout).unwrap(),
             );
         }

--- a/bee-node/build.rs
+++ b/bee-node/build.rs
@@ -6,6 +6,7 @@ use std::process::Command;
 #[derive(Debug)]
 enum BuildError {
     GitCommit,
+    GitBranch,
 }
 
 fn main() -> Result<(), BuildError> {
@@ -15,8 +16,20 @@ fn main() -> Result<(), BuildError> {
                 "cargo:rustc-env=GIT_COMMIT={}",
                 String::from_utf8(output.stdout).unwrap()
             );
-            Ok(())
         }
-        Err(_) => Err(BuildError::GitCommit),
+        Err(_) => return Err(BuildError::GitCommit),
     }
+
+    match Command::new("git").args(&["rev-parse", "--abbrev-ref", "HEAD"]).output() {
+        Ok(output) => {
+            println!("cargo:rerun-if-changed=../.git/HEAD");
+            println!(
+                "cargo:rerun-if-changed=../.git/heads/{}",
+                String::from_utf8(output.stdout).unwrap(),
+            );
+        }
+        Err(_) => return Err(BuildError::GitBranch),
+    }
+
+    Ok(())
 }


### PR DESCRIPTION
# Description of change

Tell cargo to re run the build script if the current commit changes.

## Links to any relevant issues

fixes issue #184 

## Type of change

- Bug fix (a non-breaking change which fixes an issue)

## How the change has been tested

- `cargo run -- -v` and check the version, should be equal to the one in `git rev-parse HEAD`.
- `echo "some changes" >> file.txt` and `git add file.txt && git commit -m "test"`
- `cargo run -- -v` and check that the commit shown in the version is updated.

## Change checklist

Tick the boxes that are relevant to your changes, and delete any items that are not.

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that new and existing unit tests pass locally with my changes
- [x] I have updated the CHANGELOG.md, if my changes are significant enough
