### PR TITLE
Fix `bee_common::time::local_now`

### DIFF
--- a/bee-common/bee-common/src/time.rs
+++ b/bee-common/bee-common/src/time.rs
@@ -5,7 +5,7 @@
 
 /// Retrieves the current timestamp, including UTC offset.
 pub fn now_local() -> time::OffsetDateTime {
-    time::OffsetDateTime::now_local().expect("indeterminate utc offset")
+    time::OffsetDateTime::now_local().unwrap_or(now_utc())
 }
 
 /// Retrieves the current timestamp, at UTC.

--- a/bee-common/bee-common/src/time.rs
+++ b/bee-common/bee-common/src/time.rs
@@ -5,7 +5,7 @@
 
 /// Retrieves the current timestamp, including UTC offset. If offset cannot be determined, return UTC time.
 pub fn now_local() -> time::OffsetDateTime {
-    time::OffsetDateTime::now_local().unwrap_or(now_utc())
+    time::OffsetDateTime::now_local().unwrap_or_else(|_| now_utc())
 }
 
 /// Retrieves the current timestamp, at UTC.

--- a/bee-common/bee-common/src/time.rs
+++ b/bee-common/bee-common/src/time.rs
@@ -3,7 +3,7 @@
 
 //! A module that provides common functions for timestamps.
 
-/// Retrieves the current timestamp, including UTC offset.
+/// Retrieves the current timestamp, including UTC offset. If offset cannot be determined, return UTC time.
 pub fn now_local() -> time::OffsetDateTime {
     time::OffsetDateTime::now_local().unwrap_or(now_utc())
 }


### PR DESCRIPTION
`local_now` will return UTC time if the local UTC offset cannot be determined. This is a temporary fix, while we work out the problems with the `time` crate.
