### PR TITLE
Use discriminant as `Packable` default tag if available.

### DIFF
--- a/bee-common/bee-packable-derive/src/attribute/tag.rs
+++ b/bee-common/bee-packable-derive/src/attribute/tag.rs
@@ -7,21 +7,16 @@ use proc_macro2::TokenStream;
 use quote::ToTokens;
 use syn::{
     parse::{Parse, ParseStream},
-    Attribute, ExprLit, ExprPath, Ident,
+    Attribute, ExprLit, ExprPath,
 };
 
 pub(crate) struct Tag {
-    pub(crate) value: ExprTag,
+    pub(crate) value: Option<ExprTag>,
 }
 
 impl Tag {
-    pub(crate) fn new(attrs: &[Attribute], enum_name: &Ident) -> syn::Result<Self> {
-        super::parse_attribute::<Self>("tag", attrs).unwrap_or_else(|| {
-            Err(syn::Error::new(
-                enum_name.span(),
-                "All variants of an enum that derives `Packable` require a `#[packable(tag = ...)]` attribute.",
-            ))
-        })
+    pub(crate) fn new(attrs: &[Attribute]) -> syn::Result<Self> {
+        super::parse_attribute::<Self>("tag", attrs).unwrap_or(Ok(Self { value: None }))
     }
 }
 
@@ -32,7 +27,7 @@ impl Parse for Tag {
             .parse::<ExprTag>()
             .map_err(|err| syn::Error::new(err.span(), "Tags for variants can only be literal or path expressions."))?;
 
-        Ok(Self { value })
+        Ok(Self { value: Some(value) })
     }
 }
 

--- a/bee-common/bee-packable-derive/src/trait_impl.rs
+++ b/bee-common/bee-packable-derive/src/trait_impl.rs
@@ -160,17 +160,19 @@ impl TraitImpl {
 
         let unpack_error = UnpackError::for_struct(&attrs, first_field_ty)?;
 
-        let (pack, packed_len, unpack) = match data.fields {
+        let fragments = match data.fields {
             Fields::Named(fields) => {
                 Fragments::new::<true>(quote!(Self), &fields.named, &pack_error.with, &unpack_error.with)?
-                    .consume_for_struct()
             }
             Fields::Unnamed(fields) => {
                 Fragments::new::<false>(quote!(Self), &fields.unnamed, &pack_error.with, &unpack_error.with)?
-                    .consume_for_struct()
             }
-            Fields::Unit => (quote!(Ok(())), quote!(0), quote!(Ok(Self))),
+            Fields::Unit => {
+                Fragments::new::<true>(quote!(Self), &Default::default(), &pack_error.with, &unpack_error.with)?
+            }
         };
+
+        let (pack, packed_len, unpack) = fragments.consume_for_struct();
 
         Ok(Self {
             type_name,

--- a/bee-common/bee-packable-derive/src/trait_impl.rs
+++ b/bee-common/bee-packable-derive/src/trait_impl.rs
@@ -87,7 +87,10 @@ impl TraitImpl {
             } = variant;
 
             let Tag { value: tag } = Tag::new(&attrs, &type_name)?;
-            let tag_ident = format_ident!("__TAG_{}", tags.len());
+            // @pvdrz: The span here is very important, otherwise the compiler won't detect
+            // unreachable patterns in the generated code for some reason. I think this is related
+            // to `https://github.com/rust-lang/rust/pull/80632`
+            let tag_ident = format_ident!("__TAG_{}", tags.len(), span = tag.span());
 
             // Add the `Self::` prefix to the name of the variant.
             let name = quote!(Self::#ident);

--- a/bee-common/bee-packable-derive/tests/fail/incorrect_tag_enum.stderr
+++ b/bee-common/bee-packable-derive/tests/fail/incorrect_tag_enum.stderr
@@ -1,18 +1,10 @@
 error[E0308]: mismatched types
-  --> $DIR/incorrect_tag_enum.rs:10:10
-   |
-10 | #[derive(Packable)]
-   |          ^^^^^^^^ expected `u8`, found `u32`
-   |
-   = note: expected reference `&u8`
-              found reference `&u32`
-   = note: this error originates in the derive macro `Packable` (in Nightly builds, run with -Z macro-backtrace for more info)
-
-error[E0308]: mismatched types
   --> $DIR/incorrect_tag_enum.rs:15:22
    |
-10 | #[derive(Packable)]
-   |          -------- this expression has type `u8`
-...
 15 |     #[packable(tag = 0u32)]
    |                      ^^^^ expected `u8`, found `u32`
+   |
+help: change the type of the numeric literal from `u32` to `u8`
+   |
+15 |     #[packable(tag = 0u8)]
+   |                      ^^^

--- a/bee-common/bee-packable-derive/tests/fail/missing_discriminant.rs
+++ b/bee-common/bee-packable-derive/tests/fail/missing_discriminant.rs
@@ -1,0 +1,16 @@
+// Copyright 2021 IOTA Stiftung
+// SPDX-License-Identifier: Apache-2.0
+
+#![allow(unused_imports)]
+
+use bee_packable::Packable;
+
+#[derive(Packable)]
+#[repr(u8)]
+#[packable(tag_type = u8)]
+pub enum A {
+    B = 0,
+    C,
+}
+
+fn main() {}

--- a/bee-common/bee-packable-derive/tests/fail/missing_discriminant.stderr
+++ b/bee-common/bee-packable-derive/tests/fail/missing_discriminant.stderr
@@ -1,5 +1,5 @@
 error: All variants of an enum that derives `Packable` require a `#[packable(tag = ...)]` attribute.
-  --> $DIR/missing_tag_enum.rs:15:5
+  --> $DIR/missing_discriminant.rs:13:5
    |
-15 |     None,
-   |     ^^^^
+13 |     C,
+   |     ^

--- a/bee-common/bee-packable-derive/tests/fail/overlapping_discriminant.rs
+++ b/bee-common/bee-packable-derive/tests/fail/overlapping_discriminant.rs
@@ -1,0 +1,17 @@
+// Copyright 2021 IOTA Stiftung
+// SPDX-License-Identifier: Apache-2.0
+
+#![allow(unused_imports)]
+
+use bee_packable::Packable;
+
+#[derive(Packable)]
+#[repr(u8)]
+#[packable(tag_type = u8)]
+pub enum A {
+    B = 0,
+    #[packable(tag = 0)]
+    C,
+}
+
+fn main() {}

--- a/bee-common/bee-packable-derive/tests/fail/overlapping_discriminant.stderr
+++ b/bee-common/bee-packable-derive/tests/fail/overlapping_discriminant.stderr
@@ -1,0 +1,12 @@
+error: unreachable pattern
+  --> $DIR/overlapping_discriminant.rs:13:22
+   |
+13 |     #[packable(tag = 0)]
+   |                      ^
+   |
+note: the lint level is defined here
+  --> $DIR/overlapping_discriminant.rs:8:10
+   |
+8  | #[derive(Packable)]
+   |          ^^^^^^^^
+   = note: this error originates in the derive macro `Packable` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/bee-common/bee-packable-derive/tests/lib.rs
+++ b/bee-common/bee-packable-derive/tests/lib.rs
@@ -60,9 +60,4 @@ macro_rules! make_test {
 #[rustversion::stable]
 make_test!();
 #[rustversion::not(stable)]
-make_test!(
-    packable_is_structural,
-    invalid_wrapper,
-    duplicated_tag_enum,
-    invalid_tag_enum
-);
+make_test!(invalid_tag_enum, incorrect_tag_enum);

--- a/bee-common/bee-packable-derive/tests/pass/enum_discriminant.rs
+++ b/bee-common/bee-packable-derive/tests/pass/enum_discriminant.rs
@@ -3,31 +3,42 @@
 
 use bee_packable::Packable;
 
+// repr type is used as tag type and discriminant values are used as tags.
 #[derive(Packable)]
 #[repr(u8)]
-#[packable(tag_type = u8)]
 pub enum A {
     B = 0,
     C = 1,
 }
 
+// same as the previous struct but one of the variants uses a tag attribute instead of the
+// discriminant.
 #[derive(Packable)]
 #[repr(u8)]
-#[packable(tag_type = u8)]
 pub enum D {
     E = 0,
     #[packable(tag = 1)]
     F,
 }
 
+// repr type is used as tag type but tags are specified with attributes, discriminants should be
+// ignored while packing.
 #[derive(Packable)]
 #[repr(u8)]
-#[packable(tag_type = u8)]
 pub enum G {
     #[packable(tag = 0)]
     H = 1,
     #[packable(tag = 1)]
     I = 0,
+}
+
+// tag type is specified with an attribute, repr type should be ignored while packing.
+#[derive(Packable)]
+#[repr(u8)]
+#[packable(tag_type = u16)]
+pub enum J {
+    K = 0,
+    L = 1,
 }
 
 fn main() {
@@ -39,4 +50,7 @@ fn main() {
 
     assert_eq!(G::H.pack_to_vec(), 0u8.pack_to_vec());
     assert_eq!(G::I.pack_to_vec(), 1u8.pack_to_vec());
+
+    assert_eq!(J::K.pack_to_vec(), 0u16.pack_to_vec());
+    assert_eq!(J::L.pack_to_vec(), 1u16.pack_to_vec());
 }

--- a/bee-common/bee-packable-derive/tests/pass/enum_discriminant.rs
+++ b/bee-common/bee-packable-derive/tests/pass/enum_discriminant.rs
@@ -1,0 +1,42 @@
+// Copyright 2021 IOTA Stiftung
+// SPDX-License-Identifier: Apache-2.0
+
+use bee_packable::Packable;
+
+#[derive(Packable)]
+#[repr(u8)]
+#[packable(tag_type = u8)]
+pub enum A {
+    B = 0,
+    C = 1,
+}
+
+#[derive(Packable)]
+#[repr(u8)]
+#[packable(tag_type = u8)]
+pub enum D {
+    E = 0,
+    #[packable(tag = 1)]
+    F,
+}
+
+#[derive(Packable)]
+#[repr(u8)]
+#[packable(tag_type = u8)]
+pub enum G {
+    #[packable(tag = 0)]
+    H = 1,
+    #[packable(tag = 1)]
+    I = 0,
+}
+
+fn main() {
+    assert_eq!(A::B.pack_to_vec(), 0u8.pack_to_vec());
+    assert_eq!(A::C.pack_to_vec(), 1u8.pack_to_vec());
+
+    assert_eq!(D::E.pack_to_vec(), 0u8.pack_to_vec());
+    assert_eq!(D::F.pack_to_vec(), 1u8.pack_to_vec());
+
+    assert_eq!(G::H.pack_to_vec(), 0u8.pack_to_vec());
+    assert_eq!(G::I.pack_to_vec(), 1u8.pack_to_vec());
+}

--- a/bee-storage/bee-storage/src/system/health.rs
+++ b/bee-storage/bee-storage/src/system/health.rs
@@ -8,7 +8,6 @@ use bee_packable::Packable;
 /// Represents different health states for a `StorageBackend`.
 #[repr(u8)]
 #[derive(Debug, Copy, Clone, Eq, PartialEq, Packable)]
-#[packable(tag_type = u8)]
 pub enum StorageHealth {
     /// The storage is in a healthy state.
     Healthy = 0,

--- a/bee-storage/bee-storage/src/system/health.rs
+++ b/bee-storage/bee-storage/src/system/health.rs
@@ -11,12 +11,9 @@ use bee_packable::Packable;
 #[packable(tag_type = u8)]
 pub enum StorageHealth {
     /// The storage is in a healthy state.
-    #[packable(tag = 0)]
     Healthy = 0,
     /// The storage is running and the health status is idle.
-    #[packable(tag = 1)]
     Idle = 1,
     /// The storage has been corrupted.
-    #[packable(tag = 2)]
     Corrupted = 2,
 }


### PR DESCRIPTION
# Description of change

This change lets the `Packable` derive macro use the discriminant of a unit variant as it's tag if no `tag` attribute was provided. If both the discriminant and the `tag` attribute are available, the attribute takes precedence.

## Type of change

- Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How the change has been tested

Added new tests to the macro test suite.

Make sure to provide instructions for the maintainer as well as any relevant configurations.

## Change checklist

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that new and existing unit tests pass locally with my changes
- [x] I have updated the CHANGELOG.md, if my changes are significant enough
