### PR TITLE
Add tangle `get` method

### DIFF
--- a/bee-tangle/src/lib.rs
+++ b/bee-tangle/src/lib.rs
@@ -44,7 +44,7 @@ impl Tangle {
         self.0.read().await.get(message_id).map(|data| data.metadata.clone())
     }
 
-    /// Retrieves both the [`Message`] and [`Metadata`] from the [`Tangle`] with a given [`MessageId`].
+    /// Retrieves both the [`Message`] and [`MessageMetadata`] from the [`Tangle`] with a given [`MessageId`].
     pub async fn get(&self, message_id: &MessageId) -> Option<(Arc<Message>, MessageMetadata)> {
         self.0
             .read()

--- a/bee-tangle/src/lib.rs
+++ b/bee-tangle/src/lib.rs
@@ -13,7 +13,7 @@ struct MessageData {
 }
 
 /// Tangle data structure.
-/// Provides a [`HashMap`] of [`MessageId`]s to [`Message`]s.
+/// Provides a [`HashMap`] of [`MessageId`]s to [`Message`]s, and their associated [`MessageMetadata`].
 #[derive(Default)]
 pub struct Tangle(RwLock<HashMap<MessageId, MessageData>>);
 
@@ -42,5 +42,14 @@ impl Tangle {
     /// Retrieves [`MessageMetadata`] from the [`Tangle`] with a given [`MessageId`].
     pub async fn get_metadata(&self, message_id: &MessageId) -> Option<MessageMetadata> {
         self.0.read().await.get(message_id).map(|data| data.metadata.clone())
+    }
+
+    /// Retrieves both the [`Message`] and [`Metadata`] from the [`Tangle`] with a given [`MessageId`].
+    pub async fn get(&self, message_id: &MessageId) -> Option<(Arc<Message>, MessageMetadata)> {
+        self.0
+            .read()
+            .await
+            .get(message_id)
+            .map(|data| (data.message.clone(), data.metadata.clone()))
     }
 }

--- a/bee-tangle/tests/tangle.rs
+++ b/bee-tangle/tests/tangle.rs
@@ -15,4 +15,6 @@ async fn insert() {
 
     assert_eq!(*tangle.get_message(&message_id).await.unwrap(), message);
     assert_eq!(tangle.get_metadata(&message_id).await.unwrap(), metadata);
+    assert_eq!(*tangle.get(&message_id).await.unwrap().0, message);
+    assert_eq!(tangle.get(&message_id).await.unwrap().1, metadata);
 }

--- a/bee-tangle/tests/tangle.rs
+++ b/bee-tangle/tests/tangle.rs
@@ -15,6 +15,8 @@ async fn insert() {
 
     assert_eq!(*tangle.get_message(&message_id).await.unwrap(), message);
     assert_eq!(tangle.get_metadata(&message_id).await.unwrap(), metadata);
-    assert_eq!(*tangle.get(&message_id).await.unwrap().0, message);
-    assert_eq!(tangle.get(&message_id).await.unwrap().1, metadata);
+
+    let (tangle_message, tangle_metadata) = tangle.get(&message_id).await.unwrap();
+    assert_eq!(*tangle_message, message);
+    assert_eq!(tangle_metadata, metadata);
 }


### PR DESCRIPTION
# Description of change

Adds a method to `Tangle` that retrieves both a `Message` and it's `MessageMetadata`.