### PR TITLE
Fix licenses workflow for the `dev` branch

### DIFF
--- a/.github/workflows/about.toml
+++ b/.github/workflows/about.toml
@@ -1,4 +1,5 @@
 # This is the configuration file that is used by `cargo-about` to check license compatibility.
+
 accepted = [
     "Apache-2.0",
     "BSD-2-Clause",
@@ -9,6 +10,12 @@ accepted = [
     "MPL-2.0",
     "OpenSSL",
 ]
+
+workarounds = [
+    # Non-standard license file, actually is ISC AND OpenSSL AND MIT.
+    "ring",
+]
+
 # For now, we include these so that the number of gathered crates matches the number of crates in `Cargo.lock`.
 ignore-build-dependencies = false
 ignore-dev-dependencies = false

--- a/.github/workflows/licenses.yml
+++ b/.github/workflows/licenses.yml
@@ -21,6 +21,7 @@ jobs:
       with:
           profile: minimal
           toolchain: nightly
+          override: true
     - uses: actions-rs/cargo@v1
       name: Install cargo-about
       with:
@@ -32,9 +33,9 @@ jobs:
       name: Initialize template
       with:
         command: about
-        args: --workspace --all-features init
+        args: init
     - uses: actions-rs/cargo@v1
       name: Check licenses
       with:
         command: about
-        args: --workspace --all-features --log-level info generate about.hbs
+        args: generate --workspace --all-features about.hbs


### PR DESCRIPTION
Angry CI noises but in `dev`