### PR TITLE
adjust OutputConsumed and OutputCreated event

### DIFF
--- a/bee-ledger/src/workers/consensus/worker.rs
+++ b/bee-ledger/src/workers/consensus/worker.rs
@@ -258,7 +258,7 @@ where
 
     for (output_id, (created_output, _consumed_output)) in metadata.consumed_outputs {
         bus.dispatch(OutputConsumed {
-            message_id: *output.message_id(),
+            message_id: *created_output.message_id(),
             output_id,
             output: created_output.inner().clone(),
         });

--- a/bee-ledger/src/workers/consensus/worker.rs
+++ b/bee-ledger/src/workers/consensus/worker.rs
@@ -256,20 +256,12 @@ where
         });
     }
 
-    for (output_id, (_, _consumed_output)) in metadata.consumed_outputs {
-        match storage::fetch_output(&*storage, &output_id) {
-            Ok(response) => match response {
-                Some(output) => {
-                    bus.dispatch(OutputConsumed {
-                        message_id: *output.message_id(),
-                        output_id,
-                        output: output.inner().clone(),
-                    });
-                }
-                None => {} // can this case even happen? as apply_milestone() will be called before
-            },
-            Err(_) => {} // can this case even happen? panic?
-        }
+    for (output_id, (created_output, _consumed_output)) in metadata.consumed_outputs {
+        bus.dispatch(OutputConsumed {
+            message_id: *output.message_id(),
+            output_id,
+            output: created_output.inner().clone(),
+        });
     }
 
     Ok(())

--- a/bee-ledger/src/workers/consensus/worker.rs
+++ b/bee-ledger/src/workers/consensus/worker.rs
@@ -250,9 +250,9 @@ where
 
     for (output_id, created_output) in metadata.created_outputs {
         bus.dispatch(OutputCreated {
-            message_id: created_output.message_id,
+            message_id: created_output.message_id(),
             output_id,
-            output: created_output.inner,
+            output: created_output.inner(),
         });
     }
 
@@ -261,9 +261,9 @@ where
             Ok(response) => match response {
                 Some(output) => {
                     bus.dispatch(OutputConsumed {
-                        message_id: output.message_id,
+                        message_id: output.message_id(),
                         output_id,
-                        output: output.inner,
+                        output: output.inner(),
                     });
                 }
                 None => {} // can this case even happen? as apply_milestone() will be called before

--- a/bee-ledger/src/workers/consensus/worker.rs
+++ b/bee-ledger/src/workers/consensus/worker.rs
@@ -250,9 +250,9 @@ where
 
     for (output_id, created_output) in metadata.created_outputs {
         bus.dispatch(OutputCreated {
-            message_id: created_output.message_id(),
+            message_id: *created_output.message_id(),
             output_id,
-            output: created_output.inner(),
+            output: created_output.inner().clone(),
         });
     }
 
@@ -261,9 +261,9 @@ where
             Ok(response) => match response {
                 Some(output) => {
                     bus.dispatch(OutputConsumed {
-                        message_id: output.message_id(),
+                        message_id: *output.message_id(),
                         output_id,
-                        output: output.inner(),
+                        output: output.inner().clone(),
                     });
                 }
                 None => {} // can this case even happen? as apply_milestone() will be called before

--- a/bee-ledger/src/workers/event.rs
+++ b/bee-ledger/src/workers/event.rs
@@ -44,11 +44,11 @@ pub struct MessageReferenced {
 
 /// An event that indicates that an output was consumed.
 pub struct OutputConsumed {
-    /// The identifier of the message that contains the transaction that creates the output
+    /// The identifier of the message that contains the transaction that consumes the output
     pub message_id: MessageId,
-    /// The identifier of the created output
+    /// The identifier of the consumed output
     pub output_id: OutputId,
-    /// The created output
+    /// The consumed output
     pub output: Output,
 }
 

--- a/bee-ledger/src/workers/event.rs
+++ b/bee-ledger/src/workers/event.rs
@@ -44,21 +44,21 @@ pub struct MessageReferenced {
 
 /// An event that indicates that an output was consumed.
 pub struct OutputConsumed {
-    /// The identifier of the message that contains the transaction that consumes the output
+    /// The identifier of the message that contains the transaction that consumes the output.
     pub message_id: MessageId,
-    /// The identifier of the consumed output
+    /// The identifier of the consumed output.
     pub output_id: OutputId,
-    /// The consumed output
+    /// The consumed output.
     pub output: Output,
 }
 
 /// An event that indicates that an output was created.
 pub struct OutputCreated {
-    /// The identifier of the message that contains the transaction that creates the output
+    /// The identifier of the message that contains the transaction that creates the output.
     pub message_id: MessageId,
-    /// The identifier of the created output
+    /// The identifier of the created output.
     pub output_id: OutputId,
-    /// The created output
+    /// The created output.
     pub output: Output,
 }
 

--- a/bee-ledger/src/workers/event.rs
+++ b/bee-ledger/src/workers/event.rs
@@ -43,6 +43,7 @@ pub struct MessageReferenced {
 }
 
 /// An event that indicates that an output was consumed.
+#[derive(Clone)]
 pub struct OutputConsumed {
     /// The identifier of the message that contains the transaction that consumes the output.
     pub message_id: MessageId,
@@ -53,6 +54,7 @@ pub struct OutputConsumed {
 }
 
 /// An event that indicates that an output was created.
+#[derive(Clone)]
 pub struct OutputCreated {
     /// The identifier of the message that contains the transaction that creates the output.
     pub message_id: MessageId,

--- a/bee-ledger/src/workers/event.rs
+++ b/bee-ledger/src/workers/event.rs
@@ -3,9 +3,11 @@
 
 //! Module containing the event occurring during ledger operations.
 
-use crate::types::{ConsumedOutput, CreatedOutput};
-
-use bee_message::{milestone::MilestoneIndex, MessageId};
+use bee_message::{
+    milestone::MilestoneIndex,
+    output::{Output, OutputId},
+    MessageId,
+};
 use bee_tangle::ConflictReason;
 
 /// An event that indicates that a milestone was confirmed.
@@ -41,17 +43,23 @@ pub struct MessageReferenced {
 }
 
 /// An event that indicates that an output was consumed.
-#[derive(Clone)]
 pub struct OutputConsumed {
-    /// The consumed output.
-    pub output: ConsumedOutput,
+    /// The identifier of the message that contains the transaction that creates the output
+    pub message_id: MessageId,
+    /// The identifier of the created output
+    pub output_id: OutputId,
+    /// The created output
+    pub output: Output,
 }
 
 /// An event that indicates that an output was created.
-#[derive(Clone)]
 pub struct OutputCreated {
-    /// The created output.
-    pub output: CreatedOutput,
+    /// The identifier of the message that contains the transaction that creates the output
+    pub message_id: MessageId,
+    /// The identifier of the created output
+    pub output_id: OutputId,
+    /// The created output
+    pub output: Output,
 }
 
 /// An event that indicates that a snapshot happened.


### PR DESCRIPTION
# Description of change
The `OutputConsmed` and `OutputCreated` event don't contain all necessary informations for MQTT. This PR introduces the needed changes.

