### PR TITLE
Skip `packable_is_structural` and `invalid_wrapper` for beta toolchain

### DIFF
--- a/bee-common/bee-packable-derive/tests/lib.rs
+++ b/bee-common/bee-packable-derive/tests/lib.rs
@@ -57,7 +57,7 @@ macro_rules! make_test {
 }
 
 // FIXME: change this when the new error message hits stable.
-#[rustversion::not(nightly)]
+#[rustversion::stable]
 make_test!(packable);
-#[rustversion::nightly]
+#[rustversion::not(stable)]
 make_test!(packable, packable_is_structural, invalid_wrapper);


### PR DESCRIPTION
# Description of change

Skips the `packable_is_structural` and `invalid_wrapper` tests for the `beta` toolchain, rather than just `nightly`. When the new messages become stable we can run all tests against them instead and remove this check.

## Links to any relevant issues

Encountered in #645.

## Type of change

- Bug fix (a non-breaking change which fixes an issue)

## How the change has been tested

Run tests locally on `stable`, `beta` and `nightly` toolchains, and everything passes. 

## Change checklist

Tick the boxes that are relevant to your changes, and delete any items that are not.

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that new and existing unit tests pass locally with my changes
- [ ] I have updated the CHANGELOG.md, if my changes are significant enough
