### PR TITLE
`bee-common`: only deal with UTC time

### DIFF
--- a/bee-common/bee-common/src/logger/mod.rs
+++ b/bee-common/bee-common/src/logger/mod.rs
@@ -29,7 +29,7 @@ macro_rules! log_format {
     ($target:expr, $level:expr, $message:expr, $target_width:expr, $level_width:expr) => {
         format_args!(
             "{} {:target_width$} {:level_width$} {}",
-            crate::time::format(&crate::time::now_local()),
+            crate::time::format(&crate::time::now_utc()),
             $target,
             $level,
             $message,

--- a/bee-common/bee-common/src/time.rs
+++ b/bee-common/bee-common/src/time.rs
@@ -16,7 +16,8 @@ pub fn from_unix_timestamp(timestamp: i64) -> time::OffsetDateTime {
 /// Produces a formatted `String` from a timestamp, displayed as local time.
 pub fn format(time: &time::OffsetDateTime) -> String {
     // This format string is correct, so unwrapping is fine.
-    let format_description = time::format_description::parse("[year]-[month]-[day] [hour]:[minute]:[second] (UTC)").unwrap();
+    let format_description =
+        time::format_description::parse("[year]-[month]-[day] [hour]:[minute]:[second] (UTC)").unwrap();
 
     // We know this is correct.
     time.format(&format_description).unwrap()

--- a/bee-common/bee-common/src/time.rs
+++ b/bee-common/bee-common/src/time.rs
@@ -3,11 +3,6 @@
 
 //! A module that provides common functions for timestamps.
 
-/// Retrieves the current timestamp, including UTC offset. If offset cannot be determined, return UTC time.
-pub fn now_local() -> time::OffsetDateTime {
-    time::OffsetDateTime::now_local().unwrap_or_else(|_| now_utc())
-}
-
 /// Retrieves the current timestamp, at UTC.
 pub fn now_utc() -> time::OffsetDateTime {
     time::OffsetDateTime::now_utc()
@@ -21,7 +16,7 @@ pub fn from_unix_timestamp(timestamp: i64) -> time::OffsetDateTime {
 /// Produces a formatted `String` from a timestamp, displayed as local time.
 pub fn format(time: &time::OffsetDateTime) -> String {
     // This format string is correct, so unwrapping is fine.
-    let format_description = time::format_description::parse("[year]-[month]-[day] [hour]:[minute]:[second]").unwrap();
+    let format_description = time::format_description::parse("[year]-[month]-[day] [hour]:[minute]:[second] (UTC)").unwrap();
 
     // We know this is correct.
     time.format(&format_description).unwrap()


### PR DESCRIPTION
Only deal with UTC time for now. Adds ` (UTC)` to logged timestamps to make this clearer.