### PR TITLE
Add `bee-tangle` benchmarks

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -399,7 +399,9 @@ dependencies = [
  "bee-message",
  "bee-runtime",
  "bee-storage",
+ "bee-test",
  "bitflags",
+ "criterion",
  "dashmap",
  "futures",
  "hashbrown",
@@ -759,6 +761,7 @@ dependencies = [
  "clap",
  "criterion-plot",
  "csv",
+ "futures",
  "itertools",
  "lazy_static",
  "num-traits",
@@ -771,6 +774,7 @@ dependencies = [
  "serde_derive",
  "serde_json",
  "tinytemplate",
+ "tokio",
  "walkdir",
 ]
 

--- a/bee-tangle/Cargo.toml
+++ b/bee-tangle/Cargo.toml
@@ -27,5 +27,15 @@ rand = "0.8"
 ref-cast = "1.0"
 serde = { version = "1.0", features = [ "derive" ] }
 thiserror = "1.0"
-tokio = { version = "1.11", features = [ "sync", "time" ] }
+tokio = { version = "1.11", features = [ "rt", "rt-multi-thread", "sync", "time" ] }
 tokio-stream = { version = "0.1" }
+
+[dev-dependencies]
+bee-test = { version = "0.1.0", path = "../bee-test" }
+
+criterion = { version = "0.3.5", features = [ "async_tokio" ] }
+rand = "0.8"
+
+[[bench]]
+name = "tangle_bench"
+harness = false

--- a/bee-tangle/benches/tangle_bench.rs
+++ b/bee-tangle/benches/tangle_bench.rs
@@ -1,3 +1,6 @@
+// Copyright 2020-2021 IOTA Stiftung
+// SPDX-License-Identifier: Apache-2.0
+
 use bee_message::{Message, MessageId};
 use bee_tangle::{metadata::MessageMetadata, ConflictReason, NullHooks, Tangle};
 use bee_test::rand::{message::rand_message, metadata::rand_message_metadata, number::rand_number};

--- a/bee-tangle/benches/tangle_bench.rs
+++ b/bee-tangle/benches/tangle_bench.rs
@@ -1,0 +1,69 @@
+use bee_message::{Message, MessageId};
+use bee_tangle::{metadata::MessageMetadata, ConflictReason, NullHooks, Tangle};
+use bee_test::rand::{message::rand_message, metadata::rand_message_metadata, number::rand_number};
+
+use criterion::*;
+use rand::seq::SliceRandom;
+use tokio::runtime::Runtime;
+
+fn random_input() -> (MessageId, Message, MessageMetadata) {
+    let message = rand_message();
+    let id = message.id().0;
+
+    (id, message, rand_message_metadata())
+}
+
+async fn insert(
+    tangle: &Tangle<MessageMetadata, NullHooks<MessageMetadata>>,
+    id: MessageId,
+    message: Message,
+    metadata: MessageMetadata,
+) {
+    tangle.insert(id, message, metadata).await;
+}
+
+async fn update_metadata(tangle: &Tangle<MessageMetadata, NullHooks<MessageMetadata>>, id: &MessageId, timestamp: u64) {
+    tangle
+        .update_metadata(id, |metadata| {
+            metadata.set_conflict(ConflictReason::InputUtxoAlreadySpent);
+            metadata.reference(timestamp);
+        })
+        .await;
+}
+
+fn insert_bench(c: &mut Criterion) {
+    let tangle = Tangle::<MessageMetadata, NullHooks<MessageMetadata>>::default();
+    let rt = Runtime::new().unwrap();
+
+    c.bench_function("insert", |b| {
+        b.to_async(&rt).iter_batched(
+            || random_input(),
+            |(id, message, metadata)| insert(&tangle, id, message, metadata),
+            BatchSize::SmallInput,
+        );
+    });
+}
+
+fn update_metadata_bench(c: &mut Criterion) {
+    let tangle = Tangle::<MessageMetadata, NullHooks<MessageMetadata>>::default();
+    let rt = Runtime::new().unwrap();
+
+    let data = (0..1000).map(|_| random_input());
+    let mut ids = vec![];
+
+    for (id, message, metadata) in data {
+        rt.block_on(async { tangle.insert(id, message, metadata).await });
+        ids.push(id);
+    }
+
+    c.bench_function("update_metadata", |b| {
+        b.to_async(&rt).iter_batched(
+            || (ids.choose(&mut rand::thread_rng()).unwrap(), rand_number::<u64>()),
+            |(id, timestamp)| update_metadata(&tangle, id, timestamp),
+            BatchSize::SmallInput,
+        );
+    });
+}
+
+criterion_group!(benches, insert_bench, update_metadata_bench);
+criterion_main!(benches);

--- a/bee-tangle/benches/tangle_bench.rs
+++ b/bee-tangle/benches/tangle_bench.rs
@@ -40,7 +40,7 @@ fn insert_bench(c: &mut Criterion) {
 
     c.bench_function("insert", |b| {
         b.to_async(&rt).iter_batched(
-            || random_input(),
+            random_input,
             |(id, message, metadata)| insert(&tangle, id, message, metadata),
             BatchSize::SmallInput,
         );

--- a/bee-tangle/src/lib.rs
+++ b/bee-tangle/src/lib.rs
@@ -37,7 +37,7 @@ mod vertex;
 
 pub use conflict::ConflictReason;
 pub use ms_tangle::MsTangle;
-pub use tangle::{Hooks, Tangle};
+pub use tangle::{Hooks, NullHooks, Tangle};
 pub use tangle_worker::TangleWorker;
 
 use tip_pool_cleaner_worker::TipPoolCleanerWorker;


### PR DESCRIPTION
# Description of change

Adds benchmarking for `insert` and `update_metadata` methods of `bee_tangle::Tangle`.

Example results:
```
insert                  time:   [5.2768 us 5.5545 us 5.8579 us]
                        change: [-43.394% -17.098% +13.170%] (p = 0.48 > 0.05)
                        No change in performance detected.
Found 3 outliers among 100 measurements (3.00%)
  2 (2.00%) high mild
  1 (1.00%) high severe

update_metadata         time:   [784.78 ns 786.34 ns 788.06 ns]
                        change: [-0.3812% +0.5531% +1.4271%] (p = 0.24 > 0.05)
                        No change in performance detected.
Found 6 outliers among 100 measurements (6.00%)
  3 (3.00%) high mild
  3 (3.00%) high severe
```
