### PR TITLE
Add link to Bee documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,8 @@ having to fix each one individually.
 
 ## Supporting the project
 
+The [documentation](https://bee.docs.iota.org) provides information about the structure of Bee and instructions on how to setup your own node.
+
 If you want to discuss Bee or have some questions about it, join us on the
 [IOTA Discord server](https://discord.iota.org/) in the `#bee-dev` and
 `#bee-discussion` channels.


### PR DESCRIPTION
# Description of change

Provide a link to the documentation ([`https://bee.docs.iota.org`](https://bee.docs.iota.org)) in `README.md`.

## Type of change

- Documentation Fix
