### PR TITLE
Fix unnecessary casts in `#[derive(Packable)]`

### DIFF
--- a/bee-common/bee-packable-derive/src/fragments.rs
+++ b/bee-common/bee-packable-derive/src/fragments.rs
@@ -165,7 +165,7 @@ impl Fragments {
         // the type of the tag is `W`. This would be
         // ```
         // Foo { bar: field_0 , baz: field_1 } => {
-        //     (tag as W).pack(packer).infallible()?;
+        //     W::pack(&tag, packer).infallible()?;
         //     <T>::pack(&field_0, packer).map_err(|err| err.map(core::convert::identity).coerce()?;
         //     <V>::pack(&field_1, packer).map_err(|err| err.map(core::convert::identity).coerce()?;
         //     Ok(())
@@ -181,7 +181,7 @@ impl Fragments {
 
         // This would be
         // ```
-        // Foo { bar: field_0 , baz: field_1 } => (tag as W).packed_len() + 0 + <T>::packed_len(&field_0) + <V>::packed_len(&field_1)
+        // Foo { bar: field_0 , baz: field_1 } => W::packed_len(&tag) + 0 + <T>::packed_len(&field_0) + <V>::packed_len(&field_1)
         // ```
         let packed_len = quote!(#pattern => #tag_ty::packed_len(&#tag) + #packed_len);
 

--- a/bee-common/bee-packable-derive/src/fragments.rs
+++ b/bee-common/bee-packable-derive/src/fragments.rs
@@ -174,7 +174,7 @@ impl Fragments {
         // The cast to `W` is included because `tag` is an integer without type annotations.
         let pack = quote! {
             #pattern => {
-                (#tag as #tag_ty).pack(packer).infallible()?;
+                #tag_ty::pack(&#tag, packer).infallible()?;
                 #pack
             }
         };
@@ -183,7 +183,7 @@ impl Fragments {
         // ```
         // Foo { bar: field_0 , baz: field_1 } => (tag as W).packed_len() + 0 + <T>::packed_len(&field_0) + <V>::packed_len(&field_1)
         // ```
-        let packed_len = quote!(#pattern => (#tag as #tag_ty).packed_len() + #packed_len);
+        let packed_len = quote!(#pattern => #tag_ty::packed_len(&#tag) + #packed_len);
 
         // And this would be
         // ```

--- a/bee-common/bee-packable-derive/src/trait_impl.rs
+++ b/bee-common/bee-packable-derive/src/trait_impl.rs
@@ -101,8 +101,8 @@ impl TraitImpl {
                         .consume_for_variant(&tag, &tag_ty)
                 }
                 Fields::Unit => (
-                    quote!(#name => (#tag as #tag_ty).pack(packer)),
-                    quote!(#name => (#tag as #tag_ty).packed_len()),
+                    quote!(#name => #tag_ty::pack(&#tag, packer)),
+                    quote!(#name => #tag_ty::packed_len(&#tag)),
                     quote!(#tag => Ok(#name)),
                 ),
             };

--- a/bee-common/bee-packable-derive/tests/fail/incorrect_tag_enum.stderr
+++ b/bee-common/bee-packable-derive/tests/fail/incorrect_tag_enum.stderr
@@ -1,4 +1,14 @@
 error[E0308]: mismatched types
+  --> $DIR/incorrect_tag_enum.rs:10:10
+   |
+10 | #[derive(Packable)]
+   |          ^^^^^^^^ expected `u8`, found `u32`
+   |
+   = note: expected reference `&u8`
+              found reference `&u32`
+   = note: this error originates in the derive macro `Packable` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0308]: mismatched types
   --> $DIR/incorrect_tag_enum.rs:15:22
    |
 10 | #[derive(Packable)]

--- a/bee-storage/bee-storage/src/system/health.rs
+++ b/bee-storage/bee-storage/src/system/health.rs
@@ -3,8 +3,6 @@
 
 //! Defines a type to represent different health states in which the storage backend can be.
 
-#![allow(clippy::unnecessary_cast)]
-
 use bee_packable::Packable;
 
 /// Represents different health states for a `StorageBackend`.


### PR DESCRIPTION
# Description of change

The code generated while deriving `Packable` triggered the `unnecessary_casts` clippy lint. This PR corrects that by using qualified paths for methods, i.e. instead of `(tag as u8).packed_len()` we write `u8::packed_len(&tag)`.

## Type of change

- Bug fix (a non-breaking change which fixes an issue)

## How the change has been tested

Running clippy over the source code for the tests.

## Change checklist

Tick the boxes that are relevant to your changes, and delete any items that are not.

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that new and existing unit tests pass locally with my changes
- [x] I have updated the CHANGELOG.md, if my changes are significant enough
