### PR TITLE
`bee-message` tests

### DIFF
--- a/bee-message/src/error/packable.rs
+++ b/bee-message/src/error/packable.rs
@@ -10,7 +10,7 @@ pub use crate::{
         PayloadUnpackError,
     },
     signature::SignatureUnpackError,
-    unlock::{UnlockBlockUnpackError, UnlockBlocksUnpackError},
+    unlock::UnlockBlockUnpackError,
     ValidationError,
 };
 
@@ -33,7 +33,6 @@ pub enum MessageUnpackError {
     Transaction(TransactionUnpackError),
     TransactionEssence(TransactionEssenceUnpackError),
     UnlockBlock(UnlockBlockUnpackError),
-    UnlockBlocks(UnlockBlocksUnpackError),
     Validation(ValidationError),
 }
 
@@ -54,11 +53,6 @@ impl_wrapped_validated!(
     MessageUnpackError,
     MessageUnpackError::UnlockBlock,
     UnlockBlockUnpackError
-);
-impl_wrapped_validated!(
-    MessageUnpackError,
-    MessageUnpackError::UnlockBlocks,
-    UnlockBlocksUnpackError
 );
 impl_wrapped_variant!(MessageUnpackError, MessageUnpackError::Address, AddressUnpackError);
 impl_wrapped_variant!(MessageUnpackError, MessageUnpackError::Signature, SignatureUnpackError);
@@ -88,7 +82,6 @@ impl fmt::Display for MessageUnpackError {
             Self::Transaction(e) => write!(f, "error unpacking Transaction payload: {}", e),
             Self::TransactionEssence(e) => write!(f, "error unpacking TransactionEssence: {}", e),
             Self::UnlockBlock(e) => write!(f, "error unpacking UnlockBlock: {}", e),
-            Self::UnlockBlocks(e) => write!(f, "error unpacking UnlockBlocks: {}", e),
             Self::Validation(e) => write!(f, "validation error occured while unpacking: {}", e),
         }
     }

--- a/bee-message/src/payload/transaction/mod.rs
+++ b/bee-message/src/payload/transaction/mod.rs
@@ -6,11 +6,7 @@
 mod essence;
 mod transaction_id;
 
-use crate::{
-    payload::MessagePayload,
-    unlock::{UnlockBlocks, UnlockBlocksUnpackError},
-    MessageUnpackError, ValidationError,
-};
+use crate::{payload::MessagePayload, unlock::UnlockBlocks, MessageUnpackError, ValidationError};
 
 pub use essence::{TransactionEssence, TransactionEssenceBuilder, TransactionEssenceUnpackError};
 pub use transaction_id::TransactionId;
@@ -26,15 +22,9 @@ use core::{convert::Infallible, fmt};
 #[allow(missing_docs)]
 pub enum TransactionUnpackError {
     TransactionEssence(Box<TransactionEssenceUnpackError>),
-    UnlockBlocksUnpack(UnlockBlocksUnpackError),
     Validation(ValidationError),
 }
 
-impl_wrapped_variant!(
-    TransactionUnpackError,
-    TransactionUnpackError::UnlockBlocksUnpack,
-    UnlockBlocksUnpackError
-);
 impl_wrapped_variant!(
     TransactionUnpackError,
     TransactionUnpackError::Validation,
@@ -54,7 +44,6 @@ impl fmt::Display for TransactionUnpackError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             Self::TransactionEssence(e) => write!(f, "error unpacking transaction essence: {}", e),
-            Self::UnlockBlocksUnpack(e) => write!(f, "error unpacking unlock blocks: {}", e),
             Self::Validation(e) => write!(f, "{}", e),
         }
     }

--- a/bee-message/src/unlock/mod.rs
+++ b/bee-message/src/unlock/mod.rs
@@ -9,7 +9,7 @@ mod unlock_blocks;
 
 pub use reference::{ReferenceUnlock, ReferenceUnlockUnpackError};
 pub use signature::SignatureUnlock;
-pub use unlock_blocks::{UnlockBlocks, UnlockBlocksUnpackError};
+pub use unlock_blocks::UnlockBlocks;
 
 use crate::{
     input::{INPUT_COUNT_MAX, INPUT_COUNT_RANGE, INPUT_INDEX_MAX, INPUT_INDEX_RANGE},

--- a/bee-message/tests/indexation_payload.rs
+++ b/bee-message/tests/indexation_payload.rs
@@ -4,6 +4,7 @@
 use bee_message::{
     error::{MessageUnpackError, ValidationError},
     payload::{indexation::IndexationPayload, MessagePayload},
+    MESSAGE_LENGTH_RANGE,
 };
 use bee_packable::{Packable, UnpackError};
 use bee_test::rand::bytes::rand_bytes;
@@ -107,6 +108,24 @@ fn unpack_invalid_index_length_more_than_max() {
             ValidationError::InvalidIndexationIndexLength(65)
         )),
     ));
+}
+
+#[test]
+fn unpack_invalid_data_length_more_than_max() {
+    let data_len = MESSAGE_LENGTH_RANGE.end() + 5;
+
+    let mut bytes = vec![0x0A, 0x00, 0x00, 0x00];
+    bytes.extend(rand_bytes(10));
+    bytes.extend(vec![0x05, 0x00, 0x01, 0x00]);
+    bytes.extend(vec![0; data_len]);
+
+    assert!(matches!(
+        IndexationPayload::unpack_from_slice(bytes).err().unwrap(),
+        UnpackError::Packable(MessageUnpackError::Validation(
+            ValidationError::InvalidIndexationDataLength(n)
+        ))
+            if n == data_len
+    ))
 }
 
 #[test]

--- a/bee-message/tests/message.rs
+++ b/bee-message/tests/message.rs
@@ -184,6 +184,49 @@ fn invalid_parents_blocks_more_than_max() {
 }
 
 #[test]
+fn accessors_eq() {
+    let issuer_public_key = rand_bytes_array::<32>();
+    let issue_timestamp = rand_number::<u64>();
+    let sequence_number = rand_number::<u32>();
+    let payload = Payload::from(IndexationPayload::new(rand_bytes(32), rand_bytes(32)).unwrap());
+    let nonce = 0;
+    let signature = rand_bytes_array::<64>();
+
+    let message = MessageBuilder::new()
+        .add_parents_block(
+            ParentsBlock::new(ParentsKind::Strong, vec![MessageId::new(hex_decode(PARENT_1).unwrap())]).unwrap(),
+        )
+        .add_parents_block(
+            ParentsBlock::new(ParentsKind::Weak, vec![MessageId::new(hex_decode(PARENT_2).unwrap())]).unwrap(),
+        )
+        .add_parents_block(
+            ParentsBlock::new(ParentsKind::Liked, vec![MessageId::new(hex_decode(PARENT_3).unwrap())]).unwrap(),
+        )
+        .add_parents_block(
+            ParentsBlock::new(
+                ParentsKind::Disliked,
+                vec![MessageId::new(hex_decode(PARENT_4).unwrap())],
+            )
+            .unwrap(),
+        )
+        .with_issuer_public_key(issuer_public_key)
+        .with_issue_timestamp(issue_timestamp)
+        .with_sequence_number(sequence_number)
+        .with_payload(payload.clone())
+        .with_nonce(nonce)
+        .with_signature(signature)
+        .finish()
+        .unwrap();
+
+    assert_eq!(*message.issuer_public_key(), issuer_public_key);
+    assert_eq!(message.issue_timestamp(), issue_timestamp);
+    assert_eq!(message.sequence_number(), sequence_number);
+    assert_eq!(*message.payload().as_ref().unwrap(), payload);
+    assert_eq!(message.nonce(), nonce);
+    assert_eq!(*message.signature(), signature);
+}
+
+#[test]
 fn packed_len() {
     let message = MessageBuilder::new()
         .add_parents_block(

--- a/bee-message/tests/payload.rs
+++ b/bee-message/tests/payload.rs
@@ -1,0 +1,266 @@
+// Copyright 2021 IOTA Stiftung
+// SPDX-License-Identifier: Apache-2.0
+
+use bee_message::{
+    address::{Address, Ed25519Address},
+    error::{MessageUnpackError, ValidationError},
+    input::{Input, UtxoInput},
+    output::{Output, OutputId, SignatureLockedSingleOutput},
+    payload::{
+        data::DataPayload,
+        drng::{ApplicationMessagePayload, BeaconPayload, CollectiveBeaconPayload, DkgPayload, EncryptedDeal},
+        fpc::{Conflict, FpcPayload, Timestamp},
+        indexation::IndexationPayload,
+        salt_declaration::{Salt, SaltDeclarationPayload},
+        transaction::{TransactionEssence, TransactionId, TransactionPayload},
+        MessagePayload, Payload, PayloadUnpackError,
+    },
+    signature::{Ed25519Signature, Signature},
+    unlock::{SignatureUnlock, UnlockBlock, UnlockBlocks},
+    MessageId,
+};
+use bee_packable::{Packable, UnpackError};
+use bee_test::rand::{
+    bytes::{rand_bytes, rand_bytes_array},
+    number::rand_number,
+};
+
+#[test]
+fn application_message_payload_packable_round_trip() {
+    let payload_1 = Payload::from(ApplicationMessagePayload::new(1));
+
+    let bytes = payload_1.pack_to_vec().unwrap();
+    let payload_2 = Payload::unpack_from_slice(bytes.clone()).unwrap();
+
+    assert_eq!(payload_1, payload_2);
+    assert_eq!(payload_1.kind(), ApplicationMessagePayload::KIND);
+    assert_eq!(payload_1.packed_len(), bytes.len());
+}
+
+#[test]
+fn collective_beacon_payload_packable_round_trip() {
+    let payload_1 = Payload::from(
+        CollectiveBeaconPayload::builder()
+            .with_instance_id(0)
+            .with_round(1)
+            .with_prev_signature(rand_bytes_array())
+            .with_signature(rand_bytes_array())
+            .with_distributed_public_key(rand_bytes_array())
+            .finish()
+            .unwrap(),
+    );
+
+    let bytes = payload_1.pack_to_vec().unwrap();
+    let payload_2 = Payload::unpack_from_slice(bytes.clone()).unwrap();
+
+    assert_eq!(payload_1, payload_2);
+    assert_eq!(payload_1.kind(), CollectiveBeaconPayload::KIND);
+    assert_eq!(payload_1.packed_len(), bytes.len());
+}
+
+#[test]
+fn data_payload_packable_round_trip() {
+    let payload_1 = Payload::from(DataPayload::new(vec![0; 255]).unwrap());
+
+    let bytes = payload_1.pack_to_vec().unwrap();
+    let payload_2 = Payload::unpack_from_slice(bytes.clone()).unwrap();
+
+    assert_eq!(payload_1, payload_2);
+    assert_eq!(payload_1.kind(), DataPayload::KIND);
+    assert_eq!(payload_1.packed_len(), bytes.len());
+}
+
+#[test]
+fn dkg_payload_packable_round_trip() {
+    let payload_1 = Payload::from(
+        DkgPayload::builder()
+            .with_instance_id(1)
+            .with_from_index(20)
+            .with_to_index(32)
+            .with_deal(
+                EncryptedDeal::builder()
+                    .with_dh_key(rand_bytes(128))
+                    .with_nonce(rand_bytes(12))
+                    .with_encrypted_share(rand_bytes(128))
+                    .with_threshold(10)
+                    .with_commitments(rand_bytes(12))
+                    .finish()
+                    .unwrap(),
+            )
+            .finish()
+            .unwrap(),
+    );
+
+    let bytes = payload_1.pack_to_vec().unwrap();
+    let payload_2 = Payload::unpack_from_slice(bytes.clone()).unwrap();
+
+    assert_eq!(payload_1, payload_2);
+    assert_eq!(payload_1.kind(), DkgPayload::KIND);
+    assert_eq!(payload_1.packed_len(), bytes.len());
+}
+
+#[test]
+fn fpc_payload_packable_round_trip() {
+    let payload_1 = Payload::from(
+        FpcPayload::builder()
+            .with_conflicts(vec![
+                Conflict::new(TransactionId::from(rand_bytes_array()), 0, 0),
+                Conflict::new(TransactionId::from(rand_bytes_array()), 0, 1),
+                Conflict::new(TransactionId::from(rand_bytes_array()), 1, 2),
+            ])
+            .with_timestamps(vec![
+                Timestamp::new(MessageId::from(rand_bytes_array()), 0, 0),
+                Timestamp::new(MessageId::from(rand_bytes_array()), 0, 1),
+                Timestamp::new(MessageId::from(rand_bytes_array()), 1, 2),
+            ])
+            .finish()
+            .unwrap(),
+    );
+
+    let bytes = payload_1.pack_to_vec().unwrap();
+    let payload_2 = Payload::unpack_from_slice(bytes.clone()).unwrap();
+
+    assert_eq!(payload_1, payload_2);
+    assert_eq!(payload_1.kind(), FpcPayload::KIND);
+    assert_eq!(payload_1.packed_len(), bytes.len());
+}
+
+#[test]
+fn indexation_payload_packable_round_trip() {
+    let payload_1 = Payload::from(IndexationPayload::new(rand_bytes(32), rand_bytes(64)).unwrap());
+
+    let bytes = payload_1.pack_to_vec().unwrap();
+    let payload_2 = Payload::unpack_from_slice(bytes.clone()).unwrap();
+
+    assert_eq!(payload_1, payload_2);
+    assert_eq!(payload_1.kind(), IndexationPayload::KIND);
+    assert_eq!(payload_1.packed_len(), bytes.len());
+}
+
+#[test]
+fn regular_beacon_payload_packable_round_trip() {
+    let payload_1 = Payload::from(
+        BeaconPayload::builder()
+            .with_instance_id(0)
+            .with_round(1)
+            .with_partial_public_key(rand_bytes_array())
+            .with_partial_signature(rand_bytes_array())
+            .finish()
+            .unwrap(),
+    );
+
+    let bytes = payload_1.pack_to_vec().unwrap();
+    let payload_2 = Payload::unpack_from_slice(bytes.clone()).unwrap();
+
+    assert_eq!(payload_1, payload_2);
+    assert_eq!(payload_1.kind(), BeaconPayload::KIND);
+    assert_eq!(payload_1.packed_len(), bytes.len());
+}
+
+#[test]
+fn salt_declaration_payload_packable_round_trip() {
+    let payload_1 = Payload::from(
+        SaltDeclarationPayload::builder()
+            .with_node_id(32)
+            .with_salt(Salt::new(rand_bytes(64), rand_number()).unwrap())
+            .with_timestamp(rand_number())
+            .with_signature(rand_bytes_array())
+            .finish()
+            .unwrap(),
+    );
+
+    let bytes = payload_1.pack_to_vec().unwrap();
+    let payload_2 = Payload::unpack_from_slice(bytes.clone()).unwrap();
+
+    assert_eq!(payload_1, payload_2);
+    assert_eq!(payload_1.kind(), SaltDeclarationPayload::KIND);
+    assert_eq!(payload_1.packed_len(), bytes.len());
+}
+
+#[test]
+fn transaction_payload_packable_round_trip() {
+    let payload_1 = Payload::from(
+        TransactionPayload::builder()
+            .with_essence(
+                TransactionEssence::builder()
+                    .with_timestamp(rand_number())
+                    .with_access_pledge_id(rand_bytes_array())
+                    .with_consensus_pledge_id(rand_bytes_array())
+                    .with_inputs(vec![Input::Utxo(UtxoInput::new(
+                        OutputId::new(TransactionId::new(rand_bytes_array()), 0).unwrap(),
+                    ))])
+                    .with_outputs(vec![Output::SignatureLockedSingle(
+                        SignatureLockedSingleOutput::new(
+                            Address::from(Ed25519Address::new(rand_bytes_array())),
+                            1_000_000,
+                        )
+                        .unwrap(),
+                    )])
+                    .finish()
+                    .unwrap(),
+            )
+            .with_unlock_blocks(
+                UnlockBlocks::new(vec![UnlockBlock::Signature(SignatureUnlock::from(Signature::Ed25519(
+                    Ed25519Signature::new(rand_bytes_array(), rand_bytes_array()),
+                )))])
+                .unwrap(),
+            )
+            .finish()
+            .unwrap(),
+    );
+
+    let bytes = payload_1.pack_to_vec().unwrap();
+    let payload_2 = Payload::unpack_from_slice(bytes.clone()).unwrap();
+
+    assert_eq!(payload_1, payload_2);
+    assert_eq!(payload_1.kind(), TransactionPayload::KIND);
+    assert_eq!(payload_1.packed_len(), bytes.len());
+}
+
+#[test]
+fn unpack_invalid_version() {
+    let mut bytes = vec![0x68, 0x00, 0x00, 0x00, 0x08, 0x00, 0x00, 0x00, 0x01];
+    bytes.extend([0x20, 0x00, 0x00, 0x00]);
+    bytes.extend(rand_bytes_array::<32>());
+    bytes.extend([0x40, 0x00, 0x00, 0x00]);
+    bytes.extend(rand_bytes_array::<64>());
+
+    assert!(matches!(
+        Payload::unpack_from_slice(bytes).err().unwrap(),
+        UnpackError::Packable(MessageUnpackError::Validation(ValidationError::InvalidPayloadVersion {
+            version: 1,
+            payload_kind: 8,
+        }))
+    ));
+}
+
+#[test]
+fn unpack_invalid_length() {
+    let mut bytes = vec![0x69, 0x00, 0x00, 0x00, 0x08, 0x00, 0x00, 0x00, 0x00];
+    bytes.extend([0x20, 0x00, 0x00, 0x00]);
+    bytes.extend(rand_bytes_array::<32>());
+    bytes.extend([0x40, 0x00, 0x00, 0x00]);
+    bytes.extend(rand_bytes_array::<64>());
+
+    assert!(matches!(
+        Payload::unpack_from_slice(bytes).err().unwrap(),
+        UnpackError::Packable(MessageUnpackError::Validation(ValidationError::PayloadLengthMismatch {
+            expected: 105,
+            actual: 104,
+        }))
+    ));
+}
+
+#[test]
+fn unpack_invalid_kind() {
+    let mut bytes = vec![0x69, 0x00, 0x00, 0x00, 0x12, 0x00, 0x00, 0x00, 0x00];
+    bytes.extend([0x20, 0x00, 0x00, 0x00]);
+    bytes.extend(rand_bytes_array::<32>());
+    bytes.extend([0x40, 0x00, 0x00, 0x00]);
+    bytes.extend(rand_bytes_array::<64>());
+
+    assert!(matches!(
+        Payload::unpack_from_slice(bytes).err().unwrap(),
+        UnpackError::Packable(MessageUnpackError::Payload(PayloadUnpackError::InvalidKind(18))),
+    ));
+}

--- a/bee-message/tests/signature_locked_asset_output.rs
+++ b/bee-message/tests/signature_locked_asset_output.rs
@@ -4,12 +4,14 @@
 use bee_message::{
     address::{Address, Ed25519Address},
     output::{AssetBalance, AssetId, SignatureLockedAssetOutput},
+    util::hex_decode,
 };
 use bee_packable::Packable;
 use bee_test::rand::bytes::rand_bytes_array;
 
 use core::str::FromStr;
 
+const ASSET_ID: &str = "5be056b7ce1cb91d8d7b6824eaa26d1a85d08e140292e5093aabf9ad6f50c0e2";
 const ED25519_ADDRESS: &str = "52fdfc072182654f163f5f0f9a621d729566c74d10037c4d7bbb0407d1e2c649";
 
 #[test]
@@ -48,7 +50,7 @@ fn accessors_eq() {
 
 #[test]
 fn asset_balance_accessors_eq() {
-    let id = AssetId::new(rand_bytes_array());
+    let id = AssetId::from(hex_decode(ASSET_ID).unwrap());
     let amount = 1000;
 
     let balance = AssetBalance::new(id.clone(), amount);

--- a/bee-message/tests/unlock_blocks.rs
+++ b/bee-message/tests/unlock_blocks.rs
@@ -2,12 +2,12 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use bee_message::{
-    error::ValidationError,
+    error::{MessageUnpackError, ValidationError},
     signature::{Ed25519Signature, Signature},
-    unlock::{ReferenceUnlock, SignatureUnlock, UnlockBlock, UnlockBlocks},
+    unlock::{ReferenceUnlock, SignatureUnlock, UnlockBlock, UnlockBlockUnpackError, UnlockBlocks},
 };
-use bee_packable::Packable;
-use bee_test::rand::bytes::rand_bytes_array;
+use bee_packable::{Packable, UnpackError};
+use bee_test::rand::bytes::{rand_bytes, rand_bytes_array};
 
 #[test]
 fn kind() {
@@ -149,6 +149,21 @@ fn get_signature_through_reference() {
             .get(1),
         Some(&signature)
     );
+}
+
+#[test]
+fn unpack_invalid_unlock_block_kind() {
+    let mut bytes = vec![1, 0];
+    bytes.extend([2, 0]);
+    bytes.extend(rand_bytes(32));
+    bytes.extend(rand_bytes(64));
+
+    let unlock_blocks = UnlockBlocks::unpack_from_slice(bytes);
+
+    assert!(matches!(
+        unlock_blocks.err().unwrap(),
+        UnpackError::Packable(MessageUnpackError::UnlockBlock(UnlockBlockUnpackError::InvalidKind(2))),
+    ));
 }
 
 #[test]


### PR DESCRIPTION
More test coverage for `bee-message`. Opening now so I can see the coverage info through the workflow, but not done yet.

Well, I just realised that you can't do that! So, converted to draft.

