### PR TITLE
Make eviction less "contentious"

### DIFF
--- a/bee-tangle/src/config.rs
+++ b/bee-tangle/src/config.rs
@@ -8,12 +8,14 @@ use std::num::NonZeroUsize;
 const DEFAULT_BELOW_MAX_DEPTH: u32 = 15;
 // SAFETY: initialised with a non-zero value.
 const DEFAULT_NUM_PARTITIONS: NonZeroUsize = unsafe { NonZeroUsize::new_unchecked(16) };
+const DEFAULT_MAX_EVICTION_RETRIES: usize = 10;
 
 /// A builder type for a tangle configuration.
 #[derive(Default, Deserialize)]
 pub struct TangleConfigBuilder {
     below_max_depth: Option<u32>,
     num_partitions: Option<NonZeroUsize>,
+    max_eviction_retries: Option<usize>,
 }
 
 impl TangleConfigBuilder {
@@ -27,6 +29,7 @@ impl TangleConfigBuilder {
         TangleConfig {
             below_max_depth: self.below_max_depth.unwrap_or(DEFAULT_BELOW_MAX_DEPTH),
             num_partitions: self.num_partitions.unwrap_or(DEFAULT_NUM_PARTITIONS),
+            max_eviction_retries: self.max_eviction_retries.unwrap_or(DEFAULT_MAX_EVICTION_RETRIES),
         }
     }
 }
@@ -36,6 +39,7 @@ impl TangleConfigBuilder {
 pub struct TangleConfig {
     below_max_depth: u32,
     num_partitions: NonZeroUsize,
+    max_eviction_retries: usize,
 }
 
 impl TangleConfig {
@@ -52,5 +56,10 @@ impl TangleConfig {
     /// Get the value of `num_partitions`.
     pub fn num_partitions(&self) -> NonZeroUsize {
         self.num_partitions
+    }
+
+    /// Get the value of `max_eviction_retries`.
+    pub fn max_eviction_retries(&self) -> usize {
+        self.max_eviction_retries
     }
 }

--- a/bee-tangle/src/tangle.rs
+++ b/bee-tangle/src/tangle.rs
@@ -616,6 +616,8 @@ impl<B: StorageBackend> Tangle<B> {
                         "could not perform cache eviction after {} attempts",
                         MAX_EVICTION_RETRIES
                     );
+
+                    break;
                 }
             }
         }

--- a/bee-tangle/src/tangle.rs
+++ b/bee-tangle/src/tangle.rs
@@ -611,19 +611,11 @@ impl<B: StorageBackend> Tangle<B> {
 
         if self.vertices.len() > max_len {
             while self.vertices.len() > ((1.0 - CACHE_THRESHOLD_FACTOR) * max_len as f64) as usize {
-                let mut retries = 1;
-                loop {
-                    if self.vertices.pop_random().await.is_none() {
-                        log::debug!("retrying cache eviction (attempt #{})", retries);
-                        retries += 1;
-                    } else {
-                        break;
-                    }
-
-                    if retries > MAX_EVICTION_RETRIES {
-                        log::warn!("could not perform cache eviction after {} attempts", retries);
-                        return;
-                    }
+                if self.vertices.pop_random::<MAX_EVICTION_RETRIES>().await.is_none() {
+                    log::warn!(
+                        "could not perform cache eviction after {} attempts",
+                        MAX_EVICTION_RETRIES
+                    );
                 }
             }
         }

--- a/bee-tangle/src/vertices.rs
+++ b/bee-tangle/src/vertices.rs
@@ -76,10 +76,10 @@ impl Vertices {
         .ok()
     }
 
-    pub(crate) async fn pop_random<const RETRIES: usize>(&self) -> Option<Vertex> {
+    pub(crate) async fn pop_random(&self, max_retries: usize) -> Option<Vertex> {
         let mut retries = 0;
 
-        while retries < RETRIES {
+        while retries < max_retries {
             let index = rand::thread_rng().gen_range(0..self.tables.len());
 
             // SAFETY: `index < self.tables.len()` by construction.


### PR DESCRIPTION
This PR changes the `pop_random` method so it uses `try_write` instead of `write`. Meaning that it should not `await` if the randomly chosen partition is being used.

This should cause less contention while evicting at the cost of increasing the number of retries.