### PR TITLE
Remove `chrono`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -159,6 +159,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cdb031dd78e28731d87d56cc8ffef4a8f36ca26c38fe2de700543e627f8a464a"
 
 [[package]]
+name = "base-x"
+version = "0.2.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4521f3e3d031370679b3b140beb36dfe4801b09ac77e30c61941f97df3ef28b"
+
+[[package]]
 name = "base64"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -181,7 +187,6 @@ name = "bee-common"
 version = "0.5.0"
 dependencies = [
  "autocfg",
- "chrono",
  "console-subscriber",
  "fern",
  "jsonwebtoken",
@@ -190,6 +195,7 @@ dependencies = [
  "rust-argon2",
  "serde",
  "thiserror",
+ "time 0.2.27",
  "tracing-subscriber",
 ]
 
@@ -223,7 +229,6 @@ dependencies = [
  "bee-runtime",
  "bee-storage",
  "bee-tangle",
- "chrono",
  "digest",
  "futures",
  "hashbrown",
@@ -630,7 +635,7 @@ dependencies = [
  "libc",
  "num-integer",
  "num-traits",
- "time",
+ "time 0.1.44",
  "winapi",
 ]
 
@@ -707,6 +712,12 @@ dependencies = [
  "tracing-core",
  "tracing-subscriber",
 ]
+
+[[package]]
+name = "const_fn"
+version = "0.4.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f92cfa0fd5690b3cf8c1ef2cabbd9b7ef22fa53cf5e1f92b05103f6d5d1cf6e7"
 
 [[package]]
 name = "constant_time_eq"
@@ -923,6 +934,12 @@ checksum = "d3dd60d1080a57a05ab032377049e0591415d2b31afd7028356dbf3cc6dcb066"
 dependencies = [
  "generic-array",
 ]
+
+[[package]]
+name = "discard"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "212d0f5754cb6769937f4501cc0e67f4f4483c8d2c3e1e922ee9edbe4ab4c7c0"
 
 [[package]]
 name = "ed25519"
@@ -2708,6 +2725,15 @@ checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
 
 [[package]]
 name = "rustc_version"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "138e3e0acb6c9fb258b19b67cb8abd63c00679d2851805ea151465464fe9030a"
+dependencies = [
+ "semver 0.9.0",
+]
+
+[[package]]
+name = "rustc_version"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0dfe2087c51c460008730de8b57e6a320782fbfb312e1f4d520e6c6fae155ee"
@@ -2791,11 +2817,20 @@ dependencies = [
 
 [[package]]
 name = "semver"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d7eb9ef2c18661902cc47e535f9bc51b78acd254da71d375c2f6720d9a40403"
+dependencies = [
+ "semver-parser 0.7.0",
+]
+
+[[package]]
+name = "semver"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f301af10236f6df4160f7c3f04eec6dbc70ace82d23326abad5edee88801c6b6"
 dependencies = [
- "semver-parser",
+ "semver-parser 0.10.2",
 ]
 
 [[package]]
@@ -2803,6 +2838,12 @@ name = "semver"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "568a8e6258aa33c13358f81fd834adb854c6f7c9468520910a9b1e8fac068012"
+
+[[package]]
+name = "semver-parser"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "388a1df253eca08550bef6c72392cfe7c30914bf41df5269b68cbd6ff8f570a3"
 
 [[package]]
 name = "semver-parser"
@@ -2887,6 +2928,12 @@ dependencies = [
  "quote",
  "syn",
 ]
+
+[[package]]
+name = "sha1"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2579985fda508104f7587689507983eadd6a6e84dd35d6d115361f530916fa0d"
 
 [[package]]
 name = "sha2"
@@ -3029,10 +3076,68 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6e63cff320ae2c57904679ba7cb63280a3dc4613885beafb148ee7bf9aa9042d"
 
 [[package]]
+name = "standback"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e113fb6f3de07a243d434a56ec6f186dfd51cb08448239fe7bcae73f87ff28ff"
+dependencies = [
+ "version_check",
+]
+
+[[package]]
 name = "static_assertions"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
+
+[[package]]
+name = "stdweb"
+version = "0.4.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d022496b16281348b52d0e30ae99e01a73d737b2f45d38fed4edf79f9325a1d5"
+dependencies = [
+ "discard",
+ "rustc_version 0.2.3",
+ "stdweb-derive",
+ "stdweb-internal-macros",
+ "stdweb-internal-runtime",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "stdweb-derive"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c87a60a40fccc84bef0652345bbbbbe20a605bf5d0ce81719fc476f5c03b50ef"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "serde",
+ "serde_derive",
+ "syn",
+]
+
+[[package]]
+name = "stdweb-internal-macros"
+version = "0.2.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "58fa5ff6ad0d98d1ffa8cb115892b6e69d67799f6763e162a1c9db421dc22e11"
+dependencies = [
+ "base-x",
+ "proc-macro2",
+ "quote",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "sha1",
+ "syn",
+]
+
+[[package]]
+name = "stdweb-internal-runtime"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "213701ba3370744dcd1a12960caa4843b3d68b4d1c0a5d575e0d65b2ee9d16c0"
 
 [[package]]
 name = "subtle"
@@ -3130,6 +3235,44 @@ dependencies = [
  "libc",
  "wasi 0.10.0+wasi-snapshot-preview1",
  "winapi",
+]
+
+[[package]]
+name = "time"
+version = "0.2.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4752a97f8eebd6854ff91f1c1824cd6160626ac4bd44287f7f4ea2035a02a242"
+dependencies = [
+ "const_fn",
+ "libc",
+ "standback",
+ "stdweb",
+ "time-macros",
+ "version_check",
+ "winapi",
+]
+
+[[package]]
+name = "time-macros"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "957e9c6e26f12cb6d0dd7fc776bb67a706312e7299aed74c8dd5b17ebb27e2f1"
+dependencies = [
+ "proc-macro-hack",
+ "time-macros-impl",
+]
+
+[[package]]
+name = "time-macros-impl"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fd3c141a1b43194f3f56a1411225df8646c55781d5f26db825b3d98507eb482f"
+dependencies = [
+ "proc-macro-hack",
+ "proc-macro2",
+ "quote",
+ "standback",
+ "syn",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -159,12 +159,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cdb031dd78e28731d87d56cc8ffef4a8f36ca26c38fe2de700543e627f8a464a"
 
 [[package]]
-name = "base-x"
-version = "0.2.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4521f3e3d031370679b3b140beb36dfe4801b09ac77e30c61941f97df3ef28b"
-
-[[package]]
 name = "base64"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -195,7 +189,7 @@ dependencies = [
  "rust-argon2",
  "serde",
  "thiserror",
- "time 0.2.27",
+ "time 0.3.3",
  "tracing-subscriber",
 ]
 
@@ -714,12 +708,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "const_fn"
-version = "0.4.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f92cfa0fd5690b3cf8c1ef2cabbd9b7ef22fa53cf5e1f92b05103f6d5d1cf6e7"
-
-[[package]]
 name = "constant_time_eq"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -934,12 +922,6 @@ checksum = "d3dd60d1080a57a05ab032377049e0591415d2b31afd7028356dbf3cc6dcb066"
 dependencies = [
  "generic-array",
 ]
-
-[[package]]
-name = "discard"
-version = "1.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "212d0f5754cb6769937f4501cc0e67f4f4483c8d2c3e1e922ee9edbe4ab4c7c0"
 
 [[package]]
 name = "ed25519"
@@ -2725,15 +2707,6 @@ checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
 
 [[package]]
 name = "rustc_version"
-version = "0.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "138e3e0acb6c9fb258b19b67cb8abd63c00679d2851805ea151465464fe9030a"
-dependencies = [
- "semver 0.9.0",
-]
-
-[[package]]
-name = "rustc_version"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0dfe2087c51c460008730de8b57e6a320782fbfb312e1f4d520e6c6fae155ee"
@@ -2817,20 +2790,11 @@ dependencies = [
 
 [[package]]
 name = "semver"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d7eb9ef2c18661902cc47e535f9bc51b78acd254da71d375c2f6720d9a40403"
-dependencies = [
- "semver-parser 0.7.0",
-]
-
-[[package]]
-name = "semver"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f301af10236f6df4160f7c3f04eec6dbc70ace82d23326abad5edee88801c6b6"
 dependencies = [
- "semver-parser 0.10.2",
+ "semver-parser",
 ]
 
 [[package]]
@@ -2838,12 +2802,6 @@ name = "semver"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "568a8e6258aa33c13358f81fd834adb854c6f7c9468520910a9b1e8fac068012"
-
-[[package]]
-name = "semver-parser"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "388a1df253eca08550bef6c72392cfe7c30914bf41df5269b68cbd6ff8f570a3"
 
 [[package]]
 name = "semver-parser"
@@ -2928,12 +2886,6 @@ dependencies = [
  "quote",
  "syn",
 ]
-
-[[package]]
-name = "sha1"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2579985fda508104f7587689507983eadd6a6e84dd35d6d115361f530916fa0d"
 
 [[package]]
 name = "sha2"
@@ -3076,68 +3028,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6e63cff320ae2c57904679ba7cb63280a3dc4613885beafb148ee7bf9aa9042d"
 
 [[package]]
-name = "standback"
-version = "0.2.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e113fb6f3de07a243d434a56ec6f186dfd51cb08448239fe7bcae73f87ff28ff"
-dependencies = [
- "version_check",
-]
-
-[[package]]
 name = "static_assertions"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
-
-[[package]]
-name = "stdweb"
-version = "0.4.20"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d022496b16281348b52d0e30ae99e01a73d737b2f45d38fed4edf79f9325a1d5"
-dependencies = [
- "discard",
- "rustc_version 0.2.3",
- "stdweb-derive",
- "stdweb-internal-macros",
- "stdweb-internal-runtime",
- "wasm-bindgen",
-]
-
-[[package]]
-name = "stdweb-derive"
-version = "0.5.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c87a60a40fccc84bef0652345bbbbbe20a605bf5d0ce81719fc476f5c03b50ef"
-dependencies = [
- "proc-macro2",
- "quote",
- "serde",
- "serde_derive",
- "syn",
-]
-
-[[package]]
-name = "stdweb-internal-macros"
-version = "0.2.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "58fa5ff6ad0d98d1ffa8cb115892b6e69d67799f6763e162a1c9db421dc22e11"
-dependencies = [
- "base-x",
- "proc-macro2",
- "quote",
- "serde",
- "serde_derive",
- "serde_json",
- "sha1",
- "syn",
-]
-
-[[package]]
-name = "stdweb-internal-runtime"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "213701ba3370744dcd1a12960caa4843b3d68b4d1c0a5d575e0d65b2ee9d16c0"
 
 [[package]]
 name = "subtle"
@@ -3239,40 +3133,12 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.2.27"
+version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4752a97f8eebd6854ff91f1c1824cd6160626ac4bd44287f7f4ea2035a02a242"
+checksum = "cde1cf55178e0293453ba2cca0d5f8392a922e52aa958aee9c28ed02becc6d03"
 dependencies = [
- "const_fn",
+ "itoa",
  "libc",
- "standback",
- "stdweb",
- "time-macros",
- "version_check",
- "winapi",
-]
-
-[[package]]
-name = "time-macros"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "957e9c6e26f12cb6d0dd7fc776bb67a706312e7299aed74c8dd5b17ebb27e2f1"
-dependencies = [
- "proc-macro-hack",
- "time-macros-impl",
-]
-
-[[package]]
-name = "time-macros-impl"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd3c141a1b43194f3f56a1411225df8646c55781d5f26db825b3d98507eb482f"
-dependencies = [
- "proc-macro-hack",
- "proc-macro2",
- "quote",
- "standback",
- "syn",
 ]
 
 [[package]]

--- a/bee-common/bee-common/Cargo.toml
+++ b/bee-common/bee-common/Cargo.toml
@@ -22,7 +22,7 @@ rand = { version = "0.8.4", optional = true }
 rust-argon2 = { version = "0.8.3", optional = true }
 serde = { version = "1.0.130", features = [ "derive" ] }
 thiserror = "1.0.30"
-time = "0.2.27"
+time = { version = "0.3.0", features = [ "formatting", "local-offset" ] }
 tracing-subscriber = { version = "0.2.25", optional = true }
 
 [build-dependencies]

--- a/bee-common/bee-common/Cargo.toml
+++ b/bee-common/bee-common/Cargo.toml
@@ -14,7 +14,6 @@ homepage = "https://www.iota.org"
 normal = [ "fern" ]
 
 [dependencies]
-chrono = "0.4.19"
 console-subscriber = { git = "https://github.com/tokio-rs/console.git", branch = "main", optional = true }
 fern = { version = "0.6.0", features = [ "colored" ] }
 jsonwebtoken = { version = "7.2.0", optional = true }
@@ -23,6 +22,7 @@ rand = { version = "0.8.4", optional = true }
 rust-argon2 = { version = "0.8.3", optional = true }
 serde = { version = "1.0.130", features = [ "derive" ] }
 thiserror = "1.0.30"
+time = "0.2.27"
 tracing-subscriber = { version = "0.2.25", optional = true }
 
 [build-dependencies]

--- a/bee-common/bee-common/src/lib.rs
+++ b/bee-common/bee-common/src/lib.rs
@@ -11,3 +11,4 @@ pub mod auth;
 pub mod logger;
 pub mod ord;
 pub mod packable;
+pub mod time;

--- a/bee-common/bee-common/src/logger/mod.rs
+++ b/bee-common/bee-common/src/logger/mod.rs
@@ -7,6 +7,7 @@ mod config;
 
 pub use config::{LoggerConfig, LoggerConfigBuilder, LoggerOutputConfig, LoggerOutputConfigBuilder};
 
+#[cfg(not(feature = "tokio-console"))]
 use crate::time as time_util;
 
 use thiserror::Error;

--- a/bee-common/bee-common/src/logger/mod.rs
+++ b/bee-common/bee-common/src/logger/mod.rs
@@ -27,11 +27,9 @@ pub enum Error {
 #[cfg(not(feature = "tokio-console"))]
 macro_rules! log_format {
     ($target:expr, $level:expr, $message:expr, $target_width:expr, $level_width:expr) => {
-        use crate::time as time_util;
-    
         format_args!(
             "{} {:target_width$} {:level_width$} {}",
-            time_util::format(&time_util::now_local()),
+            crate::time::format(&crate::time::now_local()),
             $target,
             $level,
             $message,

--- a/bee-common/bee-common/src/logger/mod.rs
+++ b/bee-common/bee-common/src/logger/mod.rs
@@ -7,9 +7,6 @@ mod config;
 
 pub use config::{LoggerConfig, LoggerConfigBuilder, LoggerOutputConfig, LoggerOutputConfigBuilder};
 
-#[cfg(not(feature = "tokio-console"))]
-use crate::time as time_util;
-
 use thiserror::Error;
 
 /// Name of the standard output.
@@ -30,6 +27,8 @@ pub enum Error {
 #[cfg(not(feature = "tokio-console"))]
 macro_rules! log_format {
     ($target:expr, $level:expr, $message:expr, $target_width:expr, $level_width:expr) => {
+        use crate::time as time_util;
+    
         format_args!(
             "{} {:target_width$} {:level_width$} {}",
             time_util::format(&time_util::now_local()),

--- a/bee-common/bee-common/src/logger/mod.rs
+++ b/bee-common/bee-common/src/logger/mod.rs
@@ -7,6 +7,8 @@ mod config;
 
 pub use config::{LoggerConfig, LoggerConfigBuilder, LoggerOutputConfig, LoggerOutputConfigBuilder};
 
+use crate::time as time_util;
+
 use thiserror::Error;
 
 /// Name of the standard output.
@@ -29,7 +31,7 @@ macro_rules! log_format {
     ($target:expr, $level:expr, $message:expr, $target_width:expr, $level_width:expr) => {
         format_args!(
             "{} {:target_width$} {:level_width$} {}",
-            chrono::Local::now().format("%Y-%m-%d %H:%M:%S"),
+            time_util::format(&time_util::now_local()),
             $target,
             $level,
             $message,

--- a/bee-common/bee-common/src/time.rs
+++ b/bee-common/bee-common/src/time.rs
@@ -1,0 +1,24 @@
+// Copyright 2020-2021 IOTA Stiftung
+// SPDX-License-Identifier: Apache-2.0
+
+//! A module that provides common functions for timestamps.
+
+/// Retrieves the current timestamp, including UTC offset.
+pub fn now_local() -> time::OffsetDateTime {
+    time::OffsetDateTime::try_now_local().expect("indeterminate utc offset")
+}
+
+/// Retrieves the current timestamp, at UTC.
+pub fn now_utc() -> time::OffsetDateTime {
+    time::OffsetDateTime::now_utc()
+}
+
+/// Creates a new time from a unix timestamp, at UTC. 
+pub fn from_unix_timestamp(timestamp: i64) -> time::OffsetDateTime {
+    time::OffsetDateTime::from_unix_timestamp(timestamp)
+}
+
+/// Produces a formatted `String` from a timestamp, displayed as local time.
+pub fn format(time: &time::OffsetDateTime) -> String {
+    time.format("%F %T")
+}

--- a/bee-common/bee-common/src/time.rs
+++ b/bee-common/bee-common/src/time.rs
@@ -5,7 +5,7 @@
 
 /// Retrieves the current timestamp, including UTC offset.
 pub fn now_local() -> time::OffsetDateTime {
-    time::OffsetDateTime::try_now_local().expect("indeterminate utc offset")
+    time::OffsetDateTime::now_local().expect("indeterminate utc offset")
 }
 
 /// Retrieves the current timestamp, at UTC.
@@ -15,10 +15,14 @@ pub fn now_utc() -> time::OffsetDateTime {
 
 /// Creates a new time from a unix timestamp, at UTC.
 pub fn from_unix_timestamp(timestamp: i64) -> time::OffsetDateTime {
-    time::OffsetDateTime::from_unix_timestamp(timestamp)
+    time::OffsetDateTime::from_unix_timestamp(timestamp).expect("timestamp out of range")
 }
 
 /// Produces a formatted `String` from a timestamp, displayed as local time.
 pub fn format(time: &time::OffsetDateTime) -> String {
-    time.format("%F %T")
+    // This format string is correct, so unwrapping is fine.
+    let format_description = time::format_description::parse("[year]-[month]-[day] [hour]:[minute]:[second]").unwrap();
+
+    // We know this is correct.
+    time.format(&format_description).unwrap()
 }

--- a/bee-common/bee-common/src/time.rs
+++ b/bee-common/bee-common/src/time.rs
@@ -26,3 +26,8 @@ pub fn format(time: &time::OffsetDateTime) -> String {
     // We know this is correct.
     time.format(&format_description).unwrap()
 }
+
+/// Takes a unix timestamp and returns a formatted `String`.
+pub fn format_unix_timestamp(timestamp: i64) -> String {
+    format(&from_unix_timestamp(timestamp))
+}

--- a/bee-common/bee-common/src/time.rs
+++ b/bee-common/bee-common/src/time.rs
@@ -13,7 +13,7 @@ pub fn now_utc() -> time::OffsetDateTime {
     time::OffsetDateTime::now_utc()
 }
 
-/// Creates a new time from a unix timestamp, at UTC. 
+/// Creates a new time from a unix timestamp, at UTC.
 pub fn from_unix_timestamp(timestamp: i64) -> time::OffsetDateTime {
     time::OffsetDateTime::from_unix_timestamp(timestamp)
 }

--- a/bee-common/bee-common/src/time.rs
+++ b/bee-common/bee-common/src/time.rs
@@ -1,4 +1,4 @@
-// Copyright 2020-2021 IOTA Stiftung
+// Copyright 2021 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
 //! A module that provides common functions for timestamps.

--- a/bee-ledger/Cargo.toml
+++ b/bee-ledger/Cargo.toml
@@ -18,7 +18,6 @@ bee-storage = { version = "0.9.0", path = "../bee-storage/bee-storage", optional
 bee-tangle = { version = "0.2.0", path = "../bee-tangle", optional = true }
 
 async-trait = { version = "0.1.51", optional = true }
-chrono = { version = "0.4.19", optional = true }
 digest = { version = "0.9.0", optional = true }
 futures = { version = "0.3.17", optional = true }
 hashbrown = { version = "0.11.2", optional = true }
@@ -39,7 +38,6 @@ workers = [
   "bee-storage",
   "bee-tangle",
   "async-trait",
-  "chrono",
   "digest",
   "futures",
   "hashbrown",

--- a/bee-ledger/src/workers/snapshot/import.rs
+++ b/bee-ledger/src/workers/snapshot/import.rs
@@ -20,7 +20,10 @@ use crate::{
     },
 };
 
-use bee_common::packable::{Packable, Read};
+use bee_common::{
+    packable::{Packable, Read},
+    time,
+};
 use bee_message::{
     milestone::MilestoneIndex,
     output::{self, Output, OutputId},
@@ -30,7 +33,6 @@ use bee_message::{
 use bee_storage::access::{Insert, Truncate};
 use bee_tangle::solid_entry_point::SolidEntryPoint;
 
-use chrono::{offset::TimeZone, Utc};
 use log::{info, warn};
 
 use std::{
@@ -205,7 +207,7 @@ async fn import_full_snapshot<B: StorageBackend>(storage: &B, path: &Path, netwo
 
     info!(
         "Imported full snapshot file from {} with sep index {}, ledger index {}, {} solid entry points, {} outputs and {} milestone diffs.",
-        Utc.timestamp(header.timestamp() as i64, 0).format("%d-%m-%Y %H:%M:%S"),
+        time::format(&time::from_unix_timestamp(header.timestamp() as i64)),
         *header.sep_index(),
         *header.ledger_index(),
         full_header.sep_count(),
@@ -260,7 +262,7 @@ async fn import_delta_snapshot<B: StorageBackend>(storage: &B, path: &Path, netw
 
     info!(
         "Imported delta snapshot file from {} with sep index {}, ledger index {}, {} solid entry points and {} milestone diffs.",
-        Utc.timestamp(header.timestamp() as i64, 0).format("%d-%m-%Y %H:%M:%S"),
+        time::format(&time::now_local()),
         *header.sep_index(),
         *header.ledger_index(),
         delta_header.sep_count(),

--- a/bee-ledger/src/workers/snapshot/import.rs
+++ b/bee-ledger/src/workers/snapshot/import.rs
@@ -262,7 +262,7 @@ async fn import_delta_snapshot<B: StorageBackend>(storage: &B, path: &Path, netw
 
     info!(
         "Imported delta snapshot file from {} with sep index {}, ledger index {}, {} solid entry points and {} milestone diffs.",
-        time::format(&time::now_local()),
+        time::format(&time::from_unix_timestamp(header.timestamp() as i64)),
         *header.sep_index(),
         *header.ledger_index(),
         delta_header.sep_count(),

--- a/bee-ledger/src/workers/snapshot/import.rs
+++ b/bee-ledger/src/workers/snapshot/import.rs
@@ -207,7 +207,7 @@ async fn import_full_snapshot<B: StorageBackend>(storage: &B, path: &Path, netwo
 
     info!(
         "Imported full snapshot file from {} with sep index {}, ledger index {}, {} solid entry points, {} outputs and {} milestone diffs.",
-        time::format(&time::from_unix_timestamp(header.timestamp() as i64)),
+        time::format_unix_timestamp(header.timestamp() as i64),
         *header.sep_index(),
         *header.ledger_index(),
         full_header.sep_count(),
@@ -262,7 +262,7 @@ async fn import_delta_snapshot<B: StorageBackend>(storage: &B, path: &Path, netw
 
     info!(
         "Imported delta snapshot file from {} with sep index {}, ledger index {}, {} solid entry points and {} milestone diffs.",
-        time::format(&time::from_unix_timestamp(header.timestamp() as i64)),
+        time::format_unix_timestamp(header.timestamp() as i64),
         *header.sep_index(),
         *header.ledger_index(),
         delta_header.sep_count(),

--- a/bee-ledger/src/workers/snapshot/worker.rs
+++ b/bee-ledger/src/workers/snapshot/worker.rs
@@ -48,7 +48,7 @@ where
 
             info!(
                 "Loaded snapshot from {} with snapshot index {}, entry point index {} and pruning index {}.",
-                time::format(&time::from_unix_timestamp(info.timestamp() as i64)),
+                time::format_unix_timestamp(info.timestamp() as i64),
                 *info.snapshot_index(),
                 *info.entry_point_index(),
                 *info.pruning_index(),

--- a/bee-ledger/src/workers/snapshot/worker.rs
+++ b/bee-ledger/src/workers/snapshot/worker.rs
@@ -7,6 +7,7 @@ use crate::workers::{
     storage::{self, StorageBackend},
 };
 
+use bee_common::time;
 use bee_message::milestone::MilestoneIndex;
 use bee_runtime::{node::Node, worker::Worker};
 use bee_storage::{access::AsIterator, backend::StorageBackend as _, system::StorageHealth};
@@ -14,7 +15,6 @@ use bee_tangle::{solid_entry_point::SolidEntryPoint, Tangle, TangleWorker};
 
 use async_trait::async_trait;
 
-use chrono::{offset::TimeZone, Utc};
 use log::info;
 
 use std::{any::TypeId, collections::HashMap};
@@ -48,7 +48,7 @@ where
 
             info!(
                 "Loaded snapshot from {} with snapshot index {}, entry point index {} and pruning index {}.",
-                Utc.timestamp(info.timestamp() as i64, 0).format("%d-%m-%Y %H:%M:%S"),
+                time::format(&time::from_unix_timestamp(info.timestamp() as i64)),
                 *info.snapshot_index(),
                 *info.entry_point_index(),
                 *info.pruning_index(),


### PR DESCRIPTION
# Description of change

Removes the `chrono` crate.

I have also created a new `time` module in `bee-common` for getting local time and creating formatted strings, since the same code is used in a couple of different places.

## Links to any relevant issues

#783 and #779.

## Type of change

Choose a type of change, and delete any options that are not relevant.

- Bug fix (a non-breaking change which fixes an issue)

## How the change has been tested

Run the node to ensure timestamps format correctly. The output shows as:

```
2021-10-19 13:18:54 bee_protocol::workers::message::payload    INFO  Running.
```
This is in the correct local time to me (UTC +1).

## Change checklist

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that new and existing unit tests pass locally with my changes
- [x] I have updated the CHANGELOG.md, if my changes are significant enough
