### PR TITLE
Make `Wrap::wrap` a fallible operation

### DIFF
--- a/bee-common/bee-packable/src/packable/mod.rs
+++ b/bee-common/bee-packable/src/packable/mod.rs
@@ -14,7 +14,7 @@ mod vec;
 mod vec_prefix;
 
 pub use option::UnpackOptionError;
-pub use vec_prefix::{PrefixedFromVecError, VecPrefix};
+pub use vec_prefix::{PrefixedWrapVecError, VecPrefix};
 
 pub use crate::{
     error::{PackError, UnknownTagError, UnpackError},

--- a/bee-common/bee-packable/src/wrap.rs
+++ b/bee-common/bee-packable/src/wrap.rs
@@ -2,20 +2,25 @@
 // SPDX-License-Identifier: Apache-2.0
 
 //! A module to wrap [`Packable`](crate::Packable) values.
+use core::convert::Infallible;
 
 /// A type whose values can be wrapped in values of type `W`.
 ///
-/// In essence, `A: Wrap<B>` means that every value of type `&A` can be converted into a value of
-/// type `&B` (via `Wrap::wrap`), also known as "wrapping", and that every `B` can be converted
-/// into a value of type `A` (via [`Into::into`]), also known as "unwrapping".
-pub trait Wrap<W: Into<Self>>: Sized {
+/// In essence, `A: Wrap<B>` means that some values of type `&B` can be converted into a value of
+/// type `&a` (via `Wrap::wrap`), also known as "wrapping", and that every `A` can be converted
+/// into a value of type `B` (via [`Into::into`]), also known as "unwrapping".
+pub trait Wrap<'a, W: 'a>: Sized + Into<W> {
+    /// Error raised when it is not possible to convert a value to one of type `W`.
+    type Error;
     /// Wraps a reference.
-    fn wrap(&self) -> &W;
+    fn wrap(value: &'a W) -> Result<&'a Self, Self::Error>;
 }
 
 /// `Wrap` is reflexive.
-impl<T: Sized> Wrap<T> for T {
-    fn wrap(&self) -> &Self {
-        self
+impl<'a, T: 'a + Sized> Wrap<'a, T> for T {
+    type Error = Infallible;
+
+    fn wrap(value: &'a T) -> Result<&'a Self, Self::Error> {
+        Ok(value)
     }
 }

--- a/bee-common/bee-packable/tests/vec_prefix.rs
+++ b/bee-common/bee-packable/tests/vec_prefix.rs
@@ -3,9 +3,7 @@
 
 mod common;
 
-use bee_packable::{error::UnpackPrefixError, Packable, PrefixedFromVecError, UnpackError, VecPrefix};
-
-use core::convert::TryFrom;
+use bee_packable::{error::UnpackPrefixError, wrap::Wrap, Packable, PrefixedWrapVecError, UnpackError, VecPrefix};
 
 const MAX_LENGTH: usize = 128;
 
@@ -21,7 +19,7 @@ macro_rules! impl_packable_test_for_vec_prefix {
             );
             assert_eq!(
                 common::generic_test(
-                    &VecPrefix::<Option<u32>, $ty, MAX_LENGTH>::try_from(vec![Some(0u32), None]).unwrap()
+                    VecPrefix::<Option<u32>, $ty, MAX_LENGTH>::wrap(&vec![Some(0u32), None]).unwrap()
                 )
                 .0
                 .len(),
@@ -54,13 +52,13 @@ impl_packable_test_for_vec_prefix!(packable_vec_prefix_u64, packable_vec_prefix_
 impl_packable_test_for_vec_prefix!(packable_vec_prefix_u128, packable_vec_prefix_invalid_length_u128, u128);
 
 #[test]
-fn packable_vec_prefix_from_vec_error() {
+fn packable_vec_prefix_wraps_vec_error() {
     let vec = vec![0u8; 16];
-    let prefixed = VecPrefix::<u8, u32, 8>::try_from(vec);
+    let prefixed = VecPrefix::<u8, u32, 8>::wrap(&vec);
 
     assert!(matches!(
         prefixed,
-        Err(PrefixedFromVecError {
+        Err(PrefixedWrapVecError {
             max_len: 8,
             actual_len: 16
         })


### PR DESCRIPTION
This makes `Wrap::wrap` a fallible operation which can help avoid extra `clone()` calls while packing.