### PR TITLE
Remove `get_message` and `get_metadata()` from Tangle API.

### DIFF
--- a/bee-tangle/src/lib.rs
+++ b/bee-tangle/src/lib.rs
@@ -14,14 +14,11 @@ pub struct MessageData {
 }
 
 impl MessageData {
-    /// Retrieves both the [`Message`] and the [`MessageMetadata`] from the [`MessageData`].
-    pub fn get(&self) -> (&Message, &MessageMetadata) {
-        (&self.message, &self.metadata)
-    }
     /// Retrieves the [`Message`] from the [`MessageData`].
     pub fn message(&self) -> &Message {
         &self.message
     }
+
     /// Retrieves the [`MessageMetadata`] from the [`MessageData`].
     pub fn metadata(&self) -> &MessageMetadata {
         &self.metadata

--- a/bee-tangle/src/lib.rs
+++ b/bee-tangle/src/lib.rs
@@ -7,10 +7,25 @@ use tokio::sync::RwLock;
 
 use std::{collections::HashMap, sync::Arc};
 
-/// Stores a [`Message`] with its [`MessageMetadata`].
+/// Used by the [`Tangle`] to store a [`Message`] with its associated [`MessageMetadata`].
 pub struct MessageData {
-    pub message: Message,
-    pub metadata: MessageMetadata,
+    message: Message,
+    metadata: MessageMetadata,
+}
+
+impl MessageData {
+    /// Retrieves both the [`Message`] and the [`MessageMetadata`] from the [`MessageData`].
+    pub fn get(&self) -> (&Message, &MessageMetadata) {
+        (&self.message, &self.metadata)
+    }
+    /// Retrieves the [`Message`] from the [`MessageData`].
+    pub fn message(&self) -> &Message {
+        &self.message
+    }
+    /// Retrieves the [`MessageMetadata`] from the [`MessageData`].
+    pub fn metadata(&self) -> &MessageMetadata {
+        &self.metadata
+    }
 }
 
 /// Tangle data structure.
@@ -34,6 +49,6 @@ impl Tangle {
 
     /// Retrieves the [`MessageData`] from the [`Tangle`] with a given [`MessageId`].
     pub async fn get(&self, message_id: &MessageId) -> Option<Arc<MessageData>> {
-        self.0.read().await.get(message_id).map(|data| data.clone())
+        self.0.read().await.get(message_id).cloned()
     }
 }

--- a/bee-tangle/src/lib.rs
+++ b/bee-tangle/src/lib.rs
@@ -26,7 +26,7 @@ impl MessageData {
 }
 
 /// Tangle data structure.
-/// Provides a [`HashMap`] of [`MessageId`]s to [`MessageData`]s..
+/// Provides a [`HashMap`] of [`MessageId`]s to [`MessageData`]s.
 #[derive(Default)]
 pub struct Tangle(RwLock<HashMap<MessageId, Arc<MessageData>>>);
 

--- a/bee-tangle/src/lib.rs
+++ b/bee-tangle/src/lib.rs
@@ -7,7 +7,7 @@ use tokio::sync::RwLock;
 
 use std::{collections::HashMap, sync::Arc};
 
-/// Used by the [`Tangle`] to store a [`Message`] with its associated [`MessageMetadata`].
+/// Data structure used by the [`Tangle`] to store a [`Message`] with its associated [`MessageMetadata`].
 pub struct MessageData {
     message: Message,
     metadata: MessageMetadata,

--- a/bee-tangle/tests/tangle.rs
+++ b/bee-tangle/tests/tangle.rs
@@ -14,6 +14,6 @@ async fn insert() {
     tangle.insert(message_id, message.clone(), metadata.clone()).await;
 
     let message_data = tangle.get(&message_id).await.unwrap();
-    assert_eq!(message_data.message, message);
-    assert_eq!(message_data.metadata, metadata);
+    assert_eq!(*message_data.message(), message);
+    assert_eq!(*message_data.metadata(), metadata);
 }

--- a/bee-tangle/tests/tangle.rs
+++ b/bee-tangle/tests/tangle.rs
@@ -13,10 +13,7 @@ async fn insert() {
     let tangle = Tangle::new();
     tangle.insert(message_id, message.clone(), metadata.clone()).await;
 
-    assert_eq!(*tangle.get_message(&message_id).await.unwrap(), message);
-    assert_eq!(tangle.get_metadata(&message_id).await.unwrap(), metadata);
-
-    let (tangle_message, tangle_metadata) = tangle.get(&message_id).await.unwrap();
-    assert_eq!(*tangle_message, message);
-    assert_eq!(tangle_metadata, metadata);
+    let message_data = tangle.get(&message_id).await.unwrap();
+    assert_eq!(message_data.message, message);
+    assert_eq!(message_data.metadata, metadata);
 }


### PR DESCRIPTION
Removes `get_message()` and `get_metadata()` from Tangle API.
This brings following guarantee along: by limiting access to the `get()` function you either will get both the message with it's associated metadata or nothing.
This change could help improve safety to some degree.