### PR TITLE
Replace usize by u64 in Packable impls

### DIFF
--- a/bee-common/bee-packable/src/packable/box.rs
+++ b/bee-common/bee-packable/src/packable/box.rs
@@ -38,7 +38,7 @@ impl<T: Packable> Packable for Box<[T]> {
 
     fn pack<P: Packer>(&self, packer: &mut P) -> Result<(), PackError<Self::PackError, P::Error>> {
         // The length of any dynamically-sized sequence must be prefixed.
-        self.len().pack(packer).map_err(PackError::infallible)?;
+        (self.len() as u64).pack(packer).map_err(PackError::infallible)?;
 
         for item in self.iter() {
             item.pack(packer)?;
@@ -48,7 +48,7 @@ impl<T: Packable> Packable for Box<[T]> {
     }
 
     fn packed_len(&self) -> usize {
-        0usize.packed_len() + self.iter().map(T::packed_len).sum::<usize>()
+        0u64.packed_len() + self.iter().map(T::packed_len).sum::<usize>()
     }
 
     fn unpack<U: Unpacker>(unpacker: &mut U) -> Result<Self, UnpackError<Self::UnpackError, U::Error>> {

--- a/bee-common/bee-packable/src/packable/vec.rs
+++ b/bee-common/bee-packable/src/packable/vec.rs
@@ -18,7 +18,7 @@ impl<T: Packable> Packable for Vec<T> {
 
     fn pack<P: Packer>(&self, packer: &mut P) -> Result<(), PackError<Self::PackError, P::Error>> {
         // The length of any dynamically-sized sequence must be prefixed.
-        self.len().pack(packer).map_err(PackError::infallible)?;
+        (self.len() as u64).pack(packer).map_err(PackError::infallible)?;
 
         for item in self.iter() {
             item.pack(packer)?;
@@ -28,14 +28,14 @@ impl<T: Packable> Packable for Vec<T> {
     }
 
     fn packed_len(&self) -> usize {
-        0usize.packed_len() + self.iter().map(T::packed_len).sum::<usize>()
+        0u64.packed_len() + self.iter().map(T::packed_len).sum::<usize>()
     }
 
     fn unpack<U: Unpacker>(unpacker: &mut U) -> Result<Self, UnpackError<Self::UnpackError, U::Error>> {
         // The length of any dynamically-sized sequence must be prefixed.
-        let len = usize::unpack(unpacker).map_err(UnpackError::infallible)?;
+        let len = u64::unpack(unpacker).map_err(UnpackError::infallible)?;
 
-        let mut vec = Self::with_capacity(len);
+        let mut vec = Self::with_capacity(len as usize);
 
         for _ in 0..len {
             let item = T::unpack(unpacker)?;


### PR DESCRIPTION
Replace uses of `usize` in `Packable` impls with `u64` to avoid issues with two different architectures using Packable to communicate. `u64` is the new default, a prefix impl needs to be used to change the default.

## Change checklist

Tick the boxes that are relevant to your changes, and delete any items that are not.

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that new and existing unit tests pass locally with my changes
- [x] I have updated the CHANGELOG.md, if my changes are significant enough
