### PR TITLE
Add maximum length parameter to `VecPrefix`

### DIFF
--- a/bee-common/bee-packable-derive/tests/packable/fail/invalid_wrapper.rs
+++ b/bee-common/bee-packable-derive/tests/packable/fail/invalid_wrapper.rs
@@ -11,7 +11,7 @@ use core::convert::Infallible;
 #[packable(pack_error = Infallible)]
 #[packable(unpack_error = Infallible)]
 pub struct Foo {
-    #[packable(wrapper = VecPrefix<u64, u8>)]
+    #[packable(wrapper = VecPrefix<u64, u8, 128>)]
     inner: Vec<u32>,
 }
 

--- a/bee-common/bee-packable-derive/tests/packable/fail/invalid_wrapper.stderr
+++ b/bee-common/bee-packable-derive/tests/packable/fail/invalid_wrapper.stderr
@@ -1,23 +1,23 @@
-error[E0277]: the trait bound `Vec<u32>: Wrap<VecPrefix<u64, u8>>` is not satisfied
+error[E0277]: the trait bound `Vec<u32>: Wrap<VecPrefix<u64, u8, 128_usize>>` is not satisfied
   --> $DIR/invalid_wrapper.rs:10:10
    |
 10 | #[derive(Packable)]
-   |          ^^^^^^^^ the trait `Wrap<VecPrefix<u64, u8>>` is not implemented for `Vec<u32>`
+   |          ^^^^^^^^ the trait `Wrap<VecPrefix<u64, u8, 128_usize>>` is not implemented for `Vec<u32>`
    |
    = help: the following implementations were found:
-             <Vec<T> as Wrap<VecPrefix<T, u128>>>
-             <Vec<T> as Wrap<VecPrefix<T, u16>>>
-             <Vec<T> as Wrap<VecPrefix<T, u32>>>
-             <Vec<T> as Wrap<VecPrefix<T, u64>>>
-             <Vec<T> as Wrap<VecPrefix<T, u8>>>
+             <Vec<T> as Wrap<VecPrefix<T, u128, N>>>
+             <Vec<T> as Wrap<VecPrefix<T, u16, N>>>
+             <Vec<T> as Wrap<VecPrefix<T, u32, N>>>
+             <Vec<T> as Wrap<VecPrefix<T, u64, N>>>
+             <Vec<T> as Wrap<VecPrefix<T, u8, N>>>
    = note: required by `wrap`
    = note: this error originates in a derive macro (in Nightly builds, run with -Z macro-backtrace for more info)
 
-error[E0277]: the trait bound `Vec<u32>: From<VecPrefix<u64, u8>>` is not satisfied
+error[E0277]: the trait bound `Vec<u32>: From<VecPrefix<u64, u8, 128_usize>>` is not satisfied
   --> $DIR/invalid_wrapper.rs:10:10
    |
 10 | #[derive(Packable)]
-   |          ^^^^^^^^ the trait `From<VecPrefix<u64, u8>>` is not implemented for `Vec<u32>`
+   |          ^^^^^^^^ the trait `From<VecPrefix<u64, u8, 128_usize>>` is not implemented for `Vec<u32>`
    |
    = help: the following implementations were found:
              <Vec<T, A> as From<Box<[T], A>>>
@@ -25,7 +25,7 @@ error[E0277]: the trait bound `Vec<u32>: From<VecPrefix<u64, u8>>` is not satisf
              <Vec<T> as From<&mut [T]>>
              <Vec<T> as From<BinaryHeap<T>>>
            and 6 others
-   = note: required because of the requirements on the impl of `Into<Vec<u32>>` for `VecPrefix<u64, u8>`
+   = note: required because of the requirements on the impl of `Into<Vec<u32>>` for `VecPrefix<u64, u8, 128_usize>`
    = note: required by `wrap`
    = note: this error originates in a derive macro (in Nightly builds, run with -Z macro-backtrace for more info)
 
@@ -43,11 +43,11 @@ help: consider introducing a `where` bound, but there might be an alternative be
 13 | pub struct Foo where PackError<Infallible, <P as bee_packable::Packer>::Error>: From<PackError<PackPrefixError<Infallible, u8>, <P as bee_packable::Packer>::Error>> {
    |                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-error[E0277]: the trait bound `Vec<u32>: From<VecPrefix<u64, u8>>` is not satisfied
+error[E0277]: the trait bound `Vec<u32>: From<VecPrefix<u64, u8, 128_usize>>` is not satisfied
   --> $DIR/invalid_wrapper.rs:10:10
    |
 10 | #[derive(Packable)]
-   |          ^^^^^^^^ the trait `From<VecPrefix<u64, u8>>` is not implemented for `Vec<u32>`
+   |          ^^^^^^^^ the trait `From<VecPrefix<u64, u8, 128_usize>>` is not implemented for `Vec<u32>`
    |
    = help: the following implementations were found:
              <Vec<T, A> as From<Box<[T], A>>>
@@ -55,7 +55,7 @@ error[E0277]: the trait bound `Vec<u32>: From<VecPrefix<u64, u8>>` is not satisf
              <Vec<T> as From<&mut [T]>>
              <Vec<T> as From<BinaryHeap<T>>>
            and 6 others
-   = note: required because of the requirements on the impl of `Into<Vec<u32>>` for `VecPrefix<u64, u8>`
+   = note: required because of the requirements on the impl of `Into<Vec<u32>>` for `VecPrefix<u64, u8, 128_usize>`
    = note: required by `into`
    = note: this error originates in a derive macro (in Nightly builds, run with -Z macro-backtrace for more info)
 

--- a/bee-common/bee-packable-derive/tests/packable/pass/vec_wrapper.rs
+++ b/bee-common/bee-packable-derive/tests/packable/pass/vec_wrapper.rs
@@ -15,7 +15,7 @@ use core::convert::Infallible;
 #[packable(pack_error = PackPrefixError<Infallible, u16>)]
 #[packable(unpack_error = UnpackPrefixError<Infallible, u16>)]
 pub struct Foo {
-    #[packable(wrapper = VecPrefix<u8, u16>)]
+    #[packable(wrapper = VecPrefix<u8, u16, 2>)]
     inner: Vec<u8>,
 }
 

--- a/bee-common/bee-packable/src/error.rs
+++ b/bee-common/bee-packable/src/error.rs
@@ -129,7 +129,7 @@ where
     /// Semantic error raised while unpacking the prefix of the sequence.
     Prefix(P::Error),
     /// Invalid prefix length (larger than maximum specified).
-    InvalidLength(usize),
+    InvalidPrefixLength(usize),
 }
 
 impl<T, P> From<T> for UnpackPrefixError<T, P>

--- a/bee-common/bee-packable/src/error.rs
+++ b/bee-common/bee-packable/src/error.rs
@@ -128,6 +128,8 @@ where
     Packable(T),
     /// Semantic error raised while unpacking the prefix of the sequence.
     Prefix(P::Error),
+    /// Invalid prefix length (larger than maximum specified).
+    InvalidLength(usize),
 }
 
 impl<T, P> From<T> for UnpackPrefixError<T, P>

--- a/bee-common/bee-packable/src/packable/mod.rs
+++ b/bee-common/bee-packable/src/packable/mod.rs
@@ -14,7 +14,7 @@ mod vec;
 mod vec_prefix;
 
 pub use option::UnpackOptionError;
-pub use vec_prefix::VecPrefix;
+pub use vec_prefix::{VecPrefix, PrefixedFromVecError};
 
 pub use crate::{
     error::{PackError, UnknownTagError, UnpackError},

--- a/bee-common/bee-packable/src/packable/mod.rs
+++ b/bee-common/bee-packable/src/packable/mod.rs
@@ -14,7 +14,7 @@ mod vec;
 mod vec_prefix;
 
 pub use option::UnpackOptionError;
-pub use vec_prefix::{VecPrefix, PrefixedFromVecError};
+pub use vec_prefix::{PrefixedFromVecError, VecPrefix};
 
 pub use crate::{
     error::{PackError, UnknownTagError, UnpackError},

--- a/bee-common/bee-packable/src/packable/vec_prefix.rs
+++ b/bee-common/bee-packable/src/packable/vec_prefix.rs
@@ -129,7 +129,7 @@ macro_rules! impl_packable_for_vec_prefix {
                 let len = usize::try_from(len).map_err(|err| UnpackError::Packable(UnpackPrefixError::Prefix(err)))?;
 
                 if len > N {
-                    return Err(UnpackError::Packable(UnpackPrefixError::InvalidLength(len)));
+                    return Err(UnpackError::Packable(UnpackPrefixError::InvalidPrefixLength(len)));
                 }
 
                 let mut vec = Self::with_capacity(len);

--- a/bee-common/bee-packable/src/packable/vec_prefix.rs
+++ b/bee-common/bee-packable/src/packable/vec_prefix.rs
@@ -17,7 +17,7 @@ use core::{convert::TryFrom, marker::PhantomData};
 /// Error encountered when attempting to convert a `Vec<T>` into a `VecPrefix`, where
 /// the length of the source vector exceeds the maximum length of the `VecPrefix`.
 #[derive(Debug, PartialEq, Eq)]
-pub struct FromVecError {
+pub struct PrefixedFromVecError {
     /// Maximum length of the `VecPrefix`.
     pub max_len: usize,
     /// Actual length of the source vector.
@@ -58,11 +58,11 @@ impl<T, P, const N: usize> Default for VecPrefix<T, P, N> {
 }
 
 impl<T, P, const N: usize> TryFrom<Vec<T>> for VecPrefix<T, P, N> {
-    type Error = FromVecError;
+    type Error = PrefixedFromVecError;
 
     fn try_from(vec: Vec<T>) -> Result<Self, Self::Error> {
         if vec.len() > N {
-            Err(FromVecError {
+            Err(PrefixedFromVecError {
                 max_len: N,
                 actual_len: vec.len(),
             })

--- a/bee-common/bee-packable/src/packable/vec_prefix.rs
+++ b/bee-common/bee-packable/src/packable/vec_prefix.rs
@@ -14,6 +14,16 @@ use crate::{
 use alloc::vec::Vec;
 use core::{convert::TryFrom, marker::PhantomData};
 
+/// Error encountered when attempting to convert a `Vec<T>` into a `VecPrefix`, where
+/// the length of the source vector exceeds the maximum length of the `VecPrefix`.
+#[derive(Debug, PartialEq, Eq)]
+pub struct FromVecError {
+    /// Maximum length of the `VecPrefix`.
+    pub max_len: usize,
+    /// Actual length of the source vector.
+    pub actual_len: usize,
+}
+
 /// Wrapper type for `Vec<T>` where the length prefix is of type `P`.
 /// The `Vec<T>`'s maximum length is provided by `N`.
 #[derive(Clone, Debug, Eq, PartialEq)]
@@ -47,11 +57,20 @@ impl<T, P, const N: usize> Default for VecPrefix<T, P, N> {
     }
 }
 
-impl<T, P, const N: usize> From<Vec<T>> for VecPrefix<T, P, N> {
-    fn from(vec: Vec<T>) -> Self {
-        Self {
-            inner: vec,
-            marker: PhantomData,
+impl<T, P, const N: usize> TryFrom<Vec<T>> for VecPrefix<T, P, N> {
+    type Error = FromVecError;
+
+    fn try_from(vec: Vec<T>) -> Result<Self, Self::Error> {
+        if vec.len() > N {
+            Err(FromVecError {
+                max_len: N,
+                actual_len: vec.len(),
+            })
+        } else {
+            Ok(Self {
+                inner: vec,
+                marker: PhantomData,
+            })
         }
     }
 }

--- a/bee-common/bee-packable/src/packable/vec_prefix.rs
+++ b/bee-common/bee-packable/src/packable/vec_prefix.rs
@@ -15,14 +15,15 @@ use alloc::vec::Vec;
 use core::{convert::TryFrom, marker::PhantomData};
 
 /// Wrapper type for `Vec<T>` where the length prefix is of type `P`.
+/// The `Vec<T>`'s maximum length is provided by `N`.
 #[derive(Clone, Debug, Eq, PartialEq)]
 #[repr(transparent)]
-pub struct VecPrefix<T, P> {
+pub struct VecPrefix<T, P, const N: usize> {
     inner: Vec<T>,
     marker: PhantomData<P>,
 }
 
-impl<T, P> VecPrefix<T, P> {
+impl<T, P, const N: usize> VecPrefix<T, P, N> {
     /// Creates a new empty `VecPrefix<T, P>`.
     pub fn new() -> Self {
         Self {
@@ -40,13 +41,13 @@ impl<T, P> VecPrefix<T, P> {
     }
 }
 
-impl<T, P> Default for VecPrefix<T, P> {
+impl<T, P, const N: usize> Default for VecPrefix<T, P, N> {
     fn default() -> Self {
         Self::new()
     }
 }
 
-impl<T, P> From<Vec<T>> for VecPrefix<T, P> {
+impl<T, P, const N: usize> From<Vec<T>> for VecPrefix<T, P, N> {
     fn from(vec: Vec<T>) -> Self {
         Self {
             inner: vec,
@@ -57,13 +58,13 @@ impl<T, P> From<Vec<T>> for VecPrefix<T, P> {
 
 /// We cannot provide a `From` implementation because `Vec` is not from this crate.
 #[allow(clippy::from_over_into)]
-impl<T, P> Into<Vec<T>> for VecPrefix<T, P> {
+impl<T, P, const N: usize> Into<Vec<T>> for VecPrefix<T, P, N> {
     fn into(self) -> Vec<T> {
         self.inner
     }
 }
 
-impl<T, P> core::ops::Deref for VecPrefix<T, P> {
+impl<T, P, const N: usize> core::ops::Deref for VecPrefix<T, P, N> {
     type Target = Vec<T>;
 
     fn deref(&self) -> &Self::Target {
@@ -71,7 +72,7 @@ impl<T, P> core::ops::Deref for VecPrefix<T, P> {
     }
 }
 
-impl<T, P> core::ops::DerefMut for VecPrefix<T, P> {
+impl<T, P, const N: usize> core::ops::DerefMut for VecPrefix<T, P, N> {
     fn deref_mut(&mut self) -> &mut Self::Target {
         &mut self.inner
     }
@@ -79,13 +80,13 @@ impl<T, P> core::ops::DerefMut for VecPrefix<T, P> {
 
 macro_rules! impl_wrap_for_vec {
     ($ty:ty) => {
-        impl<T> Wrap<VecPrefix<T, $ty>> for Vec<T> {
-            fn wrap(&self) -> &VecPrefix<T, $ty> {
+        impl<T, const N: usize> Wrap<VecPrefix<T, $ty, N>> for Vec<T> {
+            fn wrap(&self) -> &VecPrefix<T, $ty, N> {
                 // SAFETY: `VecPrefix` has a transparent representation and it is composed of one
                 // `Vec` field and an additional zero-sized type field. This means that `VecPrefix`
                 // has the same layout as `Vec` and any valid `Vec` reference can be casted into a
                 // valid `VecPrefix` reference.
-                unsafe { &*(self as *const Vec<T> as *const VecPrefix<T, $ty>) }
+                unsafe { &*(self as *const Vec<T> as *const VecPrefix<T, $ty, N>) }
             }
         }
     };
@@ -100,7 +101,7 @@ impl_wrap_for_vec!(u128);
 
 macro_rules! impl_packable_for_vec_prefix {
     ($ty:ty) => {
-        impl<T: Packable> Packable for VecPrefix<T, $ty> {
+        impl<T: Packable, const N: usize> Packable for VecPrefix<T, $ty, N> {
             type PackError = PackPrefixError<T::PackError, $ty>;
             type UnpackError = UnpackPrefixError<T::UnpackError, $ty>;
 
@@ -125,10 +126,13 @@ macro_rules! impl_packable_for_vec_prefix {
             fn unpack<U: Unpacker>(unpacker: &mut U) -> Result<Self, UnpackError<Self::UnpackError, U::Error>> {
                 // The length of any dynamically-sized sequence must be prefixed.
                 let len = <$ty>::unpack(unpacker).map_err(UnpackError::infallible)?;
+                let len = usize::try_from(len).map_err(|err| UnpackError::Packable(UnpackPrefixError::Prefix(err)))?;
 
-                let mut vec = Self::with_capacity(
-                    usize::try_from(len).map_err(|err| UnpackError::Packable(UnpackPrefixError::Prefix(err)))?,
-                );
+                if len > N {
+                    return Err(UnpackError::Packable(UnpackPrefixError::InvalidLength(len)));
+                }
+
+                let mut vec = Self::with_capacity(len);
 
                 for _ in 0..len {
                     let item = T::unpack(unpacker).map_err(UnpackError::coerce)?;

--- a/bee-common/bee-packable/tests/vec_prefix.rs
+++ b/bee-common/bee-packable/tests/vec_prefix.rs
@@ -12,13 +12,18 @@ macro_rules! impl_packable_test_for_vec_prefix {
         #[test]
         fn $name() {
             assert_eq!(
-                common::generic_test(&VecPrefix::<u32, $ty, MAX_LENGTH>::new()).0.len(),
+                common::generic_test(&VecPrefix::<u32, $ty, MAX_LENGTH>::new())
+                    .0
+                    .len(),
                 core::mem::size_of::<$ty>()
             );
             assert_eq!(
-                common::generic_test(&VecPrefix::<Option<u32>, $ty, MAX_LENGTH>::from(vec![Some(0u32), None]))
-                    .0
-                    .len(),
+                common::generic_test(&VecPrefix::<Option<u32>, $ty, MAX_LENGTH>::from(vec![
+                    Some(0u32),
+                    None
+                ]))
+                .0
+                .len(),
                 core::mem::size_of::<$ty>()
                     + (core::mem::size_of::<u8>() + core::mem::size_of::<u32>())
                     + core::mem::size_of::<u8>()

--- a/bee-common/bee-packable/tests/vec_prefix.rs
+++ b/bee-common/bee-packable/tests/vec_prefix.rs
@@ -10,9 +10,9 @@ use core::convert::TryFrom;
 const MAX_LENGTH: usize = 128;
 
 macro_rules! impl_packable_test_for_vec_prefix {
-    ($name:ident, $ty:ty) => {
+    ($packable_vec_prefix:ident, $packable_vec_prefix_invalid_length:ident, $ty:ty) => {
         #[test]
-        fn $name() {
+        fn $packable_vec_prefix() {
             assert_eq!(
                 common::generic_test(&VecPrefix::<u32, $ty, MAX_LENGTH>::new())
                     .0
@@ -30,20 +30,9 @@ macro_rules! impl_packable_test_for_vec_prefix {
                     + core::mem::size_of::<u8>()
             );
         }
-    };
-}
 
-impl_packable_test_for_vec_prefix!(packable_vec_prefix_u8, u8);
-impl_packable_test_for_vec_prefix!(packable_vec_prefix_u16, u16);
-impl_packable_test_for_vec_prefix!(packable_vec_prefix_u32, u32);
-impl_packable_test_for_vec_prefix!(packable_vec_prefix_u64, u64);
-#[cfg(has_u128)]
-impl_packable_test_for_vec_prefix!(packable_vec_prefix_u128, u128);
-
-macro_rules! impl_test_for_invalid_prefix_length {
-    ($name:ident, $ty:ty) => {
         #[test]
-        fn $name() {
+        fn $packable_vec_prefix_invalid_length() {
             let mut bytes = vec![0u8; MAX_LENGTH + 2];
             bytes[0] = MAX_LENGTH as u8 + 1;
 
@@ -57,15 +46,15 @@ macro_rules! impl_test_for_invalid_prefix_length {
     };
 }
 
-impl_test_for_invalid_prefix_length!(invalid_prefix_length_u8, u8);
-impl_test_for_invalid_prefix_length!(invalid_prefix_length_u16, u16);
-impl_test_for_invalid_prefix_length!(invalid_prefix_length_u32, u32);
-impl_test_for_invalid_prefix_length!(invalid_prefix_length_u64, u64);
+impl_packable_test_for_vec_prefix!(packable_vec_prefix_u8, packable_vec_prefix_invalid_length_u8, u8);
+impl_packable_test_for_vec_prefix!(packable_vec_prefix_u16, packable_vec_prefix_invalid_length_u16, u16);
+impl_packable_test_for_vec_prefix!(packable_vec_prefix_u32, packable_vec_prefix_invalid_length_u32, u32);
+impl_packable_test_for_vec_prefix!(packable_vec_prefix_u64, packable_vec_prefix_invalid_length_u64, u64);
 #[cfg(has_u128)]
-impl_test_for_invalid_prefix_length!(invalid_prefix_length_u128, u128);
+impl_packable_test_for_vec_prefix!(packable_vec_prefix_u128, packable_vec_prefix_invalid_length_u128, u128);
 
 #[test]
-fn from_vec_error() {
+fn packable_vec_prefix_from_vec_error() {
     let vec = vec![0u8; 16];
     let prefixed = VecPrefix::<u8, u32, 8>::try_from(vec);
 

--- a/bee-common/bee-packable/tests/vec_prefix.rs
+++ b/bee-common/bee-packable/tests/vec_prefix.rs
@@ -51,7 +51,7 @@ macro_rules! impl_test_for_invalid_prefix_length {
 
             assert!(matches!(
                 prefixed,
-                Err(UnpackError::Packable(UnpackPrefixError::InvalidPrefixLength(l))) if l == MAX_LENGTH + 1, 
+                Err(UnpackError::Packable(UnpackPrefixError::InvalidPrefixLength(l))) if l == MAX_LENGTH + 1,
             ));
         }
     };
@@ -69,5 +69,11 @@ fn from_vec_error() {
     let vec = vec![0u8; 16];
     let prefixed = VecPrefix::<u8, u32, 8>::try_from(vec);
 
-    assert!(matches!(prefixed, Err(PrefixedFromVecError { max_len: 8, actual_len: 16 })));
+    assert!(matches!(
+        prefixed,
+        Err(PrefixedFromVecError {
+            max_len: 8,
+            actual_len: 16
+        })
+    ));
 }

--- a/bee-common/bee-packable/tests/vec_prefix.rs
+++ b/bee-common/bee-packable/tests/vec_prefix.rs
@@ -5,16 +5,18 @@ mod common;
 
 use bee_packable::VecPrefix;
 
+const MAX_LENGTH: usize = 128;
+
 macro_rules! impl_packable_test_for_vec_prefix {
     ($name:ident, $ty:ty) => {
         #[test]
         fn $name() {
             assert_eq!(
-                common::generic_test(&VecPrefix::<u32, $ty>::new()).0.len(),
+                common::generic_test(&VecPrefix::<u32, $ty, MAX_LENGTH>::new()).0.len(),
                 core::mem::size_of::<$ty>()
             );
             assert_eq!(
-                common::generic_test(&VecPrefix::<Option<u32>, $ty>::from(vec![Some(0u32), None]))
+                common::generic_test(&VecPrefix::<Option<u32>, $ty, MAX_LENGTH>::from(vec![Some(0u32), None]))
                     .0
                     .len(),
                 core::mem::size_of::<$ty>()

--- a/bee-common/bee-packable/tests/vec_prefix.rs
+++ b/bee-common/bee-packable/tests/vec_prefix.rs
@@ -5,6 +5,8 @@ mod common;
 
 use bee_packable::VecPrefix;
 
+use core::convert::TryFrom;
+
 const MAX_LENGTH: usize = 128;
 
 macro_rules! impl_packable_test_for_vec_prefix {
@@ -18,10 +20,9 @@ macro_rules! impl_packable_test_for_vec_prefix {
                 core::mem::size_of::<$ty>()
             );
             assert_eq!(
-                common::generic_test(&VecPrefix::<Option<u32>, $ty, MAX_LENGTH>::from(vec![
-                    Some(0u32),
-                    None
-                ]))
+                common::generic_test(
+                    &VecPrefix::<Option<u32>, $ty, MAX_LENGTH>::try_from(vec![Some(0u32), None]).unwrap()
+                )
                 .0
                 .len(),
                 core::mem::size_of::<$ty>()


### PR DESCRIPTION
# Description of change

Adds a maximum length provided as a const generic parameter in the `VecPrefix` type.

## Links to any relevant issues

Identified fuzzing issues with #635, some of which should be helped by this change.

## Type of change

- Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Change checklist

Tick the boxes that are relevant to your changes, and delete any items that are not.

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that new and existing unit tests pass locally with my changes
- [x] I have updated the CHANGELOG.md, if my changes are significant enough
