### PR TITLE
Add missing `raw` feature to `hashbrown`

### DIFF
--- a/bee-tangle/Cargo.toml
+++ b/bee-tangle/Cargo.toml
@@ -19,7 +19,7 @@ bee-storage = { version = "0.9.0", path = "../bee-storage/bee-storage" }
 async-trait = "0.1.51"
 bitflags = "1.2.1"
 futures = "0.3.17"
-hashbrown = "0.11.2"
+hashbrown = { version = "0.11.2", features = [ "raw" ] }
 log = "0.4.14"
 rand = "0.8.4"
 ref-cast = "1.0.6"


### PR DESCRIPTION
# Description of change

the `bee-tangle` crate couldn't compile on its own because this feature was missing. This error didn't show because when compiling the whole workspace, some other crate/dependency used this feature.

## Type of change

- Bug fix (a non-breaking change which fixes an issue)

## How the change has been tested

`bee-tangle` compiles on its own now.

## Change checklist

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that new and existing unit tests pass locally with my changes
- [x] I have updated the CHANGELOG.md, if my changes are significant enough
