### PR TITLE
Add protobuf version of `Message`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -164,6 +164,7 @@ dependencies = [
  "bee-event-bus",
  "bee-logger",
  "bee-message",
+ "bee-test",
  "log",
  "prost",
  "thiserror",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -163,6 +163,7 @@ dependencies = [
  "async-trait",
  "bee-event-bus",
  "bee-logger",
+ "bee-message",
  "log",
  "prost",
  "thiserror",

--- a/bee-message/src/output/signature_locked_asset.rs
+++ b/bee-message/src/output/signature_locked_asset.rs
@@ -6,7 +6,10 @@ use crate::{address::Address, payload::PAYLOAD_LENGTH_MAX, MessageUnpackError, V
 use bee_packable::{error::UnpackPrefixError, BoundedU32, InvalidBoundedU32, Packable, VecPrefix};
 
 use alloc::vec::Vec;
-use core::convert::{Infallible, TryInto};
+use core::{
+    convert::{Infallible, TryInto},
+    ops::Deref,
+};
 
 /// No [`Vec`] max length specified, so use [`PAYLOAD_LENGTH_MAX`] / [`AssetId::LENGTH`].
 const PREFIXED_BALANCES_LENGTH_MAX: u32 = PAYLOAD_LENGTH_MAX / (AssetId::LENGTH + core::mem::size_of::<u64>()) as u32;
@@ -36,6 +39,14 @@ impl AssetId {
 impl From<[u8; Self::LENGTH]> for AssetId {
     fn from(bytes: [u8; Self::LENGTH]) -> Self {
         Self(bytes)
+    }
+}
+
+impl Deref for AssetId {
+    type Target = [u8; Self::LENGTH];
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
     }
 }
 

--- a/bee-node/bee-plugin/Cargo.toml
+++ b/bee-node/bee-plugin/Cargo.toml
@@ -12,6 +12,7 @@ homepage = "https://www.iota.org"
 
 [dependencies]
 bee-event-bus = { path = "../../bee-common/bee-event-bus" }
+bee-message = { path = "../../bee-message" }
 
 log = "0.4"
 prost = "0.8"

--- a/bee-node/bee-plugin/Cargo.toml
+++ b/bee-node/bee-plugin/Cargo.toml
@@ -23,6 +23,7 @@ tonic = "0.5"
 
 [dev-dependencies]
 bee-logger = { path = "../../bee-common/bee-logger" }
+bee-test = { path = "../../bee-test" }
 
 async-trait = "0.1"
 tokio = { version = "1.6", features = [ "rt-multi-thread" ] }

--- a/bee-node/bee-plugin/examples/counter_node.rs
+++ b/bee-node/bee-plugin/examples/counter_node.rs
@@ -23,16 +23,6 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let hotloader = PluginHotloader::new("./plugins", bus.clone());
     let handle = tokio::spawn(async move { hotloader.run().await });
 
-    {
-        let bus = bus.clone();
-        tokio::spawn(async move {
-            loop {
-                sleep(Duration::from_millis(1)).await;
-                bus.dispatch(MessageParsedEvent {})
-            }
-        });
-    }
-
     tokio::spawn(async move {
         loop {
             sleep(Duration::from_millis(1)).await;

--- a/bee-node/bee-plugin/examples/counter_plugin.rs
+++ b/bee-node/bee-plugin/examples/counter_plugin.rs
@@ -31,7 +31,11 @@ impl Counter {
 #[async_trait::async_trait]
 impl Plugin for Counter {
     fn handshake() -> PluginHandshake {
-        PluginHandshake::new("counter", "[::1]:50051".parse().unwrap(), vec![EventId::MessageParsed])
+        PluginHandshake::new(
+            "counter",
+            "[::1]:50051".parse().unwrap(),
+            vec![EventId::MessageRejected],
+        )
     }
 
     async fn shutdown(&self) {
@@ -41,7 +45,7 @@ impl Plugin for Counter {
         );
     }
 
-    async fn process_message_parsed_event(&self, _event: MessageParsedEvent) {
+    async fn process_message_rejected_event(&self, _event: MessageRejectedEvent) {
         self.increase();
     }
 }

--- a/bee-node/bee-plugin/proto/plugin.proto
+++ b/bee-node/bee-plugin/proto/plugin.proto
@@ -62,7 +62,7 @@ message MessageId {
 }
 
 message Payload {
-    oneof payload_kind {
+    oneof kind {
         DataPayload data = 1;
         TransactionPayload transaction = 2;
         FpcPayload fpc = 3;
@@ -85,7 +85,7 @@ message TransactionPayload {
 }
 
 message UnlockBlock {
-    oneof unlock_block_kind {
+    oneof kind {
         SignatureUnlock signature = 1;
         ReferenceUnlock reference = 2;
     }
@@ -96,7 +96,7 @@ message SignatureUnlock {
 }
 
 message Signature {
-    oneof signature_kind {
+    oneof kind {
         Ed25519Signature ed25519 = 1;
         BlsSignature bls = 2;
     }
@@ -125,7 +125,7 @@ message TransactionEssence {
 }
 
 message Input {
-    oneof input_kind {
+    oneof kind {
         UtxoInput utxo = 1;
     }
 }
@@ -144,7 +144,7 @@ message TransactionId {
 }
 
 message Output {
-    oneof output_kind {
+    oneof kind {
         SignatureLockedSingleOutput signature_locked_single = 1;
         SignatureLockedAssetOutput signature_locked_asset = 2;
     }
@@ -156,7 +156,7 @@ message SignatureLockedSingleOutput {
 }
 
 message Address {
-    oneof address_kind {
+    oneof kind {
         Ed25519Address ed25519 = 1;
         BlsAddress bls = 2;
     }

--- a/bee-node/bee-plugin/proto/plugin.proto
+++ b/bee-node/bee-plugin/proto/plugin.proto
@@ -17,8 +17,225 @@ message ShutdownReply {}
 message ProcessReply {}
 
 // Event triggered when a message succesfully passes the parsing stage.
-message MessageParsedEvent {}
+message MessageParsedEvent {
+    // The parsed message.
+    Message message = 1;
+}
+
 // Event triggered when parsing a message fails.
 message ParsingFailedEvent {}
 // Event triggered when the syntactical validation of a message fails.
 message MessageRejectedEvent {}
+
+// A message from the IOTA network.
+message Message {
+    repeated ParentsBlock parents_block = 1;
+    bytes issuer_public_key = 2;
+    uint64 issue_timestamp = 3;
+    uint32 sequence_number = 4;
+    optional Payload payload = 5;
+    uint64 nonce = 6;
+    bytes signature = 7;
+}
+
+message ParentsBlock {
+    ParentsKind kind = 1;
+    repeated MessageId reference = 2;
+}
+
+enum ParentsKind {
+    STRONG = 0;
+    WEAK = 1;
+    DISLIKED = 2;
+    LIKED = 3;
+}
+
+message MessageId {
+    bytes inner = 1;
+}
+
+message Payload {
+    oneof payload_kind {
+        DataPayload data = 1;
+        TransactionPayload transaction = 2;
+        FpcPayload fpc = 3;
+        ApplicationMessagePayload application_message = 4;
+        DkgPayload dkg = 5;
+        BeaconPayload beacon = 6;
+        CollectiveBeaconPayload collective_beacon = 7;
+        SaltDeclarationPayload salt_declaration = 8;
+        IndexationPayload indexation = 9;
+    }
+}
+
+message DataPayload {
+    bytes data = 1;
+}
+
+message TransactionPayload {
+    TransactionEssence essence = 1;
+    repeated UnlockBlock unlock_block = 2;
+}
+
+message UnlockBlock {
+    oneof unlock_block_kind {
+        SignatureUnlock signature = 1;
+        ReferenceUnlock reference = 2;
+    }
+}
+
+message SignatureUnlock {
+    Signature signature = 1;
+}
+
+message Signature {
+    oneof signature_kind {
+        Ed25519Signature ed25519 = 1;
+        BlsSignature bls = 2;
+    }
+}
+
+message Ed25519Signature {
+    bytes public_key = 1;
+    bytes signature = 2;
+}
+
+message BlsSignature {
+    bytes inner = 1;
+}
+
+message ReferenceUnlock {
+    uint32 inner = 1;
+}
+
+message TransactionEssence {
+    uint64 timestamp = 1;
+    bytes access_pledge_id = 2;
+    bytes consensus_pledge_id = 3;
+    repeated Input input = 4;
+    repeated Output output = 5;
+    optional Payload payload = 6;
+}
+
+message Input {
+    oneof input_kind {
+        UtxoInput utxo = 1;
+    }
+}
+
+message UtxoInput {
+    OutputId output_id = 1;
+}
+
+message OutputId {
+    TransactionId transaction_id = 1;
+    uint32 index = 2;
+}
+
+message TransactionId {
+    bytes inner = 1;
+}
+
+message Output {
+    oneof output_kind {
+        SignatureLockedSingleOutput ignature_locked_single = 1;
+        SignatureLockedAssetOutput signature_locked_asset = 2;
+    }
+}
+
+message SignatureLockedSingleOutput {
+    Address address = 1;
+    uint64 amount = 2;
+}
+
+message Address {
+    oneof address_kind {
+        Ed25519Address ed25519 = 1;
+        BlsAddress bls = 2;
+    }
+}
+
+message Ed25519Address {
+    bytes inner = 1;
+}
+
+message BlsAddress {
+    bytes inner = 2;
+}
+
+message SignatureLockedAssetOutput {
+    AssetId id = 1;
+    uint64 balance = 2;
+}
+
+message AssetId {
+    bytes inner = 1;
+}
+
+message FpcPayload {
+    repeated Conflict conflict = 1;
+    repeated Timestamp timestamp = 2;
+}
+
+message Conflict {
+    TransactionId transaction_id = 1;
+    uint32 opinion = 2;
+    uint32 round = 3;
+}
+
+message Timestamp {
+    MessageId message_id = 1;
+    uint32 opinion = 2;
+    uint32 round = 3;
+}
+
+message ApplicationMessagePayload {
+    uint32 instance_id = 1;
+}
+
+message DkgPayload {
+    uint32 instance_id = 1;
+    uint32 from_index = 2;
+    uint32 to_index = 3;
+    EncryptedDeal deal = 4;
+}
+
+message EncryptedDeal {
+    bytes dh_key = 1;
+    bytes nonce = 2;
+    bytes encrpyted_share = 3;
+    uint32 threshold = 4;
+    bytes commitments = 5;
+}
+
+message BeaconPayload {
+    uint32 instance_id = 1;
+    uint64 round = 2;
+    bytes partial_public_key = 3;
+    bytes partial_signature = 4;
+}
+
+message CollectiveBeaconPayload {
+    uint32 instance_id = 1;
+    uint64 round = 2;
+    bytes prev_signature = 3;
+    bytes signature = 4;
+    bytes distributed_public_key = 5;
+}
+
+message SaltDeclarationPayload {
+    uint32 node_id = 1;
+    Salt salt = 2;
+    uint64 timestamp = 3;
+    bytes signature = 4;
+}
+
+message Salt {
+    bytes bytes = 1;
+    uint64 expiry_time = 2;
+}
+
+message IndexationPayload {
+    bytes index = 1;
+    bytes data = 2;
+}

--- a/bee-node/bee-plugin/proto/plugin.proto
+++ b/bee-node/bee-plugin/proto/plugin.proto
@@ -27,20 +27,27 @@ message ParsingFailedEvent {}
 // Event triggered when the syntactical validation of a message fails.
 message MessageRejectedEvent {}
 
-// A message from the IOTA network.
+// Represents the object that nodes gossip around the network.
 message Message {
-    repeated ParentsBlock parents_block = 1;
+    // Blocks of message parents. Each block contains a list of parent message IDs grouped by type.
+    repeated ParentsBlock parents_blocks = 1;
+    // The public key of the issuing node.
     bytes issuer_public_key = 2;
+    // The Unix timestamp at the moment of issue.
     uint64 issue_timestamp = 3;
+    // The sequence number of the message, indicating the marker sequence it belongs to.
     uint32 sequence_number = 4;
+    // The optional payload of the message.
     Payload payload = 5;
+    // The result of the Proof of Work in order for the message to be accepted into the tangle.
     uint64 nonce = 6;
+    // Signature signing the above message fields.
     bytes signature = 7;
 }
 
 message ParentsBlock {
     ParentsKind kind = 1;
-    repeated MessageId reference = 2;
+    repeated MessageId references = 2;
 }
 
 enum ParentsKind {
@@ -74,7 +81,7 @@ message DataPayload {
 
 message TransactionPayload {
     TransactionEssence essence = 1;
-    repeated UnlockBlock unlock_block = 2;
+    repeated UnlockBlock unlock_blocks = 2;
 }
 
 message UnlockBlock {
@@ -105,15 +112,15 @@ message BlsSignature {
 }
 
 message ReferenceUnlock {
-    uint32 inner = 1;
+    uint32 index = 1;
 }
 
 message TransactionEssence {
     uint64 timestamp = 1;
     bytes access_pledge_id = 2;
     bytes consensus_pledge_id = 3;
-    repeated Input input = 4;
-    repeated Output output = 5;
+    repeated Input inputs = 4;
+    repeated Output outputs = 5;
     Payload payload = 6;
 }
 
@@ -138,7 +145,7 @@ message TransactionId {
 
 message Output {
     oneof output_kind {
-        SignatureLockedSingleOutput ignature_locked_single = 1;
+        SignatureLockedSingleOutput signature_locked_single = 1;
         SignatureLockedAssetOutput signature_locked_asset = 2;
     }
 }
@@ -164,6 +171,11 @@ message BlsAddress {
 }
 
 message SignatureLockedAssetOutput {
+    Address address = 1;
+    repeated AssetBalance balances = 2;
+}
+
+message AssetBalance {
     AssetId id = 1;
     uint64 balance = 2;
 }
@@ -173,8 +185,8 @@ message AssetId {
 }
 
 message FpcPayload {
-    repeated Conflict conflict = 1;
-    repeated Timestamp timestamp = 2;
+    repeated Conflict conflicts = 1;
+    repeated Timestamp timestamps = 2;
 }
 
 message Conflict {

--- a/bee-node/bee-plugin/proto/plugin.proto
+++ b/bee-node/bee-plugin/proto/plugin.proto
@@ -33,7 +33,7 @@ message Message {
     bytes issuer_public_key = 2;
     uint64 issue_timestamp = 3;
     uint32 sequence_number = 4;
-    optional Payload payload = 5;
+    Payload payload = 5;
     uint64 nonce = 6;
     bytes signature = 7;
 }
@@ -114,7 +114,7 @@ message TransactionEssence {
     bytes consensus_pledge_id = 3;
     repeated Input input = 4;
     repeated Output output = 5;
-    optional Payload payload = 6;
+    Payload payload = 6;
 }
 
 message Input {

--- a/bee-node/bee-plugin/src/lib.rs
+++ b/bee-node/bee-plugin/src/lib.rs
@@ -17,6 +17,7 @@ mod plugin;
 
 pub mod event;
 pub mod hotloader;
+pub mod message;
 
 pub use error::PluginError;
 pub use handshake::PluginHandshake;

--- a/bee-node/bee-plugin/src/message.rs
+++ b/bee-node/bee-plugin/src/message.rs
@@ -2,10 +2,15 @@
 // SPDX-License-Identifier: Apache-2.0
 
 //! Types for messages.
+//!
+//! The [`Message`] type exposed here is used for (de)serialization purposes in plugins only. You
+//! should be using [`bee_message::Message`] most of the time. In particular, you should only
+//! create [`Message`] values by converting values of [`bee_message::Message`] using the
+//! [`From::from`] trait. To convert messages back to [`bee_message::Message`] you can use
+//! [`Into::into`]. However, this method is allowed to panic if the message of type [`Message`] was
+//! not created by converting [`bee_message::Message`].
 
 pub use crate::grpc::Message;
-
-use std::convert::TryInto;
 
 use crate::grpc::{
     address::Kind as AddressKind, input::Kind as InputKind, output::Kind as OutputKind, payload::Kind as PayloadKind,
@@ -16,6 +21,8 @@ use crate::grpc::{
     SignatureLockedAssetOutput, SignatureLockedSingleOutput, SignatureUnlock, Timestamp, TransactionEssence,
     TransactionId, TransactionPayload, UnlockBlock, UtxoInput,
 };
+
+use std::convert::TryInto;
 
 impl From<&bee_message::Message> for Message {
     fn from(message: &bee_message::Message) -> Self {
@@ -65,6 +72,9 @@ impl From<&bee_message::parents::ParentsBlock> for ParentsBlock {
 #[allow(clippy::from_over_into)]
 impl Into<bee_message::parents::ParentsBlock> for ParentsBlock {
     fn into(self) -> bee_message::parents::ParentsBlock {
+        // This and every other `unwrap` in an `Into::into` implementation is ok because we assume
+        // that `self` was created from a valid `bee_message::Message` and it has no missing
+        // fields.
         bee_message::parents::ParentsBlock::new(
             ParentsKind::from_i32(self.kind).unwrap().into(),
             self.references.into_iter().map(MessageId::into).collect(),

--- a/bee-node/bee-plugin/src/message.rs
+++ b/bee-node/bee-plugin/src/message.rs
@@ -8,13 +8,13 @@ pub use crate::grpc::Message;
 use std::convert::TryInto;
 
 use crate::grpc::{
-    address::AddressKind, input::InputKind, output::OutputKind, payload::PayloadKind, signature::SignatureKind,
-    unlock_block::UnlockBlockKind, Address, ApplicationMessagePayload, AssetBalance, AssetId, BeaconPayload,
-    BlsAddress, BlsSignature, CollectiveBeaconPayload, Conflict, DataPayload, DkgPayload, Ed25519Address,
-    Ed25519Signature, EncryptedDeal, FpcPayload, IndexationPayload, Input, MessageId, Output, OutputId, ParentsBlock,
-    ParentsKind, Payload, ReferenceUnlock, Salt, SaltDeclarationPayload, Signature, SignatureLockedAssetOutput,
-    SignatureLockedSingleOutput, SignatureUnlock, Timestamp, TransactionEssence, TransactionId, TransactionPayload,
-    UnlockBlock, UtxoInput,
+    address::Kind as AddressKind, input::Kind as InputKind, output::Kind as OutputKind, payload::Kind as PayloadKind,
+    signature::Kind as SignatureKind, unlock_block::Kind as UnlockBlockKind, Address, ApplicationMessagePayload,
+    AssetBalance, AssetId, BeaconPayload, BlsAddress, BlsSignature, CollectiveBeaconPayload, Conflict, DataPayload,
+    DkgPayload, Ed25519Address, Ed25519Signature, EncryptedDeal, FpcPayload, IndexationPayload, Input, MessageId,
+    Output, OutputId, ParentsBlock, ParentsKind, Payload, ReferenceUnlock, Salt, SaltDeclarationPayload, Signature,
+    SignatureLockedAssetOutput, SignatureLockedSingleOutput, SignatureUnlock, Timestamp, TransactionEssence,
+    TransactionId, TransactionPayload, UnlockBlock, UtxoInput,
 };
 
 impl From<&bee_message::Message> for Message {
@@ -113,7 +113,7 @@ impl Into<bee_message::MessageId> for MessageId {
 
 impl From<&bee_message::payload::Payload> for Payload {
     fn from(payload: &bee_message::payload::Payload) -> Self {
-        let payload_kind = match payload {
+        let kind = match payload {
             bee_message::payload::Payload::Data(payload) => PayloadKind::Data(payload.as_ref().into()),
             bee_message::payload::Payload::Transaction(payload) => {
                 PayloadKind::Transaction(Box::new(payload.as_ref().into()))
@@ -133,16 +133,14 @@ impl From<&bee_message::payload::Payload> for Payload {
             bee_message::payload::Payload::Indexation(payload) => PayloadKind::Indexation(payload.as_ref().into()),
         };
 
-        Self {
-            payload_kind: Some(payload_kind),
-        }
+        Self { kind: Some(kind) }
     }
 }
 
 #[allow(clippy::from_over_into)]
 impl Into<bee_message::payload::Payload> for Payload {
     fn into(self) -> bee_message::payload::Payload {
-        match self.payload_kind.unwrap() {
+        match self.kind.unwrap() {
             PayloadKind::Data(payload) => bee_message::payload::Payload::Data(Box::new(payload.into())),
             PayloadKind::Transaction(payload) => {
                 bee_message::payload::Payload::Transaction(Box::new((*payload).into()))
@@ -204,21 +202,19 @@ impl Into<bee_message::payload::transaction::TransactionPayload> for Transaction
 
 impl From<&bee_message::unlock::UnlockBlock> for UnlockBlock {
     fn from(block: &bee_message::unlock::UnlockBlock) -> Self {
-        let unlock_block_kind = match block {
+        let kind = match block {
             bee_message::unlock::UnlockBlock::Signature(block) => UnlockBlockKind::Signature(block.into()),
             bee_message::unlock::UnlockBlock::Reference(block) => UnlockBlockKind::Reference(block.into()),
         };
 
-        Self {
-            unlock_block_kind: Some(unlock_block_kind),
-        }
+        Self { kind: Some(kind) }
     }
 }
 
 #[allow(clippy::from_over_into)]
 impl Into<bee_message::unlock::UnlockBlock> for UnlockBlock {
     fn into(self) -> bee_message::unlock::UnlockBlock {
-        match self.unlock_block_kind.unwrap() {
+        match self.kind.unwrap() {
             UnlockBlockKind::Signature(block) => bee_message::unlock::UnlockBlock::Signature(block.into()),
             UnlockBlockKind::Reference(block) => bee_message::unlock::UnlockBlock::Reference(block.into()),
         }
@@ -242,21 +238,19 @@ impl Into<bee_message::unlock::SignatureUnlock> for SignatureUnlock {
 
 impl From<&bee_message::signature::Signature> for Signature {
     fn from(signature: &bee_message::signature::Signature) -> Self {
-        let signature_kind = match signature {
+        let kind = match signature {
             bee_message::signature::Signature::Ed25519(signature) => SignatureKind::Ed25519(signature.into()),
             bee_message::signature::Signature::Bls(signature) => SignatureKind::Bls(signature.into()),
         };
 
-        Self {
-            signature_kind: Some(signature_kind),
-        }
+        Self { kind: Some(kind) }
     }
 }
 
 #[allow(clippy::from_over_into)]
 impl Into<bee_message::signature::Signature> for Signature {
     fn into(self) -> bee_message::signature::Signature {
-        match self.signature_kind.unwrap() {
+        match self.kind.unwrap() {
             SignatureKind::Ed25519(signature) => bee_message::signature::Signature::Ed25519(signature.into()),
             SignatureKind::Bls(signature) => bee_message::signature::Signature::Bls(signature.into()),
         }
@@ -345,20 +339,18 @@ impl Into<bee_message::payload::transaction::TransactionEssence> for Transaction
 
 impl From<&bee_message::input::Input> for Input {
     fn from(input: &bee_message::input::Input) -> Self {
-        let input_kind = match input {
+        let kind = match input {
             bee_message::input::Input::Utxo(input) => InputKind::Utxo(input.into()),
         };
 
-        Self {
-            input_kind: Some(input_kind),
-        }
+        Self { kind: Some(kind) }
     }
 }
 
 #[allow(clippy::from_over_into)]
 impl Into<bee_message::input::Input> for Input {
     fn into(self) -> bee_message::input::Input {
-        match self.input_kind.unwrap() {
+        match self.kind.unwrap() {
             InputKind::Utxo(input) => bee_message::input::Input::Utxo(input.into()),
         }
     }
@@ -412,7 +404,7 @@ impl Into<bee_message::payload::transaction::TransactionId> for TransactionId {
 
 impl From<&bee_message::output::Output> for Output {
     fn from(output: &bee_message::output::Output) -> Self {
-        let output_kind = match output {
+        let kind = match output {
             bee_message::output::Output::SignatureLockedSingle(output) => {
                 OutputKind::SignatureLockedSingle(output.into())
             }
@@ -421,16 +413,14 @@ impl From<&bee_message::output::Output> for Output {
             }
         };
 
-        Self {
-            output_kind: Some(output_kind),
-        }
+        Self { kind: Some(kind) }
     }
 }
 
 #[allow(clippy::from_over_into)]
 impl Into<bee_message::output::Output> for Output {
     fn into(self) -> bee_message::output::Output {
-        match self.output_kind.unwrap() {
+        match self.kind.unwrap() {
             OutputKind::SignatureLockedSingle(output) => {
                 bee_message::output::Output::SignatureLockedSingle(output.into())
             }
@@ -459,21 +449,19 @@ impl Into<bee_message::output::SignatureLockedSingleOutput> for SignatureLockedS
 
 impl From<&bee_message::address::Address> for Address {
     fn from(address: &bee_message::address::Address) -> Self {
-        let address_kind = match address {
+        let kind = match address {
             bee_message::address::Address::Ed25519(address) => AddressKind::Ed25519(address.into()),
             bee_message::address::Address::Bls(address) => AddressKind::Bls(address.into()),
         };
 
-        Self {
-            address_kind: Some(address_kind),
-        }
+        Self { kind: Some(kind) }
     }
 }
 
 #[allow(clippy::from_over_into)]
 impl Into<bee_message::address::Address> for Address {
     fn into(self) -> bee_message::address::Address {
-        match self.address_kind.unwrap() {
+        match self.kind.unwrap() {
             AddressKind::Ed25519(address) => bee_message::address::Address::Ed25519(address.into()),
             AddressKind::Bls(address) => bee_message::address::Address::Bls(address.into()),
         }

--- a/bee-node/bee-plugin/src/message.rs
+++ b/bee-node/bee-plugin/src/message.rs
@@ -10,6 +10,10 @@
 //! [`Into::into`]. However, this method is allowed to panic if the message of type [`Message`] was
 //! not created by converting [`bee_message::Message`].
 
+// We cannot provide a `From<Message>` implementation for `bee_message::Message` because it is an
+// external type.
+#![allow(clippy::from_over_into)]
+
 pub use crate::grpc::Message;
 
 use crate::grpc::{
@@ -38,7 +42,6 @@ impl From<&bee_message::Message> for Message {
     }
 }
 
-#[allow(clippy::from_over_into)]
 impl Into<bee_message::Message> for Message {
     fn into(self) -> bee_message::Message {
         let mut builder = bee_message::MessageBuilder::default()
@@ -69,7 +72,6 @@ impl From<&bee_message::parents::ParentsBlock> for ParentsBlock {
     }
 }
 
-#[allow(clippy::from_over_into)]
 impl Into<bee_message::parents::ParentsBlock> for ParentsBlock {
     fn into(self) -> bee_message::parents::ParentsBlock {
         // This and every other `unwrap` in an `Into::into` implementation is ok because we assume
@@ -94,7 +96,6 @@ impl From<bee_message::parents::ParentsKind> for ParentsKind {
     }
 }
 
-#[allow(clippy::from_over_into)]
 impl Into<bee_message::parents::ParentsKind> for ParentsKind {
     fn into(self) -> bee_message::parents::ParentsKind {
         match self {
@@ -114,7 +115,6 @@ impl From<&bee_message::MessageId> for MessageId {
     }
 }
 
-#[allow(clippy::from_over_into)]
 impl Into<bee_message::MessageId> for MessageId {
     fn into(self) -> bee_message::MessageId {
         bee_message::MessageId::new(self.inner.try_into().unwrap())
@@ -147,7 +147,6 @@ impl From<&bee_message::payload::Payload> for Payload {
     }
 }
 
-#[allow(clippy::from_over_into)]
 impl Into<bee_message::payload::Payload> for Payload {
     fn into(self) -> bee_message::payload::Payload {
         match self.kind.unwrap() {
@@ -180,7 +179,6 @@ impl From<&bee_message::payload::data::DataPayload> for DataPayload {
     }
 }
 
-#[allow(clippy::from_over_into)]
 impl Into<bee_message::payload::data::DataPayload> for DataPayload {
     fn into(self) -> bee_message::payload::data::DataPayload {
         bee_message::payload::data::DataPayload::new(self.data).unwrap()
@@ -196,7 +194,6 @@ impl From<&bee_message::payload::transaction::TransactionPayload> for Transactio
     }
 }
 
-#[allow(clippy::from_over_into)]
 impl Into<bee_message::payload::transaction::TransactionPayload> for TransactionPayload {
     fn into(self) -> bee_message::payload::transaction::TransactionPayload {
         bee_message::payload::transaction::TransactionPayloadBuilder::default()
@@ -221,7 +218,6 @@ impl From<&bee_message::unlock::UnlockBlock> for UnlockBlock {
     }
 }
 
-#[allow(clippy::from_over_into)]
 impl Into<bee_message::unlock::UnlockBlock> for UnlockBlock {
     fn into(self) -> bee_message::unlock::UnlockBlock {
         match self.kind.unwrap() {
@@ -239,7 +235,6 @@ impl From<&bee_message::unlock::SignatureUnlock> for SignatureUnlock {
     }
 }
 
-#[allow(clippy::from_over_into)]
 impl Into<bee_message::unlock::SignatureUnlock> for SignatureUnlock {
     fn into(self) -> bee_message::unlock::SignatureUnlock {
         bee_message::unlock::SignatureUnlock::new(self.signature.unwrap().into())
@@ -257,7 +252,6 @@ impl From<&bee_message::signature::Signature> for Signature {
     }
 }
 
-#[allow(clippy::from_over_into)]
 impl Into<bee_message::signature::Signature> for Signature {
     fn into(self) -> bee_message::signature::Signature {
         match self.kind.unwrap() {
@@ -276,7 +270,6 @@ impl From<&bee_message::signature::Ed25519Signature> for Ed25519Signature {
     }
 }
 
-#[allow(clippy::from_over_into)]
 impl Into<bee_message::signature::Ed25519Signature> for Ed25519Signature {
     fn into(self) -> bee_message::signature::Ed25519Signature {
         bee_message::signature::Ed25519Signature::new(
@@ -294,7 +287,6 @@ impl From<&bee_message::signature::BlsSignature> for BlsSignature {
     }
 }
 
-#[allow(clippy::from_over_into)]
 impl Into<bee_message::signature::BlsSignature> for BlsSignature {
     fn into(self) -> bee_message::signature::BlsSignature {
         bee_message::signature::BlsSignature::new(self.inner.try_into().unwrap())
@@ -309,7 +301,6 @@ impl From<&bee_message::unlock::ReferenceUnlock> for ReferenceUnlock {
     }
 }
 
-#[allow(clippy::from_over_into)]
 impl Into<bee_message::unlock::ReferenceUnlock> for ReferenceUnlock {
     fn into(self) -> bee_message::unlock::ReferenceUnlock {
         bee_message::unlock::ReferenceUnlock::new(self.index.try_into().unwrap()).unwrap()
@@ -329,7 +320,6 @@ impl From<&bee_message::payload::transaction::TransactionEssence> for Transactio
     }
 }
 
-#[allow(clippy::from_over_into)]
 impl Into<bee_message::payload::transaction::TransactionEssence> for TransactionEssence {
     fn into(self) -> bee_message::payload::transaction::TransactionEssence {
         let mut builder = bee_message::payload::transaction::TransactionEssenceBuilder::default()
@@ -357,7 +347,6 @@ impl From<&bee_message::input::Input> for Input {
     }
 }
 
-#[allow(clippy::from_over_into)]
 impl Into<bee_message::input::Input> for Input {
     fn into(self) -> bee_message::input::Input {
         match self.kind.unwrap() {
@@ -374,7 +363,6 @@ impl From<&bee_message::input::UtxoInput> for UtxoInput {
     }
 }
 
-#[allow(clippy::from_over_into)]
 impl Into<bee_message::input::UtxoInput> for UtxoInput {
     fn into(self) -> bee_message::input::UtxoInput {
         bee_message::input::UtxoInput::new(self.output_id.unwrap().into())
@@ -390,7 +378,6 @@ impl From<&bee_message::output::OutputId> for OutputId {
     }
 }
 
-#[allow(clippy::from_over_into)]
 impl Into<bee_message::output::OutputId> for OutputId {
     fn into(self) -> bee_message::output::OutputId {
         bee_message::output::OutputId::new(self.transaction_id.unwrap().into(), self.index.try_into().unwrap()).unwrap()
@@ -405,7 +392,6 @@ impl From<&bee_message::payload::transaction::TransactionId> for TransactionId {
     }
 }
 
-#[allow(clippy::from_over_into)]
 impl Into<bee_message::payload::transaction::TransactionId> for TransactionId {
     fn into(self) -> bee_message::payload::transaction::TransactionId {
         bee_message::payload::transaction::TransactionId::new(self.inner.try_into().unwrap())
@@ -427,7 +413,6 @@ impl From<&bee_message::output::Output> for Output {
     }
 }
 
-#[allow(clippy::from_over_into)]
 impl Into<bee_message::output::Output> for Output {
     fn into(self) -> bee_message::output::Output {
         match self.kind.unwrap() {
@@ -450,7 +435,6 @@ impl From<&bee_message::output::SignatureLockedSingleOutput> for SignatureLocked
     }
 }
 
-#[allow(clippy::from_over_into)]
 impl Into<bee_message::output::SignatureLockedSingleOutput> for SignatureLockedSingleOutput {
     fn into(self) -> bee_message::output::SignatureLockedSingleOutput {
         bee_message::output::SignatureLockedSingleOutput::new(self.address.unwrap().into(), self.amount).unwrap()
@@ -468,7 +452,6 @@ impl From<&bee_message::address::Address> for Address {
     }
 }
 
-#[allow(clippy::from_over_into)]
 impl Into<bee_message::address::Address> for Address {
     fn into(self) -> bee_message::address::Address {
         match self.kind.unwrap() {
@@ -486,7 +469,6 @@ impl From<&bee_message::address::Ed25519Address> for Ed25519Address {
     }
 }
 
-#[allow(clippy::from_over_into)]
 impl Into<bee_message::address::Ed25519Address> for Ed25519Address {
     fn into(self) -> bee_message::address::Ed25519Address {
         bee_message::address::Ed25519Address::new(self.inner.try_into().unwrap())
@@ -501,7 +483,6 @@ impl From<&bee_message::address::BlsAddress> for BlsAddress {
     }
 }
 
-#[allow(clippy::from_over_into)]
 impl Into<bee_message::address::BlsAddress> for BlsAddress {
     fn into(self) -> bee_message::address::BlsAddress {
         bee_message::address::BlsAddress::new(self.inner.try_into().unwrap())
@@ -517,7 +498,6 @@ impl From<&bee_message::output::SignatureLockedAssetOutput> for SignatureLockedA
     }
 }
 
-#[allow(clippy::from_over_into)]
 impl Into<bee_message::output::SignatureLockedAssetOutput> for SignatureLockedAssetOutput {
     fn into(self) -> bee_message::output::SignatureLockedAssetOutput {
         bee_message::output::SignatureLockedAssetOutput::new(
@@ -537,7 +517,6 @@ impl From<&bee_message::output::AssetBalance> for AssetBalance {
     }
 }
 
-#[allow(clippy::from_over_into)]
 impl Into<bee_message::output::AssetBalance> for AssetBalance {
     fn into(self) -> bee_message::output::AssetBalance {
         bee_message::output::AssetBalance::new(self.id.unwrap().into(), self.balance)
@@ -552,7 +531,6 @@ impl From<&bee_message::output::AssetId> for AssetId {
     }
 }
 
-#[allow(clippy::from_over_into)]
 impl Into<bee_message::output::AssetId> for AssetId {
     fn into(self) -> bee_message::output::AssetId {
         bee_message::output::AssetId::new(self.inner.try_into().unwrap())
@@ -568,7 +546,6 @@ impl From<&bee_message::payload::fpc::FpcPayload> for FpcPayload {
     }
 }
 
-#[allow(clippy::from_over_into)]
 impl Into<bee_message::payload::fpc::FpcPayload> for FpcPayload {
     fn into(self) -> bee_message::payload::fpc::FpcPayload {
         bee_message::payload::fpc::FpcPayloadBuilder::default()
@@ -589,7 +566,6 @@ impl From<&bee_message::payload::fpc::Conflict> for Conflict {
     }
 }
 
-#[allow(clippy::from_over_into)]
 impl Into<bee_message::payload::fpc::Conflict> for Conflict {
     fn into(self) -> bee_message::payload::fpc::Conflict {
         bee_message::payload::fpc::Conflict::new(
@@ -610,7 +586,6 @@ impl From<&bee_message::payload::fpc::Timestamp> for Timestamp {
     }
 }
 
-#[allow(clippy::from_over_into)]
 impl Into<bee_message::payload::fpc::Timestamp> for Timestamp {
     fn into(self) -> bee_message::payload::fpc::Timestamp {
         bee_message::payload::fpc::Timestamp::new(
@@ -629,7 +604,6 @@ impl From<&bee_message::payload::drng::ApplicationMessagePayload> for Applicatio
     }
 }
 
-#[allow(clippy::from_over_into)]
 impl Into<bee_message::payload::drng::ApplicationMessagePayload> for ApplicationMessagePayload {
     fn into(self) -> bee_message::payload::drng::ApplicationMessagePayload {
         bee_message::payload::drng::ApplicationMessagePayload::new(self.instance_id)
@@ -647,7 +621,6 @@ impl From<&bee_message::payload::drng::DkgPayload> for DkgPayload {
     }
 }
 
-#[allow(clippy::from_over_into)]
 impl Into<bee_message::payload::drng::DkgPayload> for DkgPayload {
     fn into(self) -> bee_message::payload::drng::DkgPayload {
         bee_message::payload::drng::DkgPayloadBuilder::default()
@@ -672,7 +645,6 @@ impl From<&bee_message::payload::drng::EncryptedDeal> for EncryptedDeal {
     }
 }
 
-#[allow(clippy::from_over_into)]
 impl Into<bee_message::payload::drng::EncryptedDeal> for EncryptedDeal {
     fn into(self) -> bee_message::payload::drng::EncryptedDeal {
         bee_message::payload::drng::EncryptedDealBuilder::default()
@@ -697,7 +669,6 @@ impl From<&bee_message::payload::drng::BeaconPayload> for BeaconPayload {
     }
 }
 
-#[allow(clippy::from_over_into)]
 impl Into<bee_message::payload::drng::BeaconPayload> for BeaconPayload {
     fn into(self) -> bee_message::payload::drng::BeaconPayload {
         bee_message::payload::drng::BeaconPayloadBuilder::default()
@@ -722,7 +693,6 @@ impl From<&bee_message::payload::drng::CollectiveBeaconPayload> for CollectiveBe
     }
 }
 
-#[allow(clippy::from_over_into)]
 impl Into<bee_message::payload::drng::CollectiveBeaconPayload> for CollectiveBeaconPayload {
     fn into(self) -> bee_message::payload::drng::CollectiveBeaconPayload {
         bee_message::payload::drng::CollectiveBeaconPayloadBuilder::default()
@@ -747,7 +717,6 @@ impl From<&bee_message::payload::salt_declaration::SaltDeclarationPayload> for S
     }
 }
 
-#[allow(clippy::from_over_into)]
 impl Into<bee_message::payload::salt_declaration::SaltDeclarationPayload> for SaltDeclarationPayload {
     fn into(self) -> bee_message::payload::salt_declaration::SaltDeclarationPayload {
         bee_message::payload::salt_declaration::SaltDeclarationPayloadBuilder::new()
@@ -769,7 +738,6 @@ impl From<&bee_message::payload::salt_declaration::Salt> for Salt {
     }
 }
 
-#[allow(clippy::from_over_into)]
 impl Into<bee_message::payload::salt_declaration::Salt> for Salt {
     fn into(self) -> bee_message::payload::salt_declaration::Salt {
         bee_message::payload::salt_declaration::Salt::new(self.bytes, self.expiry_time).unwrap()
@@ -785,7 +753,6 @@ impl From<&bee_message::payload::indexation::IndexationPayload> for IndexationPa
     }
 }
 
-#[allow(clippy::from_over_into)]
 impl Into<bee_message::payload::indexation::IndexationPayload> for IndexationPayload {
     fn into(self) -> bee_message::payload::indexation::IndexationPayload {
         bee_message::payload::indexation::IndexationPayload::new(self.index, self.data).unwrap()

--- a/bee-node/bee-plugin/src/message.rs
+++ b/bee-node/bee-plugin/src/message.rs
@@ -74,9 +74,6 @@ impl From<&bee_message::parents::ParentsBlock> for ParentsBlock {
 
 impl Into<bee_message::parents::ParentsBlock> for ParentsBlock {
     fn into(self) -> bee_message::parents::ParentsBlock {
-        // This and every other `unwrap` in an `Into::into` implementation is ok because we assume
-        // that `self` was created from a valid `bee_message::Message` and it has no missing
-        // fields.
         bee_message::parents::ParentsBlock::new(
             ParentsKind::from_i32(self.kind).unwrap().into(),
             self.references.into_iter().map(MessageId::into).collect(),

--- a/bee-node/bee-plugin/src/message.rs
+++ b/bee-node/bee-plugin/src/message.rs
@@ -1,0 +1,52 @@
+// Copyright 2021 IOTA Stiftung
+// SPDX-License-Identifier: Apache-2.0
+
+pub use crate::grpc::{payload::PayloadKind, DataPayload, Message, ParentsBlock, Payload};
+
+impl From<&bee_message::Message> for Message {
+    fn from(message: &bee_message::Message) -> Self {
+        Self {
+            parents_block: message.parents_blocks().map(ParentsBlock::from).collect(),
+            issuer_public_key: message.issuer_public_key().to_vec(),
+            issue_timestamp: message.issue_timestamp(),
+            sequence_number: message.sequence_number(),
+            payload: message.payload().as_ref().map(Payload::from),
+            nonce: message.nonce(),
+            signature: message.signature().to_vec(),
+        }
+    }
+}
+
+impl From<&bee_message::payload::Payload> for Payload {
+    fn from(payload: &bee_message::payload::Payload) -> Self {
+        let payload_kind = match payload {
+            bee_message::payload::Payload::Data(payload) => PayloadKind::Data(DataPayload::from(payload.as_ref())),
+            bee_message::payload::Payload::Transaction(_) => todo!(),
+            bee_message::payload::Payload::Fpc(_) => todo!(),
+            bee_message::payload::Payload::ApplicationMessage(_) => todo!(),
+            bee_message::payload::Payload::Dkg(_) => todo!(),
+            bee_message::payload::Payload::Beacon(_) => todo!(),
+            bee_message::payload::Payload::CollectiveBeacon(_) => todo!(),
+            bee_message::payload::Payload::SaltDeclaration(_) => todo!(),
+            bee_message::payload::Payload::Indexation(_) => todo!(),
+        };
+
+        Self {
+            payload_kind: Some(payload_kind),
+        }
+    }
+}
+
+impl From<&bee_message::payload::data::DataPayload> for DataPayload {
+    fn from(data_payload: &bee_message::payload::data::DataPayload) -> Self {
+        Self {
+            data: data_payload.data().to_vec(),
+        }
+    }
+}
+
+impl From<&bee_message::parents::ParentsBlock> for ParentsBlock {
+    fn from(_parents_block: &bee_message::parents::ParentsBlock) -> Self {
+        todo!()
+    }
+}

--- a/bee-node/bee-plugin/src/message.rs
+++ b/bee-node/bee-plugin/src/message.rs
@@ -1,12 +1,24 @@
 // Copyright 2021 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
-pub use crate::grpc::{payload::PayloadKind, DataPayload, Message, ParentsBlock, Payload};
+//! Types for messages.
+
+pub use crate::grpc::Message;
+
+use crate::grpc::{
+    address::AddressKind, input::InputKind, output::OutputKind, payload::PayloadKind, signature::SignatureKind,
+    unlock_block::UnlockBlockKind, Address, ApplicationMessagePayload, AssetBalance, AssetId, BeaconPayload,
+    BlsAddress, BlsSignature, CollectiveBeaconPayload, Conflict, DataPayload, DkgPayload, Ed25519Address,
+    Ed25519Signature, EncryptedDeal, FpcPayload, IndexationPayload, Input, MessageId, Output, OutputId, ParentsBlock,
+    ParentsKind, Payload, ReferenceUnlock, Salt, SaltDeclarationPayload, Signature, SignatureLockedAssetOutput,
+    SignatureLockedSingleOutput, SignatureUnlock, Timestamp, TransactionEssence, TransactionId, TransactionPayload,
+    UnlockBlock, UtxoInput,
+};
 
 impl From<&bee_message::Message> for Message {
     fn from(message: &bee_message::Message) -> Self {
         Self {
-            parents_block: message.parents_blocks().map(ParentsBlock::from).collect(),
+            parents_blocks: message.parents_blocks().map(ParentsBlock::from).collect(),
             issuer_public_key: message.issuer_public_key().to_vec(),
             issue_timestamp: message.issue_timestamp(),
             sequence_number: message.sequence_number(),
@@ -17,18 +29,54 @@ impl From<&bee_message::Message> for Message {
     }
 }
 
+impl From<&bee_message::parents::ParentsBlock> for ParentsBlock {
+    fn from(block: &bee_message::parents::ParentsBlock) -> Self {
+        Self {
+            kind: ParentsKind::from(block.parents_kind()).into(),
+            references: block.iter().map(MessageId::from).collect(),
+        }
+    }
+}
+
+impl From<bee_message::parents::ParentsKind> for ParentsKind {
+    fn from(parents_kind: bee_message::parents::ParentsKind) -> Self {
+        match parents_kind {
+            bee_message::parents::ParentsKind::Strong => ParentsKind::Strong,
+            bee_message::parents::ParentsKind::Weak => ParentsKind::Weak,
+            bee_message::parents::ParentsKind::Disliked => ParentsKind::Disliked,
+            bee_message::parents::ParentsKind::Liked => ParentsKind::Liked,
+        }
+    }
+}
+
+impl From<&bee_message::MessageId> for MessageId {
+    fn from(message_id: &bee_message::MessageId) -> Self {
+        Self {
+            inner: message_id.to_vec(),
+        }
+    }
+}
+
 impl From<&bee_message::payload::Payload> for Payload {
     fn from(payload: &bee_message::payload::Payload) -> Self {
         let payload_kind = match payload {
-            bee_message::payload::Payload::Data(payload) => PayloadKind::Data(DataPayload::from(payload.as_ref())),
-            bee_message::payload::Payload::Transaction(_) => todo!(),
-            bee_message::payload::Payload::Fpc(_) => todo!(),
-            bee_message::payload::Payload::ApplicationMessage(_) => todo!(),
-            bee_message::payload::Payload::Dkg(_) => todo!(),
-            bee_message::payload::Payload::Beacon(_) => todo!(),
-            bee_message::payload::Payload::CollectiveBeacon(_) => todo!(),
-            bee_message::payload::Payload::SaltDeclaration(_) => todo!(),
-            bee_message::payload::Payload::Indexation(_) => todo!(),
+            bee_message::payload::Payload::Data(payload) => PayloadKind::Data(payload.as_ref().into()),
+            bee_message::payload::Payload::Transaction(payload) => {
+                PayloadKind::Transaction(Box::new(payload.as_ref().into()))
+            }
+            bee_message::payload::Payload::Fpc(payload) => PayloadKind::Fpc(payload.as_ref().into()),
+            bee_message::payload::Payload::ApplicationMessage(payload) => {
+                PayloadKind::ApplicationMessage(payload.as_ref().into())
+            }
+            bee_message::payload::Payload::Dkg(payload) => PayloadKind::Dkg(payload.as_ref().into()),
+            bee_message::payload::Payload::Beacon(payload) => PayloadKind::Beacon(payload.as_ref().into()),
+            bee_message::payload::Payload::CollectiveBeacon(payload) => {
+                PayloadKind::CollectiveBeacon(payload.as_ref().into())
+            }
+            bee_message::payload::Payload::SaltDeclaration(payload) => {
+                PayloadKind::SaltDeclaration(payload.as_ref().into())
+            }
+            bee_message::payload::Payload::Indexation(payload) => PayloadKind::Indexation(payload.as_ref().into()),
         };
 
         Self {
@@ -38,15 +86,320 @@ impl From<&bee_message::payload::Payload> for Payload {
 }
 
 impl From<&bee_message::payload::data::DataPayload> for DataPayload {
-    fn from(data_payload: &bee_message::payload::data::DataPayload) -> Self {
+    fn from(payload: &bee_message::payload::data::DataPayload) -> Self {
         Self {
-            data: data_payload.data().to_vec(),
+            data: payload.data().to_vec(),
         }
     }
 }
 
-impl From<&bee_message::parents::ParentsBlock> for ParentsBlock {
-    fn from(_parents_block: &bee_message::parents::ParentsBlock) -> Self {
-        todo!()
+impl From<&bee_message::payload::transaction::TransactionPayload> for TransactionPayload {
+    fn from(payload: &bee_message::payload::transaction::TransactionPayload) -> Self {
+        Self {
+            essence: Some(Box::new(payload.essence().into())),
+            unlock_blocks: payload.unlock_blocks().iter().map(UnlockBlock::from).collect(),
+        }
+    }
+}
+
+impl From<&bee_message::unlock::UnlockBlock> for UnlockBlock {
+    fn from(unlock: &bee_message::unlock::UnlockBlock) -> Self {
+        let unlock_block_kind = match unlock {
+            bee_message::unlock::UnlockBlock::Signature(unlock) => UnlockBlockKind::Signature(unlock.into()),
+            bee_message::unlock::UnlockBlock::Reference(unlock) => UnlockBlockKind::Reference(unlock.into()),
+        };
+
+        Self {
+            unlock_block_kind: Some(unlock_block_kind),
+        }
+    }
+}
+
+impl From<&bee_message::unlock::SignatureUnlock> for SignatureUnlock {
+    fn from(unlock: &bee_message::unlock::SignatureUnlock) -> Self {
+        Self {
+            signature: Some(unlock.signature().into()),
+        }
+    }
+}
+
+impl From<&bee_message::signature::Signature> for Signature {
+    fn from(signature: &bee_message::signature::Signature) -> Self {
+        let signature_kind = match signature {
+            bee_message::signature::Signature::Ed25519(signature) => SignatureKind::Ed25519(signature.into()),
+            bee_message::signature::Signature::Bls(signature) => SignatureKind::Bls(signature.into()),
+        };
+
+        Self {
+            signature_kind: Some(signature_kind),
+        }
+    }
+}
+
+impl From<&bee_message::signature::Ed25519Signature> for Ed25519Signature {
+    fn from(signature: &bee_message::signature::Ed25519Signature) -> Self {
+        Self {
+            public_key: signature.public_key().to_vec(),
+            signature: signature.signature().to_vec(),
+        }
+    }
+}
+
+impl From<&bee_message::signature::BlsSignature> for BlsSignature {
+    fn from(signature: &bee_message::signature::BlsSignature) -> Self {
+        Self {
+            inner: signature.to_vec(),
+        }
+    }
+}
+
+impl From<&bee_message::unlock::ReferenceUnlock> for ReferenceUnlock {
+    fn from(reference: &bee_message::unlock::ReferenceUnlock) -> Self {
+        Self {
+            index: reference.index().into(),
+        }
+    }
+}
+
+impl From<&bee_message::payload::transaction::TransactionEssence> for TransactionEssence {
+    fn from(essence: &bee_message::payload::transaction::TransactionEssence) -> Self {
+        Self {
+            timestamp: essence.timestamp(),
+            access_pledge_id: essence.access_pledge_id().to_vec(),
+            consensus_pledge_id: essence.consensus_pledge_id().to_vec(),
+            inputs: essence.inputs().iter().map(Input::from).collect(),
+            outputs: essence.outputs().iter().map(Output::from).collect(),
+            payload: essence.payload().as_ref().map(Payload::from).map(Box::new),
+        }
+    }
+}
+
+impl From<&bee_message::input::Input> for Input {
+    fn from(input: &bee_message::input::Input) -> Self {
+        let input_kind = match input {
+            bee_message::input::Input::Utxo(input) => InputKind::Utxo(input.into()),
+        };
+
+        Self {
+            input_kind: Some(input_kind),
+        }
+    }
+}
+
+impl From<&bee_message::input::UtxoInput> for UtxoInput {
+    fn from(input: &bee_message::input::UtxoInput) -> Self {
+        Self {
+            output_id: Some(input.output_id().into()),
+        }
+    }
+}
+
+impl From<&bee_message::output::OutputId> for OutputId {
+    fn from(output_id: &bee_message::output::OutputId) -> Self {
+        Self {
+            transaction_id: Some(output_id.transaction_id().into()),
+            index: output_id.index().into(),
+        }
+    }
+}
+
+impl From<&bee_message::payload::transaction::TransactionId> for TransactionId {
+    fn from(transaction_id: &bee_message::payload::transaction::TransactionId) -> Self {
+        Self {
+            inner: transaction_id.to_vec(),
+        }
+    }
+}
+
+impl From<&bee_message::output::Output> for Output {
+    fn from(output: &bee_message::output::Output) -> Self {
+        let output_kind = match output {
+            bee_message::output::Output::SignatureLockedSingle(output) => {
+                OutputKind::SignatureLockedSingle(output.into())
+            }
+            bee_message::output::Output::SignatureLockedAsset(output) => {
+                OutputKind::SignatureLockedAsset(output.into())
+            }
+        };
+
+        Self {
+            output_kind: Some(output_kind),
+        }
+    }
+}
+
+impl From<&bee_message::output::SignatureLockedSingleOutput> for SignatureLockedSingleOutput {
+    fn from(output: &bee_message::output::SignatureLockedSingleOutput) -> Self {
+        Self {
+            address: Some(output.address().into()),
+            amount: output.amount(),
+        }
+    }
+}
+
+impl From<&bee_message::address::Address> for Address {
+    fn from(address: &bee_message::address::Address) -> Self {
+        let address_kind = match address {
+            bee_message::address::Address::Ed25519(address) => AddressKind::Ed25519(address.into()),
+            bee_message::address::Address::Bls(address) => AddressKind::Bls(address.into()),
+        };
+
+        Self {
+            address_kind: Some(address_kind),
+        }
+    }
+}
+
+impl From<&bee_message::address::Ed25519Address> for Ed25519Address {
+    fn from(address: &bee_message::address::Ed25519Address) -> Self {
+        Self {
+            inner: address.to_vec(),
+        }
+    }
+}
+
+impl From<&bee_message::address::BlsAddress> for BlsAddress {
+    fn from(address: &bee_message::address::BlsAddress) -> Self {
+        Self {
+            inner: address.to_vec(),
+        }
+    }
+}
+
+impl From<&bee_message::output::SignatureLockedAssetOutput> for SignatureLockedAssetOutput {
+    fn from(output: &bee_message::output::SignatureLockedAssetOutput) -> Self {
+        Self {
+            address: Some(output.address().into()),
+            balances: output.balance_iter().map(AssetBalance::from).collect(),
+        }
+    }
+}
+
+impl From<&bee_message::output::AssetBalance> for AssetBalance {
+    fn from(balance: &bee_message::output::AssetBalance) -> Self {
+        Self {
+            id: Some(balance.id().into()),
+            balance: balance.balance(),
+        }
+    }
+}
+
+impl From<&bee_message::output::AssetId> for AssetId {
+    fn from(asset_id: &bee_message::output::AssetId) -> Self {
+        Self {
+            inner: asset_id.to_vec(),
+        }
+    }
+}
+
+impl From<&bee_message::payload::fpc::FpcPayload> for FpcPayload {
+    fn from(payload: &bee_message::payload::fpc::FpcPayload) -> Self {
+        Self {
+            conflicts: payload.conflicts().map(Conflict::from).collect(),
+            timestamps: payload.timestamps().map(Timestamp::from).collect(),
+        }
+    }
+}
+
+impl From<&bee_message::payload::fpc::Conflict> for Conflict {
+    fn from(conflict: &bee_message::payload::fpc::Conflict) -> Self {
+        Self {
+            transaction_id: Some(conflict.transaction_id().into()),
+            opinion: conflict.opinion().into(),
+            round: conflict.round().into(),
+        }
+    }
+}
+
+impl From<&bee_message::payload::fpc::Timestamp> for Timestamp {
+    fn from(timestamp: &bee_message::payload::fpc::Timestamp) -> Self {
+        Self {
+            message_id: Some(timestamp.message_id().into()),
+            opinion: timestamp.opinion().into(),
+            round: timestamp.round().into(),
+        }
+    }
+}
+
+impl From<&bee_message::payload::drng::ApplicationMessagePayload> for ApplicationMessagePayload {
+    fn from(payload: &bee_message::payload::drng::ApplicationMessagePayload) -> Self {
+        Self {
+            instance_id: payload.instance_id(),
+        }
+    }
+}
+
+impl From<&bee_message::payload::drng::DkgPayload> for DkgPayload {
+    fn from(payload: &bee_message::payload::drng::DkgPayload) -> Self {
+        Self {
+            instance_id: payload.instance_id(),
+            from_index: payload.from_index(),
+            to_index: payload.to_index(),
+            deal: Some(payload.deal().into()),
+        }
+    }
+}
+
+impl From<&bee_message::payload::drng::EncryptedDeal> for EncryptedDeal {
+    fn from(encrypted_deal: &bee_message::payload::drng::EncryptedDeal) -> Self {
+        Self {
+            dh_key: encrypted_deal.dh_key().to_vec(),
+            nonce: encrypted_deal.nonce().to_vec(),
+            encrpyted_share: encrypted_deal.encrypted_share().to_vec(),
+            threshold: encrypted_deal.threshold(),
+            commitments: encrypted_deal.commitments().to_vec(),
+        }
+    }
+}
+
+impl From<&bee_message::payload::drng::BeaconPayload> for BeaconPayload {
+    fn from(payload: &bee_message::payload::drng::BeaconPayload) -> Self {
+        Self {
+            instance_id: payload.instance_id(),
+            round: payload.round(),
+            partial_public_key: payload.partial_public_key().to_vec(),
+            partial_signature: payload.partial_signature().to_vec(),
+        }
+    }
+}
+
+impl From<&bee_message::payload::drng::CollectiveBeaconPayload> for CollectiveBeaconPayload {
+    fn from(payload: &bee_message::payload::drng::CollectiveBeaconPayload) -> Self {
+        Self {
+            instance_id: payload.instance_id(),
+            round: payload.round(),
+            prev_signature: payload.prev_signature().to_vec(),
+            signature: payload.signature().to_vec(),
+            distributed_public_key: payload.distributed_public_key().to_vec(),
+        }
+    }
+}
+
+impl From<&bee_message::payload::salt_declaration::SaltDeclarationPayload> for SaltDeclarationPayload {
+    fn from(payload: &bee_message::payload::salt_declaration::SaltDeclarationPayload) -> Self {
+        Self {
+            node_id: payload.node_id(),
+            salt: Some(payload.salt().into()),
+            timestamp: payload.timestamp(),
+            signature: payload.signature().to_vec(),
+        }
+    }
+}
+
+impl From<&bee_message::payload::salt_declaration::Salt> for Salt {
+    fn from(salt: &bee_message::payload::salt_declaration::Salt) -> Self {
+        Self {
+            bytes: salt.bytes().to_vec(),
+            expiry_time: salt.expiry_time(),
+        }
+    }
+}
+
+impl From<&bee_message::payload::indexation::IndexationPayload> for IndexationPayload {
+    fn from(payload: &bee_message::payload::indexation::IndexationPayload) -> Self {
+        Self {
+            index: payload.index().to_vec(),
+            data: payload.data().to_vec(),
+        }
     }
 }

--- a/bee-node/bee-plugin/src/message.rs
+++ b/bee-node/bee-plugin/src/message.rs
@@ -5,6 +5,8 @@
 
 pub use crate::grpc::Message;
 
+use std::convert::TryInto;
+
 use crate::grpc::{
     address::AddressKind, input::InputKind, output::OutputKind, payload::PayloadKind, signature::SignatureKind,
     unlock_block::UnlockBlockKind, Address, ApplicationMessagePayload, AssetBalance, AssetId, BeaconPayload,
@@ -54,6 +56,13 @@ impl From<&bee_message::MessageId> for MessageId {
         Self {
             inner: message_id.to_vec(),
         }
+    }
+}
+
+#[allow(clippy::from_over_into)]
+impl Into<bee_message::MessageId> for MessageId {
+    fn into(self) -> bee_message::MessageId {
+        bee_message::MessageId::new(self.inner.try_into().unwrap())
     }
 }
 
@@ -211,6 +220,13 @@ impl From<&bee_message::payload::transaction::TransactionId> for TransactionId {
     }
 }
 
+#[allow(clippy::from_over_into)]
+impl Into<bee_message::payload::transaction::TransactionId> for TransactionId {
+    fn into(self) -> bee_message::payload::transaction::TransactionId {
+        bee_message::payload::transaction::TransactionId::new(self.inner.try_into().unwrap())
+    }
+}
+
 impl From<&bee_message::output::Output> for Output {
     fn from(output: &bee_message::output::Output) -> Self {
         let output_kind = match output {
@@ -301,6 +317,14 @@ impl From<&bee_message::payload::fpc::FpcPayload> for FpcPayload {
     }
 }
 
+
+#[allow(clippy::from_over_into)]
+impl Into<bee_message::payload::fpc::FpcPayload> for FpcPayload {
+    fn into(self) -> bee_message::payload::fpc::FpcPayload {
+        bee_message::payload::fpc::FpcPayloadBuilder::default().with_conflicts(conflicts)
+    }
+}
+
 impl From<&bee_message::payload::fpc::Conflict> for Conflict {
     fn from(conflict: &bee_message::payload::fpc::Conflict) -> Self {
         Self {
@@ -308,6 +332,17 @@ impl From<&bee_message::payload::fpc::Conflict> for Conflict {
             opinion: conflict.opinion().into(),
             round: conflict.round().into(),
         }
+    }
+}
+
+#[allow(clippy::from_over_into)]
+impl Into<bee_message::payload::fpc::Conflict> for Conflict {
+    fn into(self) -> bee_message::payload::fpc::Conflict {
+        bee_message::payload::fpc::Conflict::new(
+            self.transaction_id.unwrap().into(),
+            self.opinion.try_into().unwrap(),
+            self.round.try_into().unwrap(),
+        )
     }
 }
 
@@ -321,11 +356,29 @@ impl From<&bee_message::payload::fpc::Timestamp> for Timestamp {
     }
 }
 
+#[allow(clippy::from_over_into)]
+impl Into<bee_message::payload::fpc::Timestamp> for Timestamp {
+    fn into(self) -> bee_message::payload::fpc::Timestamp {
+        bee_message::payload::fpc::Timestamp::new(
+            self.message_id.unwrap().into(),
+            self.opinion.try_into().unwrap(),
+            self.round.try_into().unwrap(),
+        )
+    }
+}
+
 impl From<&bee_message::payload::drng::ApplicationMessagePayload> for ApplicationMessagePayload {
     fn from(payload: &bee_message::payload::drng::ApplicationMessagePayload) -> Self {
         Self {
             instance_id: payload.instance_id(),
         }
+    }
+}
+
+#[allow(clippy::from_over_into)]
+impl Into<bee_message::payload::drng::ApplicationMessagePayload> for ApplicationMessagePayload {
+    fn into(self) -> bee_message::payload::drng::ApplicationMessagePayload {
+        bee_message::payload::drng::ApplicationMessagePayload::new(self.instance_id)
     }
 }
 
@@ -337,6 +390,19 @@ impl From<&bee_message::payload::drng::DkgPayload> for DkgPayload {
             to_index: payload.to_index(),
             deal: Some(payload.deal().into()),
         }
+    }
+}
+
+#[allow(clippy::from_over_into)]
+impl Into<bee_message::payload::drng::DkgPayload> for DkgPayload {
+    fn into(self) -> bee_message::payload::drng::DkgPayload {
+        bee_message::payload::drng::DkgPayloadBuilder::default()
+            .with_instance_id(self.instance_id)
+            .with_from_index(self.from_index)
+            .with_to_index(self.to_index)
+            .with_deal(self.deal.unwrap().into())
+            .finish()
+            .unwrap()
     }
 }
 
@@ -352,6 +418,20 @@ impl From<&bee_message::payload::drng::EncryptedDeal> for EncryptedDeal {
     }
 }
 
+#[allow(clippy::from_over_into)]
+impl Into<bee_message::payload::drng::EncryptedDeal> for EncryptedDeal {
+    fn into(self) -> bee_message::payload::drng::EncryptedDeal {
+        bee_message::payload::drng::EncryptedDealBuilder::default()
+            .with_dh_key(self.dh_key)
+            .with_nonce(self.nonce)
+            .with_encrypted_share(self.encrpyted_share)
+            .with_threshold(self.threshold)
+            .with_commitments(self.commitments)
+            .finish()
+            .unwrap()
+    }
+}
+
 impl From<&bee_message::payload::drng::BeaconPayload> for BeaconPayload {
     fn from(payload: &bee_message::payload::drng::BeaconPayload) -> Self {
         Self {
@@ -360,6 +440,19 @@ impl From<&bee_message::payload::drng::BeaconPayload> for BeaconPayload {
             partial_public_key: payload.partial_public_key().to_vec(),
             partial_signature: payload.partial_signature().to_vec(),
         }
+    }
+}
+
+#[allow(clippy::from_over_into)]
+impl Into<bee_message::payload::drng::BeaconPayload> for BeaconPayload {
+    fn into(self) -> bee_message::payload::drng::BeaconPayload {
+        bee_message::payload::drng::BeaconPayloadBuilder::default()
+            .with_instance_id(self.instance_id)
+            .with_round(self.round)
+            .with_partial_public_key(self.partial_public_key.try_into().unwrap())
+            .with_partial_signature(self.partial_signature.try_into().unwrap())
+            .finish()
+            .unwrap()
     }
 }
 
@@ -375,6 +468,20 @@ impl From<&bee_message::payload::drng::CollectiveBeaconPayload> for CollectiveBe
     }
 }
 
+#[allow(clippy::from_over_into)]
+impl Into<bee_message::payload::drng::CollectiveBeaconPayload> for CollectiveBeaconPayload {
+    fn into(self) -> bee_message::payload::drng::CollectiveBeaconPayload {
+        bee_message::payload::drng::CollectiveBeaconPayloadBuilder::default()
+            .with_instance_id(self.instance_id)
+            .with_round(self.round)
+            .with_prev_signature(self.prev_signature.try_into().unwrap())
+            .with_signature(self.signature.try_into().unwrap())
+            .with_distributed_public_key(self.distributed_public_key.try_into().unwrap())
+            .finish()
+            .unwrap()
+    }
+}
+
 impl From<&bee_message::payload::salt_declaration::SaltDeclarationPayload> for SaltDeclarationPayload {
     fn from(payload: &bee_message::payload::salt_declaration::SaltDeclarationPayload) -> Self {
         Self {
@@ -383,6 +490,19 @@ impl From<&bee_message::payload::salt_declaration::SaltDeclarationPayload> for S
             timestamp: payload.timestamp(),
             signature: payload.signature().to_vec(),
         }
+    }
+}
+
+#[allow(clippy::from_over_into)]
+impl Into<bee_message::payload::salt_declaration::SaltDeclarationPayload> for SaltDeclarationPayload {
+    fn into(self) -> bee_message::payload::salt_declaration::SaltDeclarationPayload {
+        bee_message::payload::salt_declaration::SaltDeclarationPayloadBuilder::new()
+            .with_salt(self.salt.unwrap().into())
+            .with_node_id(self.node_id)
+            .with_timestamp(self.timestamp)
+            .with_signature(self.signature.try_into().unwrap())
+            .finish()
+            .unwrap()
     }
 }
 
@@ -395,11 +515,25 @@ impl From<&bee_message::payload::salt_declaration::Salt> for Salt {
     }
 }
 
+#[allow(clippy::from_over_into)]
+impl Into<bee_message::payload::salt_declaration::Salt> for Salt {
+    fn into(self) -> bee_message::payload::salt_declaration::Salt {
+        bee_message::payload::salt_declaration::Salt::new(self.bytes, self.expiry_time).unwrap()
+    }
+}
+
 impl From<&bee_message::payload::indexation::IndexationPayload> for IndexationPayload {
     fn from(payload: &bee_message::payload::indexation::IndexationPayload) -> Self {
         Self {
             index: payload.index().to_vec(),
             data: payload.data().to_vec(),
         }
+    }
+}
+
+#[allow(clippy::from_over_into)]
+impl Into<bee_message::payload::indexation::IndexationPayload> for IndexationPayload {
+    fn into(self) -> bee_message::payload::indexation::IndexationPayload {
+        bee_message::payload::indexation::IndexationPayload::new(self.index, self.data).unwrap()
     }
 }

--- a/bee-node/bee-plugin/tests/message.rs
+++ b/bee-node/bee-plugin/tests/message.rs
@@ -1,0 +1,49 @@
+// Copyright 2021 IOTA Stiftung
+// SPDX-License-Identifier: Apache-2.0
+
+use bee_message::{
+    parents::{ParentsBlock, ParentsKind},
+    payload::{indexation::IndexationPayload, Payload},
+    util::hex_decode,
+    Message, MessageBuilder, MessageId,
+};
+use bee_test::rand::{
+    bytes::{rand_bytes, rand_bytes_array},
+    number::rand_number,
+};
+
+const PARENT_1: &str = "4cfd028fe4789dd3f4518cb67810c77772c0af52261fc767e68b64015931849e";
+const PARENT_2: &str = "9bbda9ed78333088a81c73842e242a34e56703c389cba974b11d83828f421a82";
+const PARENT_3: &str = "c3186d4e99c8e10b9529e56a54e6d7052c74b84221394c825f452eba633f2c9f";
+
+#[test]
+fn round_trip_conversion() {
+    let message = MessageBuilder::new()
+        .add_parents_block(
+            ParentsBlock::new(ParentsKind::Strong, vec![MessageId::new(hex_decode(PARENT_1).unwrap())]).unwrap(),
+        )
+        .add_parents_block(
+            ParentsBlock::new(
+                ParentsKind::Weak,
+                vec![
+                    MessageId::new(hex_decode(PARENT_2).unwrap()),
+                    MessageId::new(hex_decode(PARENT_3).unwrap()),
+                ],
+            )
+            .unwrap(),
+        )
+        .with_issuer_public_key(rand_bytes_array())
+        .with_issue_timestamp(rand_number())
+        .with_sequence_number(rand_number())
+        .with_payload(Payload::from(
+            IndexationPayload::new(rand_bytes(32), rand_bytes(256)).unwrap(),
+        ))
+        .with_nonce(0)
+        .with_signature(rand_bytes_array())
+        .finish()
+        .unwrap();
+
+    let protobuf_message = bee_plugin::message::Message::from(&message);
+    let new_message: Message = protobuf_message.into();
+    assert_eq!(message, new_message);
+}


### PR DESCRIPTION
It seems we need to be able to expose something akin to `bee-message::Message` from `bee-plugin` so we can expose messages to plugins.

Next steps:
- [x] Finish the `From<bee_message::Message>` implementation.
- [x] Decide how to handle the inverse of the previous conversion.
- [ ] Figure out if there is a way to avoid the extra `Option` types used because of the way `prost` serializes `oneof` fields.
- [x] Document all the new public types.
- [x] Test that conversions between message representations are correct.

cc: @thibault-martinez @Adam-Gleave