### PR TITLE
Use arrays for batched CurlP

### DIFF
--- a/bee-crypto/src/ternary/sponge/batched_curlp/bct.rs
+++ b/bee-crypto/src/ternary/sponge/batched_curlp/bct.rs
@@ -31,12 +31,6 @@ impl BcTritBuf {
             inner: vec![BcTrit::zero(); len],
         }
     }
-
-    pub(crate) fn filled(value: usize, len: usize) -> Self {
-        Self {
-            inner: vec![BcTrit(value, value); len],
-        }
-    }
 }
 
 impl Deref for BcTritBuf {
@@ -50,6 +44,39 @@ impl Deref for BcTritBuf {
 impl DerefMut for BcTritBuf {
     fn deref_mut(&mut self) -> &mut Self::Target {
         unsafe { &mut *(self.inner.deref_mut() as *mut [BcTrit] as *mut BcTrits) }
+    }
+}
+
+#[derive(Clone)]
+pub(crate) struct BcTritArr<const N: usize> {
+    inner: [BcTrit; N],
+}
+
+impl<const N: usize> BcTritArr<N> {
+    pub(crate) fn zeros() -> Self {
+        Self {
+            inner: [BcTrit::zero(); N],
+        }
+    }
+
+    pub(crate) fn filled(value: usize) -> Self {
+        Self {
+            inner: [BcTrit(value, value); N],
+        }
+    }
+}
+
+impl<const N: usize> Deref for BcTritArr<N> {
+    type Target = BcTrits;
+
+    fn deref(&self) -> &Self::Target {
+        unsafe { &*(self.inner.as_ref() as *const [BcTrit] as *const BcTrits) }
+    }
+}
+
+impl<const N: usize> DerefMut for BcTritArr<N> {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        unsafe { &mut *(self.inner.as_mut() as *mut [BcTrit] as *mut BcTrits) }
     }
 }
 

--- a/bee-crypto/src/ternary/sponge/batched_curlp/bct_curlp.rs
+++ b/bee-crypto/src/ternary/sponge/batched_curlp/bct_curlp.rs
@@ -4,7 +4,7 @@
 use crate::ternary::{
     sponge::{
         batched_curlp::{
-            bct::{BcTrit, BcTritBuf},
+            bct::{BcTrit, BcTritArr, BcTrits},
             HIGH_BITS,
         },
         CurlPRounds,
@@ -14,8 +14,8 @@ use crate::ternary::{
 
 pub(crate) struct BctCurlP {
     rounds: CurlPRounds,
-    state: BcTritBuf,
-    scratch_pad: BcTritBuf,
+    state: BcTritArr<{ 3 * HASH_LENGTH }>,
+    scratch_pad: BcTritArr<{ 3 * HASH_LENGTH }>,
 }
 
 impl BctCurlP {
@@ -25,8 +25,8 @@ impl BctCurlP {
         assert!(3 * HASH_LENGTH > 728);
         Self {
             rounds,
-            state: BcTritBuf::filled(HIGH_BITS, 3 * HASH_LENGTH),
-            scratch_pad: BcTritBuf::filled(HIGH_BITS, 3 * HASH_LENGTH),
+            state: BcTritArr::filled(HIGH_BITS),
+            scratch_pad: BcTritArr::filled(HIGH_BITS),
         }
     }
 
@@ -83,7 +83,7 @@ impl BctCurlP {
         }
     }
 
-    pub(crate) fn absorb(&mut self, bc_trits: &BcTritBuf) {
+    pub(crate) fn absorb(&mut self, bc_trits: &BcTrits) {
         let mut length = bc_trits.len();
         let mut offset = 0;
 
@@ -106,7 +106,7 @@ impl BctCurlP {
 
     // This method shouldn't assume that `result` has any particular content, just that it has an
     // adequate size.
-    pub(crate) fn squeeze_into(&mut self, result: &mut BcTritBuf) {
+    pub(crate) fn squeeze_into(&mut self, result: &mut BcTrits) {
         let trit_count = result.len();
 
         let hash_count = trit_count / HASH_LENGTH;

--- a/bee-crypto/src/ternary/sponge/batched_curlp/mod.rs
+++ b/bee-crypto/src/ternary/sponge/batched_curlp/mod.rs
@@ -8,7 +8,7 @@ mod bct_curlp;
 
 use crate::ternary::sponge::{CurlP, CurlPRounds, Sponge, HASH_LENGTH};
 
-use bct::{BcTrit, BcTritBuf};
+use bct::{BcTrit, BcTritArr, BcTritBuf};
 use bct_curlp::BctCurlP;
 
 use bee_ternary::{
@@ -31,7 +31,7 @@ pub struct BatchHasher<B: RawEncodingBuf> {
     /// An interleaved representation of the input trits.
     bct_inputs: BcTritBuf,
     /// An interleaved representation of the output trits.
-    bct_hashes: BcTritBuf,
+    bct_hashes: BcTritArr<HASH_LENGTH>,
     /// A buffer for demultiplexing.
     buf_demux: TritBuf,
     /// The CurlP hasher for binary coded trits.
@@ -53,7 +53,7 @@ where
         Self {
             trit_inputs: Vec::with_capacity(BATCH_SIZE),
             bct_inputs: BcTritBuf::zeros(input_length),
-            bct_hashes: BcTritBuf::zeros(HASH_LENGTH),
+            bct_hashes: BcTritArr::<HASH_LENGTH>::zeros(),
             buf_demux: TritBuf::zeros(HASH_LENGTH),
             bct_curlp: BctCurlP::new(rounds),
             curlp: CurlP::new(rounds),


### PR DESCRIPTION
# Description of change

Add a `BcTritArr<N>` struct akin to `[u8; N]` to avoid heap allocations and dereferences while hashing.

This improves performance from 3 to 5% according to the benchmarks.

## Type of change

Choose a type of change, and delete any options that are not relevant.

- Enhancement (a non-breaking change which adds functionality)

## How the change has been tested

Using the existing test and benchmark suite

## Change checklist

Tick the boxes that are relevant to your changes, and delete any items that are not.

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that new and existing unit tests pass locally with my changes
- [x] I have updated the CHANGELOG.md, if my changes are significant enough
