### PR TITLE
bee-rest-api `peer` feature

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -300,7 +300,7 @@ dependencies = [
 
 [[package]]
 name = "bee-rest-api"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "bee-ledger",
  "bee-message",

--- a/bee-api/bee-rest-api/CHANGELOG.md
+++ b/bee-api/bee-rest-api/CHANGELOG.md
@@ -23,7 +23,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- `bee_protocol` feature;
+- `peer` feature;
 
 ## 0.1.1 - 2021-08-26
 

--- a/bee-api/bee-rest-api/CHANGELOG.md
+++ b/bee-api/bee-rest-api/CHANGELOG.md
@@ -19,6 +19,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Security -->
 
+## 0.1.2 - 2021-10-18
+
+### Added
+
+- `bee_protocol` feature;
+
 ## 0.1.1 - 2021-08-26
 
 ### Added

--- a/bee-api/bee-rest-api/Cargo.toml
+++ b/bee-api/bee-rest-api/Cargo.toml
@@ -21,5 +21,5 @@ serde_json = { version = "1.0.68" }
 thiserror = { version = "1.0.30" }
 
 [features]
-default = ["bee_protocol"]
-bee_protocol = ["bee-protocol"]
+default = [ "peer" ]
+bee_protocol = [ "peer" ]

--- a/bee-api/bee-rest-api/Cargo.toml
+++ b/bee-api/bee-rest-api/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bee-rest-api"
-version = "0.1.1"
+version = "0.1.2"
 authors = [ "IOTA Stiftung" ]
 edition = "2018"
 description = "The default REST API implementation for the IOTA Bee node software."
@@ -13,9 +13,13 @@ homepage = "https://www.iota.org"
 [dependencies]
 bee-ledger = { version = "0.5.0", path = "../../bee-ledger" }
 bee-message = { version = "0.1.5", path = "../../bee-message" }
-bee-protocol = { version = "0.1.1", path = "../../bee-protocol" }
+bee-protocol = { version = "0.1.1", path = "../../bee-protocol", optional = true }
 
 hex = { version = "0.4.3" }
 serde = { version = "1.0.130", features = [ "derive" ] }
 serde_json = { version = "1.0.68" }
 thiserror = { version = "1.0.30" }
+
+[features]
+default = ["bee_protocol"]
+bee_protocol = ["bee-protocol"]

--- a/bee-api/bee-rest-api/Cargo.toml
+++ b/bee-api/bee-rest-api/Cargo.toml
@@ -22,4 +22,4 @@ thiserror = { version = "1.0.30" }
 
 [features]
 default = [ "peer" ]
-bee_protocol = [ "peer" ]
+peer = [ "bee-protocol" ]

--- a/bee-api/bee-rest-api/src/types/dtos.rs
+++ b/bee-api/bee-rest-api/src/types/dtos.rs
@@ -25,7 +25,7 @@ use bee_message::{
     unlock::{ReferenceUnlock, UnlockBlock, UnlockBlocks},
     Message, MessageBuilder, MessageId,
 };
-#[cfg(feature = "bee_protocol")]
+#[cfg(feature = "peer")]
 use bee_protocol::types::peer::Peer;
 
 use serde::{Deserialize, Serialize, Serializer};
@@ -825,7 +825,7 @@ pub struct PeerDto {
     pub gossip: Option<GossipDto>,
 }
 
-#[cfg(feature = "bee_protocol")]
+#[cfg(feature = "peer")]
 impl From<&Peer> for PeerDto {
     fn from(peer: &Peer) -> Self {
         PeerDto {

--- a/bee-api/bee-rest-api/src/types/dtos.rs
+++ b/bee-api/bee-rest-api/src/types/dtos.rs
@@ -25,6 +25,7 @@ use bee_message::{
     unlock::{ReferenceUnlock, UnlockBlock, UnlockBlocks},
     Message, MessageBuilder, MessageId,
 };
+#[cfg(feature = "bee_protocol")]
 use bee_protocol::types::peer::Peer;
 
 use serde::{Deserialize, Serialize, Serializer};
@@ -824,6 +825,7 @@ pub struct PeerDto {
     pub gossip: Option<GossipDto>,
 }
 
+#[cfg(feature = "bee_protocol")]
 impl From<&Peer> for PeerDto {
     fn from(peer: &Peer) -> Self {
         PeerDto {


### PR DESCRIPTION
# Description of change

Make the bee-protocol dependency optional, because it's not required for the client library and the dependencies from libp2p only cause issues.

Should the version be "0.2.0" instead? I added it as default feature so it shouldn't break anything, but if someone would have imported it with default-feautures = false, then it would still break

## Links to any relevant issues

Could help fixing https://github.com/iotaledger/iota.rs/issues/716

## Type of change

- Enhancement (a non-breaking change which adds functionality)

## How the change has been tested

`cargo test`

## Change checklist

Tick the boxes that are relevant to your changes, and delete any items that are not.

- [ ] I have followed the contribution guidelines for this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that new and existing unit tests pass locally with my changes
- [ ] I have updated the CHANGELOG.md, if my changes are significant enough
