### PR TITLE
Fix name of p2p-identity tool in documentation

### DIFF
--- a/documentation/docs/configuration.md
+++ b/documentation/docs/configuration.md
@@ -23,12 +23,12 @@ bee -c config_example.toml
 
 ## Node
 
-| Name       | Description                                                                                | Type   |
-| :--------- | :----------------------------------------------------------------------------------------- | :----- |
-| identity   | hex representation of an Ed25519 keypair. Can be generated with the `bee p2pidentity` tool | string |
-| alias      | alias for your node. Shows up in dashboard                                                 | string |
-| bech32_hrp | network address identifier                                                                 | string |
-| network_id | network identifier                                                                         | string |
+| Name       | Description                                                                                 | Type   |
+| :--------- | :------------------------------------------------------------------------------------------ | :----- |
+| identity   | hex representation of an Ed25519 keypair. Can be generated with the `bee p2p-identity` tool | string |
+| alias      | alias for your node. Shows up in dashboard                                                  | string |
+| bech32_hrp | network address identifier                                                                  | string |
+| network_id | network identifier                                                                          | string |
 
 ## Logger
 


### PR DESCRIPTION
# Description of change

Changed the instruction on how to execute the identity tool so that it accurately  reflects the required input to run the tool.

## Links to any relevant issues

Be sure to reference any related issues by adding `fixes issue #`.

## Type of change

Choose a type of change, and delete any options that are not relevant.
- Documentation Fix

## How the change has been tested
I used it.

Make sure to provide instructions for the maintainer as well as any relevant configurations.

## Change checklist

Tick the boxes that are relevant to your changes, and delete any items that are not.

- [ ] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that new and existing unit tests pass locally with my changes
- [ ] I have updated the CHANGELOG.md, if my changes are significant enough
