### PR TITLE
Add FPC `Opinion` enum to messages

### DIFF
--- a/bee-message/src/error/packable.rs
+++ b/bee-message/src/error/packable.rs
@@ -6,6 +6,7 @@ pub use crate::{
     input::InputUnpackError,
     output::{OutputIdUnpackError, OutputUnpackError},
     payload::{
+        fpc::OpinionUnpackError,
         transaction::{TransactionEssenceUnpackError, TransactionUnpackError},
         PayloadUnpackError,
     },
@@ -26,6 +27,7 @@ pub enum MessageUnpackError {
     Input(InputUnpackError),
     InvalidPayloadKind(u32),
     InvalidOptionTag(u8),
+    Opinion(OpinionUnpackError),
     Output(OutputUnpackError),
     OutputId(OutputIdUnpackError),
     Payload(PayloadUnpackError),
@@ -55,6 +57,7 @@ impl_wrapped_validated!(
     UnlockBlockUnpackError
 );
 impl_wrapped_variant!(MessageUnpackError, MessageUnpackError::Address, AddressUnpackError);
+impl_wrapped_variant!(MessageUnpackError, MessageUnpackError::Opinion, OpinionUnpackError);
 impl_wrapped_variant!(MessageUnpackError, MessageUnpackError::Signature, SignatureUnpackError);
 impl_wrapped_variant!(MessageUnpackError, MessageUnpackError::Validation, ValidationError);
 impl_from_infallible!(MessageUnpackError);
@@ -75,6 +78,7 @@ impl fmt::Display for MessageUnpackError {
             Self::Input(e) => write!(f, "error unpacking Input: {}", e),
             Self::InvalidPayloadKind(kind) => write!(f, "invalid payload kind: {}.", kind),
             Self::InvalidOptionTag(tag) => write!(f, "invalid tag for Option: {} is not 0 or 1", tag),
+            Self::Opinion(e) => write!(f, "error unpacking Opinion: {}", e),
             Self::Output(e) => write!(f, "error unpacking Output: {}", e),
             Self::OutputId(e) => write!(f, "error unpacking OutputId: {}", e),
             Self::Payload(e) => write!(f, "error unpacking Payload: {}", e),

--- a/bee-message/src/payload/fpc/conflict.rs
+++ b/bee-message/src/payload/fpc/conflict.rs
@@ -1,25 +1,26 @@
 // Copyright 2021 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::payload::transaction::TransactionId;
+use crate::payload::{fpc::Opinion, transaction::TransactionId, MessageUnpackError};
 
 use bee_packable::Packable;
 
 /// Describes a vote in a given round for a transaction conflict.
 #[derive(Clone, Debug, Eq, PartialEq, Packable)]
 #[cfg_attr(feature = "serde1", derive(serde::Serialize, serde::Deserialize))]
+#[packable(unpack_error = MessageUnpackError)]
 pub struct Conflict {
     /// Identifier of the conflicting transaction.
     transaction_id: TransactionId,
     /// The node's opinion value in a given round.
-    opinion: u8,
+    opinion: Opinion,
     /// Voting round number.
     round: u8,
 }
 
 impl Conflict {
     /// Creates a new [`Conflict`].
-    pub fn new(transaction_id: TransactionId, opinion: u8, round: u8) -> Self {
+    pub fn new(transaction_id: TransactionId, opinion: Opinion, round: u8) -> Self {
         Self {
             transaction_id,
             opinion,
@@ -33,7 +34,7 @@ impl Conflict {
     }
 
     /// Returns the node's opinion value in a given round.
-    pub fn opinion(&self) -> u8 {
+    pub fn opinion(&self) -> Opinion {
         self.opinion
     }
 

--- a/bee-message/src/payload/fpc/mod.rs
+++ b/bee-message/src/payload/fpc/mod.rs
@@ -4,9 +4,11 @@
 //! Module describing the FPC statement payload.
 
 mod conflict;
+mod opinion;
 mod timestamp;
 
 pub use conflict::Conflict;
+pub use opinion::{Opinion, OpinionUnpackError};
 pub use timestamp::Timestamp;
 
 use crate::{
@@ -17,7 +19,7 @@ use crate::{
 use bee_packable::{error::UnpackPrefixError, BoundedU32, InvalidBoundedU32, Packable, VecPrefix};
 
 use alloc::vec::Vec;
-use core::convert::{Infallible, TryInto};
+use core::convert::TryInto;
 
 /// No [`Vec`] max length specified, so use [`PAYLOAD_LENGTH_MAX`] / length of [`Conflict`].
 const PREFIXED_CONFLICTS_LENGTH_MAX: u32 =
@@ -27,17 +29,17 @@ const PREFIXED_CONFLICTS_LENGTH_MAX: u32 =
 const PREFIXED_TIMESTAMPS_LENGTH_MAX: u32 =
     PAYLOAD_LENGTH_MAX / (MessageId::LENGTH + 2 * core::mem::size_of::<u8>()) as u32;
 
-fn unpack_prefix_to_conflict_validation_error(error: UnpackPrefixError<Infallible>) -> ValidationError {
+fn unpack_prefix_to_conflict_validation_error(error: UnpackPrefixError<MessageUnpackError>) -> MessageUnpackError {
     match error {
-        UnpackPrefixError::InvalidPrefixLength(len) => ValidationError::InvalidConflictsCount(len),
-        UnpackPrefixError::Packable(e) => match e {},
+        UnpackPrefixError::InvalidPrefixLength(len) => ValidationError::InvalidConflictsCount(len).into(),
+        UnpackPrefixError::Packable(e) => e,
     }
 }
 
-fn unpack_prefix_to_timestamp_validation_error(error: UnpackPrefixError<Infallible>) -> ValidationError {
+fn unpack_prefix_to_timestamp_validation_error(error: UnpackPrefixError<MessageUnpackError>) -> MessageUnpackError {
     match error {
-        UnpackPrefixError::InvalidPrefixLength(len) => ValidationError::InvalidTimestampsCount(len),
-        UnpackPrefixError::Packable(e) => match e {},
+        UnpackPrefixError::InvalidPrefixLength(len) => ValidationError::InvalidTimestampsCount(len).into(),
+        UnpackPrefixError::Packable(e) => e,
     }
 }
 

--- a/bee-message/src/payload/fpc/opinion.rs
+++ b/bee-message/src/payload/fpc/opinion.rs
@@ -9,17 +9,16 @@ use core::{convert::Infallible, fmt};
 
 /// Error encountered when unpacking an [`Opinion`].
 #[derive(Debug)]
-pub struct OpinionUnpackError(u8);
-
-impl OpinionUnpackError {
-    fn new(tag: u8) -> Self {
-        Self(tag)
-    }
+#[allow(missing_docs)]
+pub enum OpinionUnpackError {
+    InvalidKind(u8),
 }
 
 impl fmt::Display for OpinionUnpackError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "invalid Opinion kind: {}", self.0)
+        match self {
+            Self::InvalidKind(kind) => write!(f, "invalid Opinion kind: {}", kind),
+        }
     }
 }
 
@@ -28,7 +27,7 @@ impl_from_infallible!(OpinionUnpackError);
 /// Defines an opinion.
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Packable)]
 #[cfg_attr(feature = "serde1", derive(serde::Serialize, serde::Deserialize))]
-#[packable(tag_type = u8, with_error = OpinionUnpackError::new)]
+#[packable(tag_type = u8, with_error = OpinionUnpackError::InvalidKind)]
 #[packable(unpack_error = MessageUnpackError)]
 pub enum Opinion {
     /// Defines a "liked" opinion.

--- a/bee-message/src/payload/fpc/opinion.rs
+++ b/bee-message/src/payload/fpc/opinion.rs
@@ -1,0 +1,49 @@
+// Copyright 2021 IOTA Stiftung
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::MessageUnpackError;
+
+use bee_packable::Packable;
+
+use core::{convert::Infallible, fmt};
+
+/// Error encountered when unpacking an [`Opinion`].
+#[derive(Debug)]
+pub struct OpinionUnpackError(u8);
+
+impl OpinionUnpackError {
+    fn new(tag: u8) -> Self {
+        Self(tag)
+    }
+}
+
+impl fmt::Display for OpinionUnpackError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "invalid Opinion kind: {}", self.0)
+    }
+}
+
+impl_from_infallible!(OpinionUnpackError);
+
+/// Defines an opinion.
+#[derive(Debug, Copy, Clone, PartialEq, Eq, Packable)]
+#[cfg_attr(feature = "serde1", derive(serde::Serialize, serde::Deserialize))]
+#[packable(tag_type = u8, with_error = OpinionUnpackError::new)]
+#[packable(unpack_error = MessageUnpackError)]
+pub enum Opinion {
+    /// Defines a "liked" opinion.
+    #[packable(tag = 1)]
+    Like,
+    /// Defines a "disliked" opinion.
+    #[packable(tag = 2)]
+    Dislike,
+    /// Defines an "unknown" opinion.
+    #[packable(tag = 4)]
+    Unknown,
+}
+
+impl fmt::Display for Opinion {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "{:?}", self)
+    }
+}

--- a/bee-message/src/payload/fpc/timestamp.rs
+++ b/bee-message/src/payload/fpc/timestamp.rs
@@ -1,25 +1,26 @@
 // Copyright 2021 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::MessageId;
+use crate::{payload::fpc::Opinion, MessageId, MessageUnpackError};
 
 use bee_packable::Packable;
 
 /// Describes a vote in a given round for a message timestamp.
 #[derive(Clone, Debug, Eq, PartialEq, Packable)]
 #[cfg_attr(feature = "serde1", derive(serde::Serialize, serde::Deserialize))]
+#[packable(unpack_error = MessageUnpackError)]
 pub struct Timestamp {
     /// Identifier of the message that contains the timestamp.
     message_id: MessageId,
     /// The node's opinion value in a given round.
-    opinion: u8,
+    opinion: Opinion,
     /// Voting round number.
     round: u8,
 }
 
 impl Timestamp {
     /// Creates a new [`Timestamp`].
-    pub fn new(message_id: MessageId, opinion: u8, round: u8) -> Self {
+    pub fn new(message_id: MessageId, opinion: Opinion, round: u8) -> Self {
         Self {
             message_id,
             opinion,
@@ -33,7 +34,7 @@ impl Timestamp {
     }
 
     /// Returns the node's opinion value in a given round.
-    pub fn opinion(&self) -> u8 {
+    pub fn opinion(&self) -> Opinion {
         self.opinion
     }
 

--- a/bee-message/tests/fpc_payload.rs
+++ b/bee-message/tests/fpc_payload.rs
@@ -102,9 +102,7 @@ fn unpack_valid() {
     bytes.extend(rand_bytes_array::<32>());
     bytes.extend(vec![2, 2]);
 
-    let fpc = FpcPayload::unpack_from_slice(bytes);
-
-    assert!(fpc.is_ok());
+    assert!(FpcPayload::unpack_from_slice(bytes).is_ok());
 }
 
 #[test]
@@ -114,11 +112,11 @@ fn unpack_invalid_opinion() {
     bytes.extend(rand_bytes_array::<32>());
     bytes.extend(vec![0, 0]);
 
-    let fpc = FpcPayload::unpack_from_slice(bytes);
-
     assert!(matches!(
-        fpc.err().unwrap(),
-        UnpackError::Packable(MessageUnpackError::Opinion(OpinionUnpackError::InvalidKind(0))),
+        FpcPayload::unpack_from_slice(bytes),
+        Err(UnpackError::Packable(MessageUnpackError::Opinion(
+            OpinionUnpackError::InvalidKind(0)
+        ))),
     ));
 }
 
@@ -137,7 +135,6 @@ fn packable_round_trip() {
         ])
         .finish()
         .unwrap();
-
     let fpc_b = FpcPayload::unpack_from_slice(fpc_a.pack_to_vec().unwrap()).unwrap();
 
     assert_eq!(fpc_a, fpc_b);

--- a/bee-message/tests/fpc_payload.rs
+++ b/bee-message/tests/fpc_payload.rs
@@ -3,7 +3,7 @@
 
 use bee_message::{
     payload::{
-        fpc::{Conflict, FpcPayload, Timestamp},
+        fpc::{Conflict, FpcPayload, Opinion, Timestamp},
         transaction::TransactionId,
         MessagePayload,
     },
@@ -26,14 +26,14 @@ fn version() {
 fn new_valid() {
     let fpc = FpcPayload::builder()
         .with_conflicts(vec![
-            Conflict::new(TransactionId::from(rand_bytes_array()), 0, 0),
-            Conflict::new(TransactionId::from(rand_bytes_array()), 0, 1),
-            Conflict::new(TransactionId::from(rand_bytes_array()), 1, 2),
+            Conflict::new(TransactionId::from(rand_bytes_array()), Opinion::Dislike, 0),
+            Conflict::new(TransactionId::from(rand_bytes_array()), Opinion::Dislike, 1),
+            Conflict::new(TransactionId::from(rand_bytes_array()), Opinion::Like, 2),
         ])
         .with_timestamps(vec![
-            Timestamp::new(MessageId::from(rand_bytes_array()), 0, 0),
-            Timestamp::new(MessageId::from(rand_bytes_array()), 0, 1),
-            Timestamp::new(MessageId::from(rand_bytes_array()), 1, 2),
+            Timestamp::new(MessageId::from(rand_bytes_array()), Opinion::Dislike, 0),
+            Timestamp::new(MessageId::from(rand_bytes_array()), Opinion::Dislike, 1),
+            Timestamp::new(MessageId::from(rand_bytes_array()), Opinion::Like, 2),
         ])
         .finish();
 
@@ -43,35 +43,35 @@ fn new_valid() {
 #[test]
 fn conflict_accessors_eq() {
     let transaction_id = TransactionId::from(rand_bytes_array());
-    let conflict = Conflict::new(transaction_id, 0, 0);
+    let conflict = Conflict::new(transaction_id, Opinion::Dislike, 0);
 
     assert_eq!(conflict.transaction_id(), &transaction_id);
-    assert_eq!(conflict.opinion(), 0);
+    assert_eq!(conflict.opinion(), Opinion::Dislike);
     assert_eq!(conflict.round(), 0);
 }
 
 #[test]
 fn timestamp_accessors_eq() {
     let message_id = MessageId::from(rand_bytes_array());
-    let timestamp = Timestamp::new(message_id, 0, 0);
+    let timestamp = Timestamp::new(message_id, Opinion::Dislike, 0);
 
     assert_eq!(timestamp.message_id(), &message_id);
-    assert_eq!(timestamp.opinion(), 0);
+    assert_eq!(timestamp.opinion(), Opinion::Dislike);
     assert_eq!(timestamp.round(), 0);
 }
 
 #[test]
 fn accessors_eq() {
     let conflicts = vec![
-        Conflict::new(TransactionId::from(rand_bytes_array()), 0, 0),
-        Conflict::new(TransactionId::from(rand_bytes_array()), 0, 1),
-        Conflict::new(TransactionId::from(rand_bytes_array()), 1, 2),
+        Conflict::new(TransactionId::from(rand_bytes_array()), Opinion::Dislike, 0),
+        Conflict::new(TransactionId::from(rand_bytes_array()), Opinion::Dislike, 1),
+        Conflict::new(TransactionId::from(rand_bytes_array()), Opinion::Like, 2),
     ];
 
     let timestamps = vec![
-        Timestamp::new(MessageId::from(rand_bytes_array()), 0, 0),
-        Timestamp::new(MessageId::from(rand_bytes_array()), 0, 1),
-        Timestamp::new(MessageId::from(rand_bytes_array()), 1, 2),
+        Timestamp::new(MessageId::from(rand_bytes_array()), Opinion::Dislike, 0),
+        Timestamp::new(MessageId::from(rand_bytes_array()), Opinion::Dislike, 1),
+        Timestamp::new(MessageId::from(rand_bytes_array()), Opinion::Like, 2),
     ];
 
     let fpc = FpcPayload::builder()
@@ -89,19 +89,19 @@ fn unpack_valid() {
     let mut bytes = vec![3, 0, 0, 0];
 
     bytes.extend(rand_bytes_array::<32>());
-    bytes.extend(vec![0, 0]);
+    bytes.extend(vec![1, 0]);
     bytes.extend(rand_bytes_array::<32>());
-    bytes.extend(vec![0, 1]);
+    bytes.extend(vec![1, 1]);
     bytes.extend(rand_bytes_array::<32>());
-    bytes.extend(vec![1, 2]);
+    bytes.extend(vec![2, 2]);
 
     bytes.extend(vec![3, 0, 0, 0]);
     bytes.extend(rand_bytes_array::<32>());
-    bytes.extend(vec![0, 0]);
+    bytes.extend(vec![1, 0]);
     bytes.extend(rand_bytes_array::<32>());
-    bytes.extend(vec![0, 1]);
+    bytes.extend(vec![1, 1]);
     bytes.extend(rand_bytes_array::<32>());
-    bytes.extend(vec![1, 2]);
+    bytes.extend(vec![2, 2]);
 
     let fpc = FpcPayload::unpack_from_slice(bytes);
 
@@ -112,14 +112,14 @@ fn unpack_valid() {
 fn packable_round_trip() {
     let fpc_a = FpcPayload::builder()
         .with_conflicts(vec![
-            Conflict::new(TransactionId::from(rand_bytes_array()), 0, 0),
-            Conflict::new(TransactionId::from(rand_bytes_array()), 0, 1),
-            Conflict::new(TransactionId::from(rand_bytes_array()), 1, 2),
+            Conflict::new(TransactionId::from(rand_bytes_array()), Opinion::Dislike, 0),
+            Conflict::new(TransactionId::from(rand_bytes_array()), Opinion::Dislike, 1),
+            Conflict::new(TransactionId::from(rand_bytes_array()), Opinion::Like, 2),
         ])
         .with_timestamps(vec![
-            Timestamp::new(MessageId::from(rand_bytes_array()), 0, 0),
-            Timestamp::new(MessageId::from(rand_bytes_array()), 0, 1),
-            Timestamp::new(MessageId::from(rand_bytes_array()), 1, 2),
+            Timestamp::new(MessageId::from(rand_bytes_array()), Opinion::Dislike, 0),
+            Timestamp::new(MessageId::from(rand_bytes_array()), Opinion::Dislike, 1),
+            Timestamp::new(MessageId::from(rand_bytes_array()), Opinion::Like, 2),
         ])
         .finish()
         .unwrap();
@@ -133,14 +133,14 @@ fn packable_round_trip() {
 fn serde_round_trip() {
     let fpc_payload_1 = FpcPayload::builder()
         .with_conflicts(vec![
-            Conflict::new(TransactionId::from(rand_bytes_array()), 0, 0),
-            Conflict::new(TransactionId::from(rand_bytes_array()), 0, 1),
-            Conflict::new(TransactionId::from(rand_bytes_array()), 1, 2),
+            Conflict::new(TransactionId::from(rand_bytes_array()), Opinion::Dislike, 0),
+            Conflict::new(TransactionId::from(rand_bytes_array()), Opinion::Dislike, 1),
+            Conflict::new(TransactionId::from(rand_bytes_array()), Opinion::Like, 2),
         ])
         .with_timestamps(vec![
-            Timestamp::new(MessageId::from(rand_bytes_array()), 0, 0),
-            Timestamp::new(MessageId::from(rand_bytes_array()), 0, 1),
-            Timestamp::new(MessageId::from(rand_bytes_array()), 1, 2),
+            Timestamp::new(MessageId::from(rand_bytes_array()), Opinion::Dislike, 0),
+            Timestamp::new(MessageId::from(rand_bytes_array()), Opinion::Dislike, 1),
+            Timestamp::new(MessageId::from(rand_bytes_array()), Opinion::Like, 2),
         ])
         .finish()
         .unwrap();

--- a/bee-message/tests/fpc_payload.rs
+++ b/bee-message/tests/fpc_payload.rs
@@ -3,13 +3,13 @@
 
 use bee_message::{
     payload::{
-        fpc::{Conflict, FpcPayload, Opinion, Timestamp},
+        fpc::{Conflict, FpcPayload, Opinion, OpinionUnpackError, Timestamp},
         transaction::TransactionId,
         MessagePayload,
     },
-    MessageId,
+    MessageId, MessageUnpackError,
 };
-use bee_packable::Packable;
+use bee_packable::{Packable, UnpackError};
 use bee_test::rand::bytes::rand_bytes_array;
 
 #[test]
@@ -87,7 +87,6 @@ fn accessors_eq() {
 #[test]
 fn unpack_valid() {
     let mut bytes = vec![3, 0, 0, 0];
-
     bytes.extend(rand_bytes_array::<32>());
     bytes.extend(vec![1, 0]);
     bytes.extend(rand_bytes_array::<32>());
@@ -106,6 +105,21 @@ fn unpack_valid() {
     let fpc = FpcPayload::unpack_from_slice(bytes);
 
     assert!(fpc.is_ok());
+}
+
+#[test]
+fn unpack_invalid_opinion() {
+    let mut bytes = vec![1, 0, 0, 0];
+
+    bytes.extend(rand_bytes_array::<32>());
+    bytes.extend(vec![0, 0]);
+
+    let fpc = FpcPayload::unpack_from_slice(bytes);
+
+    assert!(matches!(
+        fpc.err().unwrap(),
+        UnpackError::Packable(MessageUnpackError::Opinion(OpinionUnpackError::InvalidKind(0))),
+    ));
 }
 
 #[test]

--- a/bee-message/tests/payload.rs
+++ b/bee-message/tests/payload.rs
@@ -9,7 +9,7 @@ use bee_message::{
     payload::{
         data::DataPayload,
         drng::{ApplicationMessagePayload, BeaconPayload, CollectiveBeaconPayload, DkgPayload, EncryptedDeal},
-        fpc::{Conflict, FpcPayload, Timestamp},
+        fpc::{Conflict, FpcPayload, Opinion, Timestamp},
         indexation::IndexationPayload,
         salt_declaration::{Salt, SaltDeclarationPayload},
         transaction::{TransactionEssence, TransactionId, TransactionPayload},
@@ -104,14 +104,14 @@ fn fpc_payload_packable_round_trip() {
     let payload_1 = Payload::from(
         FpcPayload::builder()
             .with_conflicts(vec![
-                Conflict::new(TransactionId::from(rand_bytes_array()), 0, 0),
-                Conflict::new(TransactionId::from(rand_bytes_array()), 0, 1),
-                Conflict::new(TransactionId::from(rand_bytes_array()), 1, 2),
+                Conflict::new(TransactionId::from(rand_bytes_array()), Opinion::Dislike, 0),
+                Conflict::new(TransactionId::from(rand_bytes_array()), Opinion::Dislike, 1),
+                Conflict::new(TransactionId::from(rand_bytes_array()), Opinion::Like, 2),
             ])
             .with_timestamps(vec![
-                Timestamp::new(MessageId::from(rand_bytes_array()), 0, 0),
-                Timestamp::new(MessageId::from(rand_bytes_array()), 0, 1),
-                Timestamp::new(MessageId::from(rand_bytes_array()), 1, 2),
+                Timestamp::new(MessageId::from(rand_bytes_array()), Opinion::Dislike, 0),
+                Timestamp::new(MessageId::from(rand_bytes_array()), Opinion::Dislike, 1),
+                Timestamp::new(MessageId::from(rand_bytes_array()), Opinion::Like, 2),
             ])
             .finish()
             .unwrap(),

--- a/bee-node/bee-plugin/proto/plugin.proto
+++ b/bee-node/bee-plugin/proto/plugin.proto
@@ -189,15 +189,22 @@ message FpcPayload {
     repeated Timestamp timestamps = 2;
 }
 
+enum Opinion {
+    NONE = 0;
+    LIKE = 1;
+    DISLIKE = 2;
+    UNKNOWN = 4;
+}
+
 message Conflict {
     TransactionId transaction_id = 1;
-    uint32 opinion = 2;
+    Opinion opinion = 2;
     uint32 round = 3;
 }
 
 message Timestamp {
     MessageId message_id = 1;
-    uint32 opinion = 2;
+    Opinion opinion = 2;
     uint32 round = 3;
 }
 


### PR DESCRIPTION
# Description of change

Ports over the FPC `Opinion` type from the FPC PR into `bee-message`.

## Change checklist

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that new and existing unit tests pass locally with my changes
- [ ] I have updated the CHANGELOG.md, if my changes are significant enough
