### PR TITLE
Add `Packable::unpack` variants

### DIFF
--- a/bee-common/bee-packable-derive/src/fragments.rs
+++ b/bee-common/bee-packable-derive/src/fragments.rs
@@ -35,7 +35,7 @@ impl Fragments {
                 Ok(())
             },
             unpack: quote! {Ok(#path {
-                #(#fields_pattern_ident: <#fields_type>::unpack::<_, CHECK>(unpacker).map_packable_err(#fields_unpack_error_with).coerce()?,)*
+                #(#fields_pattern_ident: <#fields_type>::unpack::<_, VERIFY>(unpacker).map_packable_err(#fields_unpack_error_with).coerce()?,)*
             })},
         }
     }

--- a/bee-common/bee-packable-derive/src/fragments.rs
+++ b/bee-common/bee-packable-derive/src/fragments.rs
@@ -35,7 +35,7 @@ impl Fragments {
                 Ok(())
             },
             unpack: quote! {Ok(#path {
-                #(#fields_pattern_ident: <#fields_type>::unpack(unpacker).map_packable_err(#fields_unpack_error_with).coerce()?,)*
+                #(#fields_pattern_ident: <#fields_type>::unpack::<_, CHECK>(unpacker).map_packable_err(#fields_unpack_error_with).coerce()?,)*
             })},
         }
     }

--- a/bee-common/bee-packable-derive/src/trait_impl.rs
+++ b/bee-common/bee-packable-derive/src/trait_impl.rs
@@ -117,7 +117,7 @@ impl TraitImpl {
                         #(#tag_decls)*
 
                         #[deny(unreachable_patterns)]
-                        match <#tag_type>::unpack(unpacker).infallible()? {
+                        match <#tag_type>::unpack::<_, CHECK>(unpacker).infallible()? {
                             #(#unpack_arms)*
                             tag => Err(bee_packable::error::UnpackError::from_packable(#tag_with_error(tag)))
                         }
@@ -158,7 +158,7 @@ impl ToTokens for TraitImpl {
                     #pack
                 }
 
-                fn unpack<U: bee_packable::unpacker::Unpacker>(unpacker: &mut U) -> Result<Self, bee_packable::error::UnpackError<Self::UnpackError, U::Error>> {
+                fn unpack<U: bee_packable::unpacker::Unpacker, const CHECK: bool>(unpacker: &mut U) -> Result<Self, bee_packable::error::UnpackError<Self::UnpackError, U::Error>> {
                     use bee_packable::error::UnpackErrorExt;
                     #unpack
                 }

--- a/bee-common/bee-packable-derive/src/trait_impl.rs
+++ b/bee-common/bee-packable-derive/src/trait_impl.rs
@@ -117,7 +117,7 @@ impl TraitImpl {
                         #(#tag_decls)*
 
                         #[deny(unreachable_patterns)]
-                        match <#tag_type>::unpack::<_, CHECK>(unpacker).infallible()? {
+                        match <#tag_type>::unpack::<_, VERIFY>(unpacker).infallible()? {
                             #(#unpack_arms)*
                             tag => Err(bee_packable::error::UnpackError::from_packable(#tag_with_error(tag)))
                         }
@@ -158,7 +158,7 @@ impl ToTokens for TraitImpl {
                     #pack
                 }
 
-                fn unpack<U: bee_packable::unpacker::Unpacker, const CHECK: bool>(unpacker: &mut U) -> Result<Self, bee_packable::error::UnpackError<Self::UnpackError, U::Error>> {
+                fn unpack<U: bee_packable::unpacker::Unpacker, const VERIFY: bool>(unpacker: &mut U) -> Result<Self, bee_packable::error::UnpackError<Self::UnpackError, U::Error>> {
                     use bee_packable::error::UnpackErrorExt;
                     #unpack
                 }

--- a/bee-common/bee-packable-derive/tests/pass/enum_discriminant.rs
+++ b/bee-common/bee-packable-derive/tests/pass/enum_discriminant.rs
@@ -1,7 +1,7 @@
 // Copyright 2021 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
-use bee_packable::Packable;
+use bee_packable::{Packable, PackableExt};
 
 // repr type is used as tag type and discriminant values are used as tags.
 #[derive(Packable)]

--- a/bee-common/bee-packable-derive/tests/pass/error_coercion.rs
+++ b/bee-common/bee-packable-derive/tests/pass/error_coercion.rs
@@ -29,10 +29,10 @@ impl Packable for Picky {
         self.0.pack(packer)
     }
 
-    fn unpack<U: Unpacker, const CHECK: bool>(
+    fn unpack<U: Unpacker, const VERIFY: bool>(
         unpacker: &mut U,
     ) -> Result<Self, UnpackError<Self::UnpackError, U::Error>> {
-        let value = u8::unpack::<_, CHECK>(unpacker).infallible()?;
+        let value = u8::unpack::<_, VERIFY>(unpacker).infallible()?;
 
         if value == 42 {
             Ok(Self(value))

--- a/bee-common/bee-packable-derive/tests/pass/error_coercion.rs
+++ b/bee-common/bee-packable-derive/tests/pass/error_coercion.rs
@@ -29,8 +29,10 @@ impl Packable for Picky {
         self.0.pack(packer)
     }
 
-    fn unpack<U: Unpacker>(unpacker: &mut U) -> Result<Self, UnpackError<Self::UnpackError, U::Error>> {
-        let value = u8::unpack(unpacker).infallible()?;
+    fn unpack<U: Unpacker, const CHECK: bool>(
+        unpacker: &mut U,
+    ) -> Result<Self, UnpackError<Self::UnpackError, U::Error>> {
+        let value = u8::unpack::<_, CHECK>(unpacker).infallible()?;
 
         if value == 42 {
             Ok(Self(value))

--- a/bee-common/bee-packable/src/packable/array.rs
+++ b/bee-common/bee-packable/src/packable/array.rs
@@ -20,7 +20,7 @@ impl<T: Packable, const N: usize> Packable for [T; N] {
         Ok(())
     }
 
-    fn unpack<U: Unpacker, const CHECK: bool>(
+    fn unpack<U: Unpacker, const VERIFY: bool>(
         unpacker: &mut U,
     ) -> Result<Self, UnpackError<Self::UnpackError, U::Error>> {
         // Safety: an uninitialized array of [`MaybeUninit`]s is safe to be considered initialized.
@@ -28,7 +28,7 @@ impl<T: Packable, const N: usize> Packable for [T; N] {
         let mut array = unsafe { MaybeUninit::<[MaybeUninit<T>; N]>::uninit().assume_init() };
 
         for item in array.iter_mut() {
-            let unpacked = T::unpack::<_, CHECK>(unpacker)?;
+            let unpacked = T::unpack::<_, VERIFY>(unpacker)?;
             // Safety: each `item` is only visited once so we are never overwriting nor dropping
             // values that are already initialized.
             unsafe {

--- a/bee-common/bee-packable/src/packable/array.rs
+++ b/bee-common/bee-packable/src/packable/array.rs
@@ -20,13 +20,15 @@ impl<T: Packable, const N: usize> Packable for [T; N] {
         Ok(())
     }
 
-    fn unpack<U: Unpacker>(unpacker: &mut U) -> Result<Self, UnpackError<Self::UnpackError, U::Error>> {
+    fn unpack<U: Unpacker, const CHECK: bool>(
+        unpacker: &mut U,
+    ) -> Result<Self, UnpackError<Self::UnpackError, U::Error>> {
         // Safety: an uninitialized array of [`MaybeUninit`]s is safe to be considered initialized.
         // FIXME: replace with [`MaybeUninit::uninit_array`] when stabilized.
         let mut array = unsafe { MaybeUninit::<[MaybeUninit<T>; N]>::uninit().assume_init() };
 
         for item in array.iter_mut() {
-            let unpacked = T::unpack(unpacker)?;
+            let unpacked = T::unpack::<_, CHECK>(unpacker)?;
             // Safety: each `item` is only visited once so we are never overwriting nor dropping
             // values that are already initialized.
             unsafe {

--- a/bee-common/bee-packable/src/packable/bool.rs
+++ b/bee-common/bee-packable/src/packable/bool.rs
@@ -23,9 +23,9 @@ impl Packable for bool {
     }
 
     /// Booleans are unpacked if the byte used to represent them is non-zero.
-    fn unpack<U: Unpacker, const CHECK: bool>(
+    fn unpack<U: Unpacker, const VERIFY: bool>(
         unpacker: &mut U,
     ) -> Result<Self, UnpackError<Self::UnpackError, U::Error>> {
-        Ok(u8::unpack::<_, CHECK>(unpacker).infallible()? != 0)
+        Ok(u8::unpack::<_, VERIFY>(unpacker).infallible()? != 0)
     }
 }

--- a/bee-common/bee-packable/src/packable/bool.rs
+++ b/bee-common/bee-packable/src/packable/bool.rs
@@ -23,7 +23,9 @@ impl Packable for bool {
     }
 
     /// Booleans are unpacked if the byte used to represent them is non-zero.
-    fn unpack<U: Unpacker>(unpacker: &mut U) -> Result<Self, UnpackError<Self::UnpackError, U::Error>> {
-        Ok(u8::unpack(unpacker).infallible()? != 0)
+    fn unpack<U: Unpacker, const CHECK: bool>(
+        unpacker: &mut U,
+    ) -> Result<Self, UnpackError<Self::UnpackError, U::Error>> {
+        Ok(u8::unpack::<_, CHECK>(unpacker).infallible()? != 0)
     }
 }

--- a/bee-common/bee-packable/src/packable/bounded.rs
+++ b/bee-common/bee-packable/src/packable/bounded.rs
@@ -114,12 +114,12 @@ macro_rules! bounded {
             }
 
 
-            fn unpack<U: Unpacker, const CHECK: bool>(
+            fn unpack<U: Unpacker, const VERIFY: bool>(
                 unpacker: &mut U,
             ) -> Result<Self, UnpackError<Self::UnpackError, U::Error>> {
-                let value = $ty::unpack::<_, CHECK>(unpacker).infallible()?;
+                let value = $ty::unpack::<_, VERIFY>(unpacker).infallible()?;
 
-                if CHECK && !(MIN..=MAX).contains(&value) {
+                if VERIFY && !(MIN..=MAX).contains(&value) {
                     return Err(UnpackError::Packable($error(value)));
                 }
 

--- a/bee-common/bee-packable/src/packable/box.rs
+++ b/bee-common/bee-packable/src/packable/box.rs
@@ -21,10 +21,10 @@ impl<T: Packable> Packable for Box<T> {
         Ok(())
     }
 
-    fn unpack<U: Unpacker, const CHECK: bool>(
+    fn unpack<U: Unpacker, const VERIFY: bool>(
         unpacker: &mut U,
     ) -> Result<Self, UnpackError<Self::UnpackError, U::Error>> {
-        Ok(Box::new(T::unpack::<_, CHECK>(unpacker)?))
+        Ok(Box::new(T::unpack::<_, VERIFY>(unpacker)?))
     }
 }
 
@@ -46,9 +46,9 @@ impl<T: Packable> Packable for Box<[T]> {
         Ok(())
     }
 
-    fn unpack<U: Unpacker, const CHECK: bool>(
+    fn unpack<U: Unpacker, const VERIFY: bool>(
         unpacker: &mut U,
     ) -> Result<Self, UnpackError<Self::UnpackError, U::Error>> {
-        Ok(Vec::<T>::unpack::<_, CHECK>(unpacker)?.into_boxed_slice())
+        Ok(Vec::<T>::unpack::<_, VERIFY>(unpacker)?.into_boxed_slice())
     }
 }

--- a/bee-common/bee-packable/src/packable/box.rs
+++ b/bee-common/bee-packable/src/packable/box.rs
@@ -21,8 +21,10 @@ impl<T: Packable> Packable for Box<T> {
         Ok(())
     }
 
-    fn unpack<U: Unpacker>(unpacker: &mut U) -> Result<Self, UnpackError<Self::UnpackError, U::Error>> {
-        Ok(Box::new(T::unpack(unpacker)?))
+    fn unpack<U: Unpacker, const CHECK: bool>(
+        unpacker: &mut U,
+    ) -> Result<Self, UnpackError<Self::UnpackError, U::Error>> {
+        Ok(Box::new(T::unpack::<_, CHECK>(unpacker)?))
     }
 }
 
@@ -44,7 +46,9 @@ impl<T: Packable> Packable for Box<[T]> {
         Ok(())
     }
 
-    fn unpack<U: Unpacker>(unpacker: &mut U) -> Result<Self, UnpackError<Self::UnpackError, U::Error>> {
-        Ok(Vec::<T>::unpack(unpacker)?.into_boxed_slice())
+    fn unpack<U: Unpacker, const CHECK: bool>(
+        unpacker: &mut U,
+    ) -> Result<Self, UnpackError<Self::UnpackError, U::Error>> {
+        Ok(Vec::<T>::unpack::<_, CHECK>(unpacker)?.into_boxed_slice())
     }
 }

--- a/bee-common/bee-packable/src/packable/integer.rs
+++ b/bee-common/bee-packable/src/packable/integer.rs
@@ -23,7 +23,7 @@ macro_rules! impl_packable_for_integer {
                 packer.pack_bytes(&self.to_le_bytes())
             }
 
-            fn unpack<U: Unpacker, const CHECK: bool>(
+            fn unpack<U: Unpacker, const VERIFY: bool>(
                 unpacker: &mut U,
             ) -> Result<Self, UnpackError<Self::UnpackError, U::Error>> {
                 let mut bytes = [0u8; core::mem::size_of::<Self>()];
@@ -53,10 +53,10 @@ impl Packable for usize {
         (*self as u64).pack(packer)
     }
 
-    fn unpack<U: Unpacker, const CHECK: bool>(
+    fn unpack<U: Unpacker, const VERIFY: bool>(
         unpacker: &mut U,
     ) -> Result<Self, UnpackError<Self::UnpackError, U::Error>> {
-        Ok(u64::unpack::<_, CHECK>(unpacker).infallible()? as usize)
+        Ok(u64::unpack::<_, VERIFY>(unpacker).infallible()? as usize)
     }
 }
 
@@ -79,9 +79,9 @@ impl Packable for isize {
         (*self as i64).pack(packer)
     }
 
-    fn unpack<U: Unpacker, const CHECK: bool>(
+    fn unpack<U: Unpacker, const VERIFY: bool>(
         unpacker: &mut U,
     ) -> Result<Self, UnpackError<Self::UnpackError, U::Error>> {
-        Ok(i64::unpack::<_, CHECK>(unpacker).infallible()? as isize)
+        Ok(i64::unpack::<_, VERIFY>(unpacker).infallible()? as isize)
     }
 }

--- a/bee-common/bee-packable/src/packable/integer.rs
+++ b/bee-common/bee-packable/src/packable/integer.rs
@@ -23,7 +23,9 @@ macro_rules! impl_packable_for_integer {
                 packer.pack_bytes(&self.to_le_bytes())
             }
 
-            fn unpack<U: Unpacker>(unpacker: &mut U) -> Result<Self, UnpackError<Self::UnpackError, U::Error>> {
+            fn unpack<U: Unpacker, const CHECK: bool>(
+                unpacker: &mut U,
+            ) -> Result<Self, UnpackError<Self::UnpackError, U::Error>> {
                 let mut bytes = [0u8; core::mem::size_of::<Self>()];
                 unpacker.unpack_bytes(&mut bytes)?;
                 Ok(Self::from_le_bytes(bytes))
@@ -51,8 +53,10 @@ impl Packable for usize {
         (*self as u64).pack(packer)
     }
 
-    fn unpack<U: Unpacker>(unpacker: &mut U) -> Result<Self, UnpackError<Self::UnpackError, U::Error>> {
-        Ok(u64::unpack(unpacker).infallible()? as usize)
+    fn unpack<U: Unpacker, const CHECK: bool>(
+        unpacker: &mut U,
+    ) -> Result<Self, UnpackError<Self::UnpackError, U::Error>> {
+        Ok(u64::unpack::<_, CHECK>(unpacker).infallible()? as usize)
     }
 }
 
@@ -75,7 +79,9 @@ impl Packable for isize {
         (*self as i64).pack(packer)
     }
 
-    fn unpack<U: Unpacker>(unpacker: &mut U) -> Result<Self, UnpackError<Self::UnpackError, U::Error>> {
-        Ok(i64::unpack(unpacker).infallible()? as isize)
+    fn unpack<U: Unpacker, const CHECK: bool>(
+        unpacker: &mut U,
+    ) -> Result<Self, UnpackError<Self::UnpackError, U::Error>> {
+        Ok(i64::unpack::<_, CHECK>(unpacker).infallible()? as isize)
     }
 }

--- a/bee-common/bee-packable/src/packable/mod.rs
+++ b/bee-common/bee-packable/src/packable/mod.rs
@@ -50,7 +50,7 @@ pub trait Packable: Sized {
     ) -> Result<Self, UnpackError<Self::UnpackError, U::Error>>;
 }
 
-/// Extension trait for types that implement `Packable`.
+/// Extension trait for types that implement [`Packable`].
 pub trait PackableExt: Packable {
     /// Convenience method that packs this value into a [`Vec<u8>`].
     fn pack_to_vec(&self) -> Vec<u8>;

--- a/bee-common/bee-packable/src/packable/mod.rs
+++ b/bee-common/bee-packable/src/packable/mod.rs
@@ -55,11 +55,23 @@ pub trait Packable: Sized {
     }
 
     /// Unpacks this value from the given [`Unpacker`].
-    fn unpack<U: Unpacker>(unpacker: &mut U) -> Result<Self, UnpackError<Self::UnpackError, U::Error>>;
+    fn unpack<U: Unpacker, const CHECK: bool>(
+        unpacker: &mut U,
+    ) -> Result<Self, UnpackError<Self::UnpackError, U::Error>>;
+
+    /// Unpacks this value from the given [`Unpacker`] doing syntactical checks.
+    fn unpack_checked<U: Unpacker>(unpacker: &mut U) -> Result<Self, UnpackError<Self::UnpackError, U::Error>> {
+        Self::unpack::<U, true>(unpacker)
+    }
+
+    /// Unpacks this value from the given [`Unpacker`] without doing syntactical checks.
+    fn unpack_unchecked<U: Unpacker>(unpacker: &mut U) -> Result<Self, UnpackError<Self::UnpackError, U::Error>> {
+        Self::unpack::<U, false>(unpacker)
+    }
 
     /// Unpacks this value from a type that implements [`AsRef<[u8]>`].
     fn unpack_from_slice<T: AsRef<[u8]>>(bytes: T) -> Result<Self, UnpackError<Self::UnpackError, UnexpectedEOF>> {
         let mut unpacker = SliceUnpacker::new(bytes.as_ref());
-        Packable::unpack(&mut unpacker)
+        Packable::unpack_checked(&mut unpacker)
     }
 }

--- a/bee-common/bee-packable/src/packable/mod.rs
+++ b/bee-common/bee-packable/src/packable/mod.rs
@@ -45,7 +45,7 @@ pub trait Packable: Sized {
     fn pack<P: Packer>(&self, packer: &mut P) -> Result<(), P::Error>;
 
     /// Unpacks this value from the given [`Unpacker`].
-    fn unpack<U: Unpacker, const CHECK: bool>(
+    fn unpack<U: Unpacker, const VERIFY: bool>(
         unpacker: &mut U,
     ) -> Result<Self, UnpackError<Self::UnpackError, U::Error>>;
 }

--- a/bee-common/bee-packable/src/packable/option.rs
+++ b/bee-common/bee-packable/src/packable/option.rs
@@ -47,12 +47,12 @@ impl<T: Packable> Packable for Option<T> {
         }
     }
 
-    fn unpack<U: Unpacker, const CHECK: bool>(
+    fn unpack<U: Unpacker, const VERIFY: bool>(
         unpacker: &mut U,
     ) -> Result<Self, UnpackError<Self::UnpackError, U::Error>> {
-        match u8::unpack::<_, CHECK>(unpacker).infallible()? {
+        match u8::unpack::<_, VERIFY>(unpacker).infallible()? {
             0 => Ok(None),
-            1 => Ok(Some(T::unpack::<_, CHECK>(unpacker).coerce()?)),
+            1 => Ok(Some(T::unpack::<_, VERIFY>(unpacker).coerce()?)),
             n => Err(UnpackError::Packable(Self::UnpackError::UnknownTag(n))),
         }
     }

--- a/bee-common/bee-packable/src/packable/option.rs
+++ b/bee-common/bee-packable/src/packable/option.rs
@@ -47,10 +47,12 @@ impl<T: Packable> Packable for Option<T> {
         }
     }
 
-    fn unpack<U: Unpacker>(unpacker: &mut U) -> Result<Self, UnpackError<Self::UnpackError, U::Error>> {
-        match u8::unpack(unpacker).infallible()? {
+    fn unpack<U: Unpacker, const CHECK: bool>(
+        unpacker: &mut U,
+    ) -> Result<Self, UnpackError<Self::UnpackError, U::Error>> {
+        match u8::unpack::<_, CHECK>(unpacker).infallible()? {
             0 => Ok(None),
-            1 => Ok(Some(T::unpack(unpacker).coerce()?)),
+            1 => Ok(Some(T::unpack::<_, CHECK>(unpacker).coerce()?)),
             n => Err(UnpackError::Packable(Self::UnpackError::UnknownTag(n))),
         }
     }

--- a/bee-common/bee-packable/src/packable/prefix.rs
+++ b/bee-common/bee-packable/src/packable/prefix.rs
@@ -172,18 +172,18 @@ macro_rules! impl_vec_prefix {
                 Ok(())
             }
 
-            fn unpack<U: Unpacker, const CHECK: bool>(
+            fn unpack<U: Unpacker, const VERIFY: bool>(
                 unpacker: &mut U,
             ) -> Result<Self, UnpackError<Self::UnpackError, U::Error>> {
                 // The length of any dynamically-sized sequence must be prefixed.
-                let len = <$bounded<MIN, MAX>>::unpack::<_, CHECK>(unpacker)
+                let len = <$bounded<MIN, MAX>>::unpack::<_, VERIFY>(unpacker)
                     .map_packable_err(UnpackPrefixError::Prefix)?
                     .into();
 
                 let mut inner = Vec::with_capacity(len as usize);
 
                 for _ in 0..len {
-                    let item = T::unpack::<_, CHECK>(unpacker).coerce()?;
+                    let item = T::unpack::<_, VERIFY>(unpacker).coerce()?;
                     inner.push(item);
                 }
 
@@ -290,18 +290,18 @@ macro_rules! impl_boxed_slice_prefix {
                 Ok(())
             }
 
-            fn unpack<U: Unpacker, const CHECK: bool>(
+            fn unpack<U: Unpacker, const VERIFY: bool>(
                 unpacker: &mut U,
             ) -> Result<Self, UnpackError<Self::UnpackError, U::Error>> {
                 // The length of any dynamically-sized sequence must be prefixed.
-                let len = <$bounded<MIN, MAX>>::unpack::<_, CHECK>(unpacker)
+                let len = <$bounded<MIN, MAX>>::unpack::<_, VERIFY>(unpacker)
                     .map_packable_err(UnpackPrefixError::Prefix)?
                     .into();
 
                 let mut inner = Vec::with_capacity(len as usize);
 
                 for _ in 0..len {
-                    let item = T::unpack::<_, CHECK>(unpacker).coerce()?;
+                    let item = T::unpack::<_, VERIFY>(unpacker).coerce()?;
                     inner.push(item);
                 }
 

--- a/bee-common/bee-packable/src/packable/prefix.rs
+++ b/bee-common/bee-packable/src/packable/prefix.rs
@@ -172,16 +172,18 @@ macro_rules! impl_vec_prefix {
                 Ok(())
             }
 
-            fn unpack<U: Unpacker>(unpacker: &mut U) -> Result<Self, UnpackError<Self::UnpackError, U::Error>> {
+            fn unpack<U: Unpacker, const CHECK: bool>(
+                unpacker: &mut U,
+            ) -> Result<Self, UnpackError<Self::UnpackError, U::Error>> {
                 // The length of any dynamically-sized sequence must be prefixed.
-                let len = <$bounded<MIN, MAX>>::unpack(unpacker)
+                let len = <$bounded<MIN, MAX>>::unpack::<_, CHECK>(unpacker)
                     .map_packable_err(UnpackPrefixError::Prefix)?
                     .into();
 
                 let mut inner = Vec::with_capacity(len as usize);
 
                 for _ in 0..len {
-                    let item = T::unpack(unpacker).coerce()?;
+                    let item = T::unpack::<_, CHECK>(unpacker).coerce()?;
                     inner.push(item);
                 }
 
@@ -288,16 +290,18 @@ macro_rules! impl_boxed_slice_prefix {
                 Ok(())
             }
 
-            fn unpack<U: Unpacker>(unpacker: &mut U) -> Result<Self, UnpackError<Self::UnpackError, U::Error>> {
+            fn unpack<U: Unpacker, const CHECK: bool>(
+                unpacker: &mut U,
+            ) -> Result<Self, UnpackError<Self::UnpackError, U::Error>> {
                 // The length of any dynamically-sized sequence must be prefixed.
-                let len = <$bounded<MIN, MAX>>::unpack(unpacker)
+                let len = <$bounded<MIN, MAX>>::unpack::<_, CHECK>(unpacker)
                     .map_packable_err(UnpackPrefixError::Prefix)?
                     .into();
 
                 let mut inner = Vec::with_capacity(len as usize);
 
                 for _ in 0..len {
-                    let item = T::unpack(unpacker).coerce()?;
+                    let item = T::unpack::<_, CHECK>(unpacker).coerce()?;
                     inner.push(item);
                 }
 

--- a/bee-common/bee-packable/src/packable/vec.rs
+++ b/bee-common/bee-packable/src/packable/vec.rs
@@ -30,14 +30,16 @@ impl<T: Packable> Packable for Vec<T> {
         Ok(())
     }
 
-    fn unpack<U: Unpacker>(unpacker: &mut U) -> Result<Self, UnpackError<Self::UnpackError, U::Error>> {
+    fn unpack<U: Unpacker, const CHECK: bool>(
+        unpacker: &mut U,
+    ) -> Result<Self, UnpackError<Self::UnpackError, U::Error>> {
         // The length of any dynamically-sized sequence must be prefixed.
-        let len = u64::unpack(unpacker).infallible()?;
+        let len = u64::unpack::<_, CHECK>(unpacker).infallible()?;
 
         let mut vec = Self::with_capacity(len as usize);
 
         for _ in 0..len {
-            let item = T::unpack(unpacker)?;
+            let item = T::unpack::<_, CHECK>(unpacker)?;
             vec.push(item);
         }
 

--- a/bee-common/bee-packable/src/packable/vec.rs
+++ b/bee-common/bee-packable/src/packable/vec.rs
@@ -30,16 +30,16 @@ impl<T: Packable> Packable for Vec<T> {
         Ok(())
     }
 
-    fn unpack<U: Unpacker, const CHECK: bool>(
+    fn unpack<U: Unpacker, const VERIFY: bool>(
         unpacker: &mut U,
     ) -> Result<Self, UnpackError<Self::UnpackError, U::Error>> {
         // The length of any dynamically-sized sequence must be prefixed.
-        let len = u64::unpack::<_, CHECK>(unpacker).infallible()?;
+        let len = u64::unpack::<_, VERIFY>(unpacker).infallible()?;
 
         let mut vec = Self::with_capacity(len as usize);
 
         for _ in 0..len {
-            let item = T::unpack::<_, CHECK>(unpacker)?;
+            let item = T::unpack::<_, VERIFY>(unpacker)?;
             vec.push(item);
         }
 

--- a/bee-common/bee-packable/src/packer/vec.rs
+++ b/bee-common/bee-packable/src/packer/vec.rs
@@ -3,10 +3,10 @@
 
 extern crate alloc;
 
-use crate::{packer::Packer, unpacker::SliceUnpacker};
+use crate::packer::Packer;
 
 use alloc::vec::Vec;
-use core::convert::Infallible;
+use core::{convert::Infallible, ops::Deref};
 
 /// A [`Packer`] backed by a [`Vec<u8>`].
 #[derive(Default)]
@@ -21,11 +21,6 @@ impl VecPacker {
     /// Creates an empty packer with an initial capacity.
     pub fn with_capacity(capacity: usize) -> Self {
         Self(Vec::with_capacity(capacity))
-    }
-
-    /// Uses the backing [`Vec<u8>`] to create an [`Unpacker`](crate::unpacker::Unpacker).
-    pub fn as_slice(&self) -> SliceUnpacker<'_> {
-        SliceUnpacker::new(self.0.as_slice())
     }
 
     /// Consumes the [`VecPacker`] and returns the inner [`Vec<u8>`].
@@ -50,5 +45,13 @@ impl Packer for VecPacker {
     fn pack_bytes<B: AsRef<[u8]>>(&mut self, bytes: B) -> Result<(), Self::Error> {
         self.0.extend_from_slice(bytes.as_ref());
         Ok(())
+    }
+}
+
+impl Deref for VecPacker {
+    type Target = Vec<u8>;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
     }
 }

--- a/bee-common/bee-packable/tests/bool.rs
+++ b/bee-common/bee-packable/tests/bool.rs
@@ -16,7 +16,7 @@ fn packable_bool_packed_non_zero_bytes_are_truthy() {
     let mut packer = VecPacker::default();
     42u8.pack(&mut packer).unwrap();
 
-    let is_true = bool::unpack_checked(&mut packer.as_slice()).unwrap();
+    let is_true = bool::unpack_verified(&mut packer.as_slice()).unwrap();
 
     assert!(is_true);
 }

--- a/bee-common/bee-packable/tests/bool.rs
+++ b/bee-common/bee-packable/tests/bool.rs
@@ -16,7 +16,7 @@ fn packable_bool_packed_non_zero_bytes_are_truthy() {
     let mut packer = VecPacker::default();
     42u8.pack(&mut packer).unwrap();
 
-    let is_true = bool::unpack(&mut packer.as_slice()).unwrap();
+    let is_true = bool::unpack_checked(&mut packer.as_slice()).unwrap();
 
     assert!(is_true);
 }

--- a/bee-common/bee-packable/tests/bool.rs
+++ b/bee-common/bee-packable/tests/bool.rs
@@ -3,7 +3,7 @@
 
 mod common;
 
-use bee_packable::{packer::VecPacker, Packable};
+use bee_packable::{packer::VecPacker, Packable, PackableExt};
 
 #[test]
 fn packable_bool() {

--- a/bee-common/bee-packable/tests/bounded.rs
+++ b/bee-common/bee-packable/tests/bounded.rs
@@ -53,11 +53,7 @@ macro_rules! impl_packable_test_for_bounded_integer {
             let bytes = vec![0u8; core::mem::size_of::<$wrapped>()];
             let unpacked = <$wrapper>::unpack_verified(&bytes);
 
-            assert!(
-                matches!(unpacked, Err(UnpackError::Packable($error(0)))),
-                "found {:?}",
-                unpacked
-            )
+            assert!(matches!(unpacked, Err(UnpackError::Packable($error(0)))))
         }
     };
 }

--- a/bee-common/bee-packable/tests/bounded.rs
+++ b/bee-common/bee-packable/tests/bounded.rs
@@ -53,7 +53,11 @@ macro_rules! impl_packable_test_for_bounded_integer {
             let bytes = vec![0u8; core::mem::size_of::<$wrapped>()];
             let unpacked = <$wrapper>::unpack_from_slice(&bytes);
 
-            assert!(matches!(unpacked, Err(UnpackError::Packable($error(0)))))
+            assert!(
+                matches!(unpacked, Err(UnpackError::Packable($error(0)))),
+                "found {:?}",
+                unpacked
+            )
         }
     };
 }

--- a/bee-common/bee-packable/tests/bounded.rs
+++ b/bee-common/bee-packable/tests/bounded.rs
@@ -9,7 +9,7 @@ use bee_packable::{
         InvalidBoundedU64, InvalidBoundedU8,
     },
     error::UnpackError,
-    Packable,
+    PackableExt,
 };
 
 macro_rules! impl_bounds_test_for_bounded_integer {

--- a/bee-common/bee-packable/tests/bounded.rs
+++ b/bee-common/bee-packable/tests/bounded.rs
@@ -51,7 +51,7 @@ macro_rules! impl_packable_test_for_bounded_integer {
         #[test]
         fn $packable_invalid_name() {
             let bytes = vec![0u8; core::mem::size_of::<$wrapped>()];
-            let unpacked = <$wrapper>::unpack_from_slice(&bytes);
+            let unpacked = <$wrapper>::unpack_verified(&bytes);
 
             assert!(
                 matches!(unpacked, Err(UnpackError::Packable($error(0)))),

--- a/bee-common/bee-packable/tests/common/mod.rs
+++ b/bee-common/bee-packable/tests/common/mod.rs
@@ -8,7 +8,7 @@ use bee_packable::{
 
 use core::fmt::Debug;
 
-fn generic_test_pack_to_slice_unpack_from_slice<P>(packable: &P)
+fn generic_test_pack_to_slice_unpack_verified<P>(packable: &P)
 where
     P: Packable + Eq + Debug,
     P::UnpackError: Debug,
@@ -18,7 +18,7 @@ where
     let mut packer = SlicePacker::new(&mut vec);
     packable.pack(&mut packer).unwrap();
 
-    let unpacked = P::unpack_from_slice(&vec).unwrap();
+    let unpacked = P::unpack_verified(&vec).unwrap();
 
     assert_eq!(packable, &unpacked);
 
@@ -28,13 +28,13 @@ where
     }
 }
 
-fn generic_test_pack_to_vec_unpack_from_slice<P>(packable: &P) -> (Vec<u8>, P)
+fn generic_test_pack_to_vec_unpack_verified<P>(packable: &P) -> (Vec<u8>, P)
 where
     P: Packable + Eq + Debug,
     P::UnpackError: Debug,
 {
     let vec = packable.pack_to_vec();
-    let unpacked = P::unpack_from_slice(&vec).unwrap();
+    let unpacked = P::unpack_verified(&vec).unwrap();
 
     assert_eq!(packable, &unpacked);
     assert_eq!(packable.packed_len(), vec.len());
@@ -51,16 +51,16 @@ where
 
     let mut vec_packer = VecPacker::new();
     packable.pack(&mut vec_packer).unwrap();
-    let unpacked = P::unpack_checked(&mut vec_packer.as_slice()).unwrap();
+    let unpacked = P::unpack_verified(&mut vec_packer.as_slice()).unwrap();
     assert_eq!(packable, &unpacked);
 
     // Tests for Read and Write
 
     let mut vec = Vec::new();
     packable.pack(&mut vec).unwrap();
-    let unpacked = P::unpack_checked(&mut vec_packer.as_slice()).unwrap();
+    let unpacked = P::unpack_verified(&mut vec_packer.as_slice()).unwrap();
     assert_eq!(packable, &unpacked);
 
-    generic_test_pack_to_slice_unpack_from_slice(packable);
-    generic_test_pack_to_vec_unpack_from_slice(packable)
+    generic_test_pack_to_slice_unpack_verified(packable);
+    generic_test_pack_to_vec_unpack_verified(packable)
 }

--- a/bee-common/bee-packable/tests/common/mod.rs
+++ b/bee-common/bee-packable/tests/common/mod.rs
@@ -3,7 +3,7 @@
 
 use bee_packable::{
     packer::{SlicePacker, VecPacker},
-    Packable,
+    Packable, PackableExt,
 };
 
 use core::fmt::Debug;

--- a/bee-common/bee-packable/tests/common/mod.rs
+++ b/bee-common/bee-packable/tests/common/mod.rs
@@ -51,14 +51,14 @@ where
 
     let mut vec_packer = VecPacker::new();
     packable.pack(&mut vec_packer).unwrap();
-    let unpacked = P::unpack(&mut vec_packer.as_slice()).unwrap();
+    let unpacked = P::unpack_checked(&mut vec_packer.as_slice()).unwrap();
     assert_eq!(packable, &unpacked);
 
     // Tests for Read and Write
 
     let mut vec = Vec::new();
     packable.pack(&mut vec).unwrap();
-    let unpacked = P::unpack(&mut vec_packer.as_slice()).unwrap();
+    let unpacked = P::unpack_checked(&mut vec_packer.as_slice()).unwrap();
     assert_eq!(packable, &unpacked);
 
     generic_test_pack_to_slice_unpack_from_slice(packable);

--- a/bee-common/bee-packable/tests/vec_prefix.rs
+++ b/bee-common/bee-packable/tests/vec_prefix.rs
@@ -36,7 +36,7 @@ macro_rules! impl_packable_test_for_vec_prefix {
             let mut bytes = vec![0u8; LEN + 1];
             bytes[0] = LEN as u8;
 
-            let prefixed = VecPrefix::<u8, $bounded<$min, $max>>::unpack_from_slice(bytes);
+            let prefixed = VecPrefix::<u8, $bounded<$min, $max>>::unpack_verified(bytes);
 
             const LEN_AS_TY: $ty = LEN as $ty;
 

--- a/bee-common/bee-packable/tests/vec_prefix.rs
+++ b/bee-common/bee-packable/tests/vec_prefix.rs
@@ -10,7 +10,7 @@ use bee_packable::{
     },
     error::UnpackError,
     prefix::{TryIntoPrefixError, UnpackPrefixError, VecPrefix},
-    Packable,
+    PackableExt,
 };
 
 macro_rules! impl_packable_test_for_vec_prefix {

--- a/bee-message/fuzz/fuzz_targets/fuzz_message.rs
+++ b/bee-message/fuzz/fuzz_targets/fuzz_message.rs
@@ -9,5 +9,5 @@ use bee_packable::packable::Packable;
 use libfuzzer_sys::fuzz_target;
 
 fuzz_target!(|data: &[u8]| {
-    let _ = Message::unpack_from_slice(data);
+    let _ = Message::unpack_verified(data);
 });

--- a/bee-message/src/address/bech32.rs
+++ b/bee-message/src/address/bech32.rs
@@ -61,7 +61,7 @@ impl TryInto<Address> for Bech32Address {
     type Error = ValidationError;
 
     fn try_into(self) -> Result<Address, Self::Error> {
-        Address::unpack_from_slice(self.data()).map_err(|_| ValidationError::InvalidAddress)
+        Address::unpack_verified(self.data()).map_err(|_| ValidationError::InvalidAddress)
     }
 }
 

--- a/bee-message/src/address/bech32.rs
+++ b/bee-message/src/address/bech32.rs
@@ -3,7 +3,7 @@
 
 use crate::{address::Address, error::ValidationError};
 
-use bee_packable::Packable;
+use bee_packable::PackableExt;
 
 use bech32::{self, FromBase32, ToBase32};
 

--- a/bee-message/src/builder.rs
+++ b/bee-message/src/builder.rs
@@ -8,7 +8,7 @@ use crate::{
     ValidationError,
 };
 
-use bee_packable::Packable;
+use bee_packable::PackableExt;
 
 /// A builder to build a [`Message`].
 #[derive(Default)]

--- a/bee-message/src/message.rs
+++ b/bee-message/src/message.rs
@@ -159,17 +159,19 @@ impl Packable for Message {
         self.signature.pack(packer)
     }
 
-    fn unpack<U: Unpacker>(unpacker: &mut U) -> Result<Self, UnpackError<Self::UnpackError, U::Error>> {
-        let version = u8::unpack(unpacker).infallible()?;
+    fn unpack<U: Unpacker, const CHECK: bool>(
+        unpacker: &mut U,
+    ) -> Result<Self, UnpackError<Self::UnpackError, U::Error>> {
+        let version = u8::unpack::<_, CHECK>(unpacker).infallible()?;
         validate_message_version(version).map_err(UnpackError::from_packable)?;
 
-        let parents = Parents::unpack(unpacker)?;
-        let issuer_public_key = <[u8; MESSAGE_PUBLIC_KEY_LENGTH]>::unpack(unpacker).infallible()?;
-        let issue_timestamp = u64::unpack(unpacker).infallible()?;
-        let sequence_number = u32::unpack(unpacker).infallible()?;
-        let payload = OptionalPayload::unpack(unpacker)?;
-        let nonce = u64::unpack(unpacker).infallible()?;
-        let signature = <[u8; MESSAGE_SIGNATURE_LENGTH]>::unpack(unpacker).infallible()?;
+        let parents = Parents::unpack::<_, CHECK>(unpacker)?;
+        let issuer_public_key = <[u8; MESSAGE_PUBLIC_KEY_LENGTH]>::unpack::<_, CHECK>(unpacker).infallible()?;
+        let issue_timestamp = u64::unpack::<_, CHECK>(unpacker).infallible()?;
+        let sequence_number = u32::unpack::<_, CHECK>(unpacker).infallible()?;
+        let payload = OptionalPayload::unpack::<_, CHECK>(unpacker)?;
+        let nonce = u64::unpack::<_, CHECK>(unpacker).infallible()?;
+        let signature = <[u8; MESSAGE_SIGNATURE_LENGTH]>::unpack::<_, CHECK>(unpacker).infallible()?;
 
         let message = Self {
             parents,

--- a/bee-message/src/message.rs
+++ b/bee-message/src/message.rs
@@ -11,7 +11,7 @@ use bee_packable::{
     error::{UnpackError, UnpackErrorExt},
     packer::Packer,
     unpacker::Unpacker,
-    Packable,
+    Packable, PackableExt,
 };
 
 use crypto::{

--- a/bee-message/src/message.rs
+++ b/bee-message/src/message.rs
@@ -159,19 +159,19 @@ impl Packable for Message {
         self.signature.pack(packer)
     }
 
-    fn unpack<U: Unpacker, const CHECK: bool>(
+    fn unpack<U: Unpacker, const VERIFY: bool>(
         unpacker: &mut U,
     ) -> Result<Self, UnpackError<Self::UnpackError, U::Error>> {
-        let version = u8::unpack::<_, CHECK>(unpacker).infallible()?;
+        let version = u8::unpack::<_, VERIFY>(unpacker).infallible()?;
         validate_message_version(version).map_err(UnpackError::from_packable)?;
 
-        let parents = Parents::unpack::<_, CHECK>(unpacker)?;
-        let issuer_public_key = <[u8; MESSAGE_PUBLIC_KEY_LENGTH]>::unpack::<_, CHECK>(unpacker).infallible()?;
-        let issue_timestamp = u64::unpack::<_, CHECK>(unpacker).infallible()?;
-        let sequence_number = u32::unpack::<_, CHECK>(unpacker).infallible()?;
-        let payload = OptionalPayload::unpack::<_, CHECK>(unpacker)?;
-        let nonce = u64::unpack::<_, CHECK>(unpacker).infallible()?;
-        let signature = <[u8; MESSAGE_SIGNATURE_LENGTH]>::unpack::<_, CHECK>(unpacker).infallible()?;
+        let parents = Parents::unpack::<_, VERIFY>(unpacker)?;
+        let issuer_public_key = <[u8; MESSAGE_PUBLIC_KEY_LENGTH]>::unpack::<_, VERIFY>(unpacker).infallible()?;
+        let issue_timestamp = u64::unpack::<_, VERIFY>(unpacker).infallible()?;
+        let sequence_number = u32::unpack::<_, VERIFY>(unpacker).infallible()?;
+        let payload = OptionalPayload::unpack::<_, VERIFY>(unpacker)?;
+        let nonce = u64::unpack::<_, VERIFY>(unpacker).infallible()?;
+        let signature = <[u8; MESSAGE_SIGNATURE_LENGTH]>::unpack::<_, VERIFY>(unpacker).infallible()?;
 
         let message = Self {
             parents,

--- a/bee-message/src/metadata.rs
+++ b/bee-message/src/metadata.rs
@@ -96,8 +96,10 @@ impl Packable for Flags {
         self.bits().pack(packer)
     }
 
-    fn unpack<U: Unpacker>(unpacker: &mut U) -> Result<Self, UnpackError<Self::UnpackError, U::Error>> {
-        Ok(Self::from_bits_truncate(u8::unpack(unpacker).infallible()?))
+    fn unpack<U: Unpacker, const CHECK: bool>(
+        unpacker: &mut U,
+    ) -> Result<Self, UnpackError<Self::UnpackError, U::Error>> {
+        Ok(Self::from_bits_truncate(u8::unpack::<_, CHECK>(unpacker).infallible()?))
     }
 }
 
@@ -196,12 +198,14 @@ impl Packable for MessageMetadata {
         self.opinion.pack(packer)
     }
 
-    fn unpack<U: Unpacker>(unpacker: &mut U) -> Result<Self, UnpackError<Self::UnpackError, U::Error>> {
-        let flags = Flags::unpack(unpacker).infallible()?;
-        let received_timestamp = u64::unpack(unpacker).infallible()?;
-        let solidification_timestamp = u64::unpack(unpacker).infallible()?;
-        let branch_id = <[u8; 32]>::unpack(unpacker).infallible()?;
-        let opinion = Opinion::unpack(unpacker)?;
+    fn unpack<U: Unpacker, const CHECK: bool>(
+        unpacker: &mut U,
+    ) -> Result<Self, UnpackError<Self::UnpackError, U::Error>> {
+        let flags = Flags::unpack::<_, CHECK>(unpacker).infallible()?;
+        let received_timestamp = u64::unpack::<_, CHECK>(unpacker).infallible()?;
+        let solidification_timestamp = u64::unpack::<_, CHECK>(unpacker).infallible()?;
+        let branch_id = <[u8; 32]>::unpack::<_, CHECK>(unpacker).infallible()?;
+        let opinion = Opinion::unpack::<_, CHECK>(unpacker)?;
 
         Ok(Self {
             flags,

--- a/bee-message/src/metadata.rs
+++ b/bee-message/src/metadata.rs
@@ -96,10 +96,12 @@ impl Packable for Flags {
         self.bits().pack(packer)
     }
 
-    fn unpack<U: Unpacker, const CHECK: bool>(
+    fn unpack<U: Unpacker, const VERIFY: bool>(
         unpacker: &mut U,
     ) -> Result<Self, UnpackError<Self::UnpackError, U::Error>> {
-        Ok(Self::from_bits_truncate(u8::unpack::<_, CHECK>(unpacker).infallible()?))
+        Ok(Self::from_bits_truncate(
+            u8::unpack::<_, VERIFY>(unpacker).infallible()?,
+        ))
     }
 }
 
@@ -198,14 +200,14 @@ impl Packable for MessageMetadata {
         self.opinion.pack(packer)
     }
 
-    fn unpack<U: Unpacker, const CHECK: bool>(
+    fn unpack<U: Unpacker, const VERIFY: bool>(
         unpacker: &mut U,
     ) -> Result<Self, UnpackError<Self::UnpackError, U::Error>> {
-        let flags = Flags::unpack::<_, CHECK>(unpacker).infallible()?;
-        let received_timestamp = u64::unpack::<_, CHECK>(unpacker).infallible()?;
-        let solidification_timestamp = u64::unpack::<_, CHECK>(unpacker).infallible()?;
-        let branch_id = <[u8; 32]>::unpack::<_, CHECK>(unpacker).infallible()?;
-        let opinion = Opinion::unpack::<_, CHECK>(unpacker)?;
+        let flags = Flags::unpack::<_, VERIFY>(unpacker).infallible()?;
+        let received_timestamp = u64::unpack::<_, VERIFY>(unpacker).infallible()?;
+        let solidification_timestamp = u64::unpack::<_, VERIFY>(unpacker).infallible()?;
+        let branch_id = <[u8; 32]>::unpack::<_, VERIFY>(unpacker).infallible()?;
+        let opinion = Opinion::unpack::<_, VERIFY>(unpacker)?;
 
         Ok(Self {
             flags,

--- a/bee-message/src/output/signature_locked_single.rs
+++ b/bee-message/src/output/signature_locked_single.rs
@@ -60,12 +60,12 @@ impl Packable for SignatureLockedSingleOutput {
         self.amount.pack(packer)
     }
 
-    fn unpack<U: Unpacker, const CHECK: bool>(
+    fn unpack<U: Unpacker, const VERIFY: bool>(
         unpacker: &mut U,
     ) -> Result<Self, UnpackError<Self::UnpackError, U::Error>> {
-        let address = Address::unpack::<_, CHECK>(unpacker)?;
+        let address = Address::unpack::<_, VERIFY>(unpacker)?;
 
-        let amount = u64::unpack::<_, CHECK>(unpacker).infallible()?;
+        let amount = u64::unpack::<_, VERIFY>(unpacker).infallible()?;
         validate_amount(amount).map_err(UnpackError::from_packable)?;
 
         Ok(Self { address, amount })

--- a/bee-message/src/output/signature_locked_single.rs
+++ b/bee-message/src/output/signature_locked_single.rs
@@ -60,10 +60,12 @@ impl Packable for SignatureLockedSingleOutput {
         self.amount.pack(packer)
     }
 
-    fn unpack<U: Unpacker>(unpacker: &mut U) -> Result<Self, UnpackError<Self::UnpackError, U::Error>> {
-        let address = Address::unpack(unpacker)?;
+    fn unpack<U: Unpacker, const CHECK: bool>(
+        unpacker: &mut U,
+    ) -> Result<Self, UnpackError<Self::UnpackError, U::Error>> {
+        let address = Address::unpack::<_, CHECK>(unpacker)?;
 
-        let amount = u64::unpack(unpacker).infallible()?;
+        let amount = u64::unpack::<_, CHECK>(unpacker).infallible()?;
         validate_amount(amount).map_err(UnpackError::from_packable)?;
 
         Ok(Self { address, amount })

--- a/bee-message/src/parents.rs
+++ b/bee-message/src/parents.rs
@@ -137,11 +137,13 @@ impl Packable for Parents {
         Ok(())
     }
 
-    fn unpack<U: Unpacker>(unpacker: &mut U) -> Result<Self, UnpackError<Self::UnpackError, U::Error>> {
-        let count = u8::unpack(unpacker).infallible()?;
+    fn unpack<U: Unpacker, const CHECK: bool>(
+        unpacker: &mut U,
+    ) -> Result<Self, UnpackError<Self::UnpackError, U::Error>> {
+        let count = u8::unpack::<_, CHECK>(unpacker).infallible()?;
         validate_parents_count(count as usize).map_err(UnpackError::from_packable)?;
 
-        let bits_repr = u8::unpack(unpacker).infallible()?;
+        let bits_repr = u8::unpack::<_, CHECK>(unpacker).infallible()?;
 
         let mut bits = bitarr![Lsb0, u8; 0; 8];
         bits.store(bits_repr);
@@ -152,7 +154,7 @@ impl Packable for Parents {
         parents.reserve(count as usize);
 
         for i in 0..count {
-            let id = MessageId::unpack(unpacker).infallible()?;
+            let id = MessageId::unpack::<_, CHECK>(unpacker).infallible()?;
 
             if *bits.get(i as usize).unwrap() {
                 parents.push(Parent::Strong(id))

--- a/bee-message/src/parents.rs
+++ b/bee-message/src/parents.rs
@@ -137,13 +137,13 @@ impl Packable for Parents {
         Ok(())
     }
 
-    fn unpack<U: Unpacker, const CHECK: bool>(
+    fn unpack<U: Unpacker, const VERIFY: bool>(
         unpacker: &mut U,
     ) -> Result<Self, UnpackError<Self::UnpackError, U::Error>> {
-        let count = u8::unpack::<_, CHECK>(unpacker).infallible()?;
+        let count = u8::unpack::<_, VERIFY>(unpacker).infallible()?;
         validate_parents_count(count as usize).map_err(UnpackError::from_packable)?;
 
-        let bits_repr = u8::unpack::<_, CHECK>(unpacker).infallible()?;
+        let bits_repr = u8::unpack::<_, VERIFY>(unpacker).infallible()?;
 
         let mut bits = bitarr![Lsb0, u8; 0; 8];
         bits.store(bits_repr);
@@ -154,7 +154,7 @@ impl Packable for Parents {
         parents.reserve(count as usize);
 
         for i in 0..count {
-            let id = MessageId::unpack::<_, CHECK>(unpacker).infallible()?;
+            let id = MessageId::unpack::<_, VERIFY>(unpacker).infallible()?;
 
             if *bits.get(i as usize).unwrap() {
                 parents.push(Parent::Strong(id))

--- a/bee-message/src/payload/mod.rs
+++ b/bee-message/src/payload/mod.rs
@@ -75,11 +75,11 @@ pub trait MessagePayload: Packable + Into<Payload> {
     }
 
     /// Unpacks a payload, its type and version.
-    fn unpack_payload<U: Unpacker, E, const CHECK: bool>(unpacker: &mut U) -> Result<Payload, UnpackError<E, U::Error>>
+    fn unpack_payload<U: Unpacker, E, const VERIFY: bool>(unpacker: &mut U) -> Result<Payload, UnpackError<E, U::Error>>
     where
         E: From<MessageUnpackError> + From<ValidationError> + From<Self::UnpackError>,
     {
-        let version = u8::unpack::<_, CHECK>(unpacker).infallible()?;
+        let version = u8::unpack::<_, VERIFY>(unpacker).infallible()?;
 
         if version != Self::VERSION {
             return Err(ValidationError::InvalidPayloadVersion {
@@ -89,7 +89,7 @@ pub trait MessagePayload: Packable + Into<Payload> {
             .map_err(UnpackError::from_packable)?;
         }
 
-        Ok(Self::unpack::<_, CHECK>(unpacker).coerce()?.into())
+        Ok(Self::unpack::<_, VERIFY>(unpacker).coerce()?.into())
     }
 }
 
@@ -171,19 +171,19 @@ impl Packable for Payload {
         }
     }
 
-    fn unpack<U: Unpacker, const CHECK: bool>(
+    fn unpack<U: Unpacker, const VERIFY: bool>(
         unpacker: &mut U,
     ) -> Result<Self, UnpackError<Self::UnpackError, U::Error>> {
-        match u32::unpack::<_, CHECK>(unpacker).infallible()? {
-            DataPayload::KIND => DataPayload::unpack_payload::<_, _, CHECK>(unpacker),
-            TransactionPayload::KIND => TransactionPayload::unpack_payload::<_, _, CHECK>(unpacker),
-            FpcPayload::KIND => FpcPayload::unpack_payload::<_, _, CHECK>(unpacker),
-            ApplicationMessagePayload::KIND => ApplicationMessagePayload::unpack_payload::<_, _, CHECK>(unpacker),
-            DkgPayload::KIND => DkgPayload::unpack_payload::<_, _, CHECK>(unpacker),
-            BeaconPayload::KIND => BeaconPayload::unpack_payload::<_, _, CHECK>(unpacker),
-            CollectiveBeaconPayload::KIND => CollectiveBeaconPayload::unpack_payload::<_, _, CHECK>(unpacker),
-            SaltDeclarationPayload::KIND => SaltDeclarationPayload::unpack_payload::<_, _, CHECK>(unpacker),
-            IndexationPayload::KIND => IndexationPayload::unpack_payload::<_, _, CHECK>(unpacker),
+        match u32::unpack::<_, VERIFY>(unpacker).infallible()? {
+            DataPayload::KIND => DataPayload::unpack_payload::<_, _, VERIFY>(unpacker),
+            TransactionPayload::KIND => TransactionPayload::unpack_payload::<_, _, VERIFY>(unpacker),
+            FpcPayload::KIND => FpcPayload::unpack_payload::<_, _, VERIFY>(unpacker),
+            ApplicationMessagePayload::KIND => ApplicationMessagePayload::unpack_payload::<_, _, VERIFY>(unpacker),
+            DkgPayload::KIND => DkgPayload::unpack_payload::<_, _, VERIFY>(unpacker),
+            BeaconPayload::KIND => BeaconPayload::unpack_payload::<_, _, VERIFY>(unpacker),
+            CollectiveBeaconPayload::KIND => CollectiveBeaconPayload::unpack_payload::<_, _, VERIFY>(unpacker),
+            SaltDeclarationPayload::KIND => SaltDeclarationPayload::unpack_payload::<_, _, VERIFY>(unpacker),
+            IndexationPayload::KIND => IndexationPayload::unpack_payload::<_, _, VERIFY>(unpacker),
             k => Err(UnpackError::Packable(PayloadUnpackError::InvalidKind(k).into())),
         }
     }
@@ -277,13 +277,13 @@ impl Packable for OptionalPayload {
         }
     }
 
-    fn unpack<U: Unpacker, const CHECK: bool>(
+    fn unpack<U: Unpacker, const VERIFY: bool>(
         unpacker: &mut U,
     ) -> Result<Self, UnpackError<Self::UnpackError, U::Error>> {
-        let len = u32::unpack::<_, CHECK>(unpacker).infallible()? as usize;
+        let len = u32::unpack::<_, VERIFY>(unpacker).infallible()? as usize;
 
         if len > 0 {
-            let payload = Payload::unpack::<_, CHECK>(unpacker)?;
+            let payload = Payload::unpack::<_, VERIFY>(unpacker)?;
             let actual_len = payload.packed_len();
 
             if len != actual_len {

--- a/bee-message/src/payload/transaction/essence.rs
+++ b/bee-message/src/payload/transaction/essence.rs
@@ -15,7 +15,7 @@ use bee_packable::{
     packer::Packer,
     prefix::VecPrefix,
     unpacker::Unpacker,
-    Packable,
+    Packable, PackableExt,
 };
 
 use alloc::vec::Vec;
@@ -313,7 +313,7 @@ fn validate_inputs_unique_utxos(inputs: &[Input]) -> Result<(), ValidationError>
 }
 
 fn validate_inputs_sorted(inputs: &[Input]) -> Result<(), ValidationError> {
-    if !is_sorted(inputs.iter().map(Packable::pack_to_vec)) {
+    if !is_sorted(inputs.iter().map(PackableExt::pack_to_vec)) {
         Err(ValidationError::TransactionInputsNotSorted)
     } else {
         Ok(())

--- a/bee-message/src/payload/transaction/mod.rs
+++ b/bee-message/src/payload/transaction/mod.rs
@@ -112,10 +112,12 @@ impl Packable for TransactionPayload {
         self.unlock_blocks.pack(packer)
     }
 
-    fn unpack<U: Unpacker>(unpacker: &mut U) -> Result<Self, UnpackError<Self::UnpackError, U::Error>> {
-        let essence = TransactionEssence::unpack(unpacker)?;
+    fn unpack<U: Unpacker, const CHECK: bool>(
+        unpacker: &mut U,
+    ) -> Result<Self, UnpackError<Self::UnpackError, U::Error>> {
+        let essence = TransactionEssence::unpack::<_, CHECK>(unpacker)?;
 
-        let unlock_blocks = UnlockBlocks::unpack(unpacker)?;
+        let unlock_blocks = UnlockBlocks::unpack::<_, CHECK>(unpacker)?;
         validate_unlock_block_count(&essence, &unlock_blocks).map_err(UnpackError::from_packable)?;
 
         Ok(Self { essence, unlock_blocks })

--- a/bee-message/src/payload/transaction/mod.rs
+++ b/bee-message/src/payload/transaction/mod.rs
@@ -113,12 +113,12 @@ impl Packable for TransactionPayload {
         self.unlock_blocks.pack(packer)
     }
 
-    fn unpack<U: Unpacker, const CHECK: bool>(
+    fn unpack<U: Unpacker, const VERIFY: bool>(
         unpacker: &mut U,
     ) -> Result<Self, UnpackError<Self::UnpackError, U::Error>> {
-        let essence = TransactionEssence::unpack::<_, CHECK>(unpacker)?;
+        let essence = TransactionEssence::unpack::<_, VERIFY>(unpacker)?;
 
-        let unlock_blocks = UnlockBlocks::unpack::<_, CHECK>(unpacker)?;
+        let unlock_blocks = UnlockBlocks::unpack::<_, VERIFY>(unpacker)?;
         validate_unlock_block_count(&essence, &unlock_blocks).map_err(UnpackError::from_packable)?;
 
         Ok(Self { essence, unlock_blocks })

--- a/bee-message/src/payload/transaction/mod.rs
+++ b/bee-message/src/payload/transaction/mod.rs
@@ -14,7 +14,8 @@ pub(crate) use essence::{
 };
 pub use transaction_id::TransactionId;
 
-use bee_packable::{error::UnpackError, packer::Packer, unpacker::Unpacker, Packable};
+use bee_packable::{error::UnpackError, packer::Packer, unpacker::Unpacker, Packable, PackableExt};
+
 use crypto::hashes::{blake2b::Blake2b256, Digest};
 
 use alloc::boxed::Box;

--- a/bee-message/src/unlock/unlock_blocks.rs
+++ b/bee-message/src/unlock/unlock_blocks.rs
@@ -81,13 +81,13 @@ impl Packable for UnlockBlocks {
         self.0.pack(packer)
     }
 
-    fn unpack<U: Unpacker, const CHECK: bool>(
+    fn unpack<U: Unpacker, const VERIFY: bool>(
         unpacker: &mut U,
     ) -> Result<Self, UnpackError<Self::UnpackError, U::Error>> {
         let inner = VecPrefix::<
             UnlockBlock,
             BoundedU16<PREFIXED_UNLOCK_BLOCKS_LENGTH_MIN, PREFIXED_UNLOCK_BLOCKS_LENGTH_MAX>,
-        >::unpack::<_, CHECK>(unpacker)
+        >::unpack::<_, VERIFY>(unpacker)
         .map_packable_err(|err| {
             err.unwrap_packable_or_else(|prefix_err| ValidationError::InvalidUnlockBlockCount(prefix_err.into()))
         })?;

--- a/bee-message/src/unlock/unlock_blocks.rs
+++ b/bee-message/src/unlock/unlock_blocks.rs
@@ -81,11 +81,13 @@ impl Packable for UnlockBlocks {
         self.0.pack(packer)
     }
 
-    fn unpack<U: Unpacker>(unpacker: &mut U) -> Result<Self, UnpackError<Self::UnpackError, U::Error>> {
+    fn unpack<U: Unpacker, const CHECK: bool>(
+        unpacker: &mut U,
+    ) -> Result<Self, UnpackError<Self::UnpackError, U::Error>> {
         let inner = VecPrefix::<
             UnlockBlock,
             BoundedU16<PREFIXED_UNLOCK_BLOCKS_LENGTH_MIN, PREFIXED_UNLOCK_BLOCKS_LENGTH_MAX>,
-        >::unpack(unpacker)
+        >::unpack::<_, CHECK>(unpacker)
         .map_packable_err(|err| {
             err.unwrap_packable_or_else(|prefix_err| ValidationError::InvalidUnlockBlockCount(prefix_err.into()))
         })?;

--- a/bee-message/tests/address.rs
+++ b/bee-message/tests/address.rs
@@ -75,7 +75,7 @@ fn packed_len() {
 #[test]
 fn packable_round_trip() {
     let address_1 = Address::from(Ed25519Address::new(hex_decode(ED25519_ADDRESS).unwrap()));
-    let address_2 = Address::unpack_from_slice(address_1.pack_to_vec()).unwrap();
+    let address_2 = Address::unpack_verified(address_1.pack_to_vec()).unwrap();
 
     assert_eq!(address_1, address_2);
 }
@@ -83,7 +83,7 @@ fn packable_round_trip() {
 #[test]
 fn unpack_invalid_kind() {
     assert!(matches!(
-        Address::unpack_from_slice(vec![
+        Address::unpack_verified(vec![
             0x04, 0x1d, 0x38, 0x9e, 0xa2, 0x7a, 0x77, 0xc9, 0x1d, 0x08, 0x40, 0xf9, 0x38, 0x61, 0x44, 0x2a, 0x95, 0xca,
             0x5e, 0x88, 0x2e, 0x0d, 0x9f, 0x9c, 0x2f, 0x99, 0x65, 0x81, 0x54, 0x09, 0xd9, 0x39, 0xe4
         ]),

--- a/bee-message/tests/address.rs
+++ b/bee-message/tests/address.rs
@@ -6,7 +6,7 @@ use bee_message::{
     util::hex_decode,
     MessageUnpackError,
 };
-use bee_packable::{error::UnpackError, Packable};
+use bee_packable::{error::UnpackError, Packable, PackableExt};
 use bee_test::rand::bytes::rand_bytes_array;
 
 use core::str::FromStr;

--- a/bee-message/tests/application_message_payload.rs
+++ b/bee-message/tests/application_message_payload.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use bee_message::payload::{drng::ApplicationMessagePayload, MessagePayload};
-use bee_packable::Packable;
+use bee_packable::{Packable, PackableExt};
 
 #[test]
 fn kind() {

--- a/bee-message/tests/application_message_payload.rs
+++ b/bee-message/tests/application_message_payload.rs
@@ -32,7 +32,7 @@ fn from() {
 fn unpack_valid() {
     let bytes = vec![0, 0, 0, 1];
 
-    assert!(ApplicationMessagePayload::unpack_from_slice(bytes).is_ok());
+    assert!(ApplicationMessagePayload::unpack_verified(bytes).is_ok());
 }
 
 #[test]
@@ -45,7 +45,7 @@ fn packed_len() {
 #[test]
 fn packable_round_trip() {
     let application_msg_1 = ApplicationMessagePayload::new(1);
-    let application_msg_2 = ApplicationMessagePayload::unpack_from_slice(application_msg_1.pack_to_vec()).unwrap();
+    let application_msg_2 = ApplicationMessagePayload::unpack_verified(application_msg_1.pack_to_vec()).unwrap();
 
     assert_eq!(application_msg_1, application_msg_2);
 }

--- a/bee-message/tests/bls_address.rs
+++ b/bee-message/tests/bls_address.rs
@@ -92,7 +92,7 @@ fn packed_len() {
 #[test]
 fn packable_round_trip() {
     let address_1 = BlsAddress::from_str(BLS_ADDRESS).unwrap();
-    let address_2 = BlsAddress::unpack_from_slice(address_1.pack_to_vec()).unwrap();
+    let address_2 = BlsAddress::unpack_verified(address_1.pack_to_vec()).unwrap();
 
     assert_eq!(address_1, address_2);
 }

--- a/bee-message/tests/bls_address.rs
+++ b/bee-message/tests/bls_address.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use bee_message::address::{Address, Bech32Address, BlsAddress};
-use bee_packable::Packable;
+use bee_packable::{Packable, PackableExt};
 
 use core::{ops::Deref, str::FromStr};
 

--- a/bee-message/tests/bls_signature.rs
+++ b/bee-message/tests/bls_signature.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use bee_message::{signature::BlsSignature, util::hex_decode};
-use bee_packable::Packable;
+use bee_packable::{Packable, PackableExt};
 
 use core::ops::Deref;
 

--- a/bee-message/tests/bls_signature.rs
+++ b/bee-message/tests/bls_signature.rs
@@ -54,7 +54,7 @@ fn packed_len() {
 #[test]
 fn packable_round_trip() {
     let signature_1 = BlsSignature::new(hex_decode(BLS_SIGNATURE).unwrap());
-    let signature_2 = BlsSignature::unpack_from_slice(signature_1.pack_to_vec()).unwrap();
+    let signature_2 = BlsSignature::unpack_verified(signature_1.pack_to_vec()).unwrap();
 
     assert_eq!(signature_1, signature_2);
 }

--- a/bee-message/tests/collective_beacon_payload.rs
+++ b/bee-message/tests/collective_beacon_payload.rs
@@ -5,7 +5,7 @@ use bee_message::{
     payload::{drng::CollectiveBeaconPayload, MessagePayload},
     util::hex_decode,
 };
-use bee_packable::Packable;
+use bee_packable::{Packable, PackableExt};
 
 const BEACON_SIGNATURE_0: &str = "55914b063d6342d89680c90b3617877c0dd5c1b88fce7e19d24904ebe56aaca9835d458d77f61bb2a250\
     805e25ab6be095f2a498419f89056157b29cb088271c93253e1b420f52d893abe4d76be718964d0f322991a253ef6a66c17ec5862441";

--- a/bee-message/tests/collective_beacon_payload.rs
+++ b/bee-message/tests/collective_beacon_payload.rs
@@ -47,7 +47,7 @@ fn unpack_valid() {
     bytes.extend(hex::decode(BEACON_SIGNATURE_1).unwrap());
     bytes.extend(hex::decode(BEACON_DISTRIBUTED_PUBLIC_KEY).unwrap());
 
-    assert!(CollectiveBeaconPayload::unpack_from_slice(bytes).is_ok());
+    assert!(CollectiveBeaconPayload::unpack_verified(bytes).is_ok());
 }
 
 #[test]
@@ -97,7 +97,7 @@ fn packable_round_trip() {
         .finish()
         .unwrap();
 
-    let beacon_b = CollectiveBeaconPayload::unpack_from_slice(beacon_a.pack_to_vec()).unwrap();
+    let beacon_b = CollectiveBeaconPayload::unpack_verified(beacon_a.pack_to_vec()).unwrap();
 
     assert_eq!(beacon_a, beacon_b);
 }

--- a/bee-message/tests/data_payload.rs
+++ b/bee-message/tests/data_payload.rs
@@ -6,7 +6,7 @@ use bee_message::{
     payload::{data::DataPayload, MessagePayload},
     MessageUnpackError,
 };
-use bee_packable::{bounded::InvalidBoundedU32, error::UnpackError, prefix::TryIntoPrefixError, Packable};
+use bee_packable::{bounded::InvalidBoundedU32, error::UnpackError, prefix::TryIntoPrefixError, Packable, PackableExt};
 use bee_test::rand::bytes::rand_bytes;
 
 #[test]

--- a/bee-message/tests/data_payload.rs
+++ b/bee-message/tests/data_payload.rs
@@ -47,7 +47,7 @@ fn unpack_valid() {
 
     bytes.extend(rand_bytes(255));
 
-    let data = DataPayload::unpack_from_slice(bytes);
+    let data = DataPayload::unpack_verified(bytes);
 
     assert!(data.is_ok());
 }
@@ -60,7 +60,7 @@ fn unpack_invalid_length() {
 
     bytes.extend(rand_bytes(data_bytes));
 
-    let data = DataPayload::unpack_from_slice(bytes);
+    let data = DataPayload::unpack_verified(bytes);
 
     assert!(matches!(
         data,
@@ -88,7 +88,7 @@ fn packed_len() {
 #[test]
 fn packable_round_trip() {
     let data_a = DataPayload::new(rand_bytes(255)).unwrap();
-    let data_b = DataPayload::unpack_from_slice(data_a.pack_to_vec()).unwrap();
+    let data_b = DataPayload::unpack_verified(data_a.pack_to_vec()).unwrap();
 
     assert_eq!(data_a, data_b);
 }

--- a/bee-message/tests/dkg_payload.rs
+++ b/bee-message/tests/dkg_payload.rs
@@ -72,7 +72,7 @@ fn encrypted_deal_packed_len() {
 fn encryped_deal_unwrap() {
     let bytes = vec![0u8, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 10, 0, 0, 0, 0];
 
-    let deal = EncryptedDeal::unpack_from_slice(bytes);
+    let deal = EncryptedDeal::unpack_verified(bytes);
 
     assert!(deal.is_ok());
 }
@@ -88,7 +88,7 @@ fn encrypted_deal_packable_round_trip() {
         .finish()
         .unwrap();
 
-    let deal_b = EncryptedDeal::unpack_from_slice(deal_a.pack_to_vec()).unwrap();
+    let deal_b = EncryptedDeal::unpack_verified(deal_a.pack_to_vec()).unwrap();
 
     assert_eq!(deal_a, deal_b);
 }
@@ -120,7 +120,7 @@ fn dkg_unpack_valid() {
         0, 0, 0, 1, 0, 0, 0, 20, 0, 0, 0, 32, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 10, 0, 0, 0, 0,
     ];
 
-    let dkg = DkgPayload::unpack_from_slice(bytes);
+    let dkg = DkgPayload::unpack_verified(bytes);
 
     assert!(dkg.is_ok());
 }
@@ -191,7 +191,7 @@ fn dkg_packable_round_trip() {
         .finish()
         .unwrap();
 
-    let dkg_b = DkgPayload::unpack_from_slice(dkg_a.pack_to_vec()).unwrap();
+    let dkg_b = DkgPayload::unpack_verified(dkg_a.pack_to_vec()).unwrap();
 
     assert_eq!(dkg_a, dkg_b);
 }

--- a/bee-message/tests/dkg_payload.rs
+++ b/bee-message/tests/dkg_payload.rs
@@ -5,7 +5,7 @@ use bee_message::payload::{
     drng::{DkgPayload, EncryptedDeal},
     MessagePayload,
 };
-use bee_packable::Packable;
+use bee_packable::{Packable, PackableExt};
 use bee_test::rand::bytes::rand_bytes;
 
 #[test]

--- a/bee-message/tests/ed25519_address.rs
+++ b/bee-message/tests/ed25519_address.rs
@@ -98,7 +98,7 @@ fn packed_len() {
 #[test]
 fn packable_round_trip() {
     let address_1 = Ed25519Address::from_str(ED25519_ADDRESS).unwrap();
-    let address_2 = Ed25519Address::unpack_from_slice(address_1.pack_to_vec()).unwrap();
+    let address_2 = Ed25519Address::unpack_verified(address_1.pack_to_vec()).unwrap();
 
     assert_eq!(address_1, address_2);
 }

--- a/bee-message/tests/ed25519_address.rs
+++ b/bee-message/tests/ed25519_address.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use bee_message::address::{Address, Bech32Address, Ed25519Address};
-use bee_packable::Packable;
+use bee_packable::{Packable, PackableExt};
 
 use core::{ops::Deref, str::FromStr};
 

--- a/bee-message/tests/ed25519_signature.rs
+++ b/bee-message/tests/ed25519_signature.rs
@@ -47,7 +47,7 @@ fn packable_round_trip() {
         hex_decode(ED25519_PUBLIC_KEY).unwrap(),
         hex_decode(ED25519_SIGNATURE).unwrap(),
     );
-    let signature_2 = Ed25519Signature::unpack_from_slice(signature_1.pack_to_vec()).unwrap();
+    let signature_2 = Ed25519Signature::unpack_verified(signature_1.pack_to_vec()).unwrap();
 
     assert_eq!(signature_1, signature_2);
 }

--- a/bee-message/tests/ed25519_signature.rs
+++ b/bee-message/tests/ed25519_signature.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use bee_message::{signature::Ed25519Signature, util::hex_decode};
-use bee_packable::Packable;
+use bee_packable::{Packable, PackableExt};
 
 const ED25519_PUBLIC_KEY: &str = "1da5ddd11ba3f961acab68fafee3177d039875eaa94ac5fdbff8b53f0c50bfb9";
 const ED25519_SIGNATURE: &str = "c6a40edf9a089f42c18f4ebccb35fe4b578d93b879e99b87f63573324a710d3456b03fb6d1fcc027e6401cbd9581f790ee3ed7a3f68e9c225fcb9f1cd7b7110d";

--- a/bee-message/tests/fpc_payload.rs
+++ b/bee-message/tests/fpc_payload.rs
@@ -102,7 +102,7 @@ fn unpack_valid() {
     bytes.extend(rand_bytes_array::<32>());
     bytes.extend(vec![2, 2]);
 
-    assert!(FpcPayload::unpack_from_slice(bytes).is_ok());
+    assert!(FpcPayload::unpack_verified(bytes).is_ok());
 }
 
 #[test]
@@ -113,7 +113,7 @@ fn unpack_invalid_opinion() {
     bytes.extend(vec![0, 0]);
 
     assert!(matches!(
-        FpcPayload::unpack_from_slice(bytes),
+        FpcPayload::unpack_verified(bytes),
         Err(UnpackError::Packable(MessageUnpackError::Opinion(
             OpinionUnpackError::InvalidKind(0)
         ))),
@@ -135,7 +135,7 @@ fn packable_round_trip() {
         ])
         .finish()
         .unwrap();
-    let fpc_b = FpcPayload::unpack_from_slice(fpc_a.pack_to_vec()).unwrap();
+    let fpc_b = FpcPayload::unpack_verified(fpc_a.pack_to_vec()).unwrap();
 
     assert_eq!(fpc_a, fpc_b);
 }

--- a/bee-message/tests/fpc_payload.rs
+++ b/bee-message/tests/fpc_payload.rs
@@ -9,7 +9,7 @@ use bee_message::{
     },
     MessageId, MessageUnpackError,
 };
-use bee_packable::{error::UnpackError, Packable};
+use bee_packable::{error::UnpackError, PackableExt};
 use bee_test::rand::bytes::rand_bytes_array;
 
 #[test]

--- a/bee-message/tests/indexation_payload.rs
+++ b/bee-message/tests/indexation_payload.rs
@@ -90,7 +90,7 @@ fn new_invalid_data_length_more_than_max() {
 #[test]
 fn unpack_invalid_index_length_less_than_min() {
     assert!(matches!(
-        IndexationPayload::unpack_from_slice(vec![0x00, 0x00, 0x00, 0x00, 0x00, 0x00]),
+        IndexationPayload::unpack_verified(vec![0x00, 0x00, 0x00, 0x00, 0x00, 0x00]),
         Err(UnpackError::Packable(MessageUnpackError::Validation(
             ValidationError::InvalidIndexationIndexLength(TryIntoPrefixError::Invalid(InvalidBoundedU32(0)))
         ))),
@@ -100,7 +100,7 @@ fn unpack_invalid_index_length_less_than_min() {
 #[test]
 fn unpack_invalid_index_length_more_than_max() {
     assert!(matches!(
-        IndexationPayload::unpack_from_slice(vec![
+        IndexationPayload::unpack_verified(vec![
             0x41, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
             0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
             0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
@@ -122,7 +122,7 @@ fn unpack_invalid_data_length_more_than_max() {
     bytes.extend(vec![0; data_len]);
 
     assert!(matches!(
-        IndexationPayload::unpack_from_slice(bytes),
+        IndexationPayload::unpack_verified(bytes),
         Err(UnpackError::Packable(MessageUnpackError::Validation(
             ValidationError::InvalidIndexationDataLength(TryIntoPrefixError::Invalid(InvalidBoundedU32(n)))
         )))
@@ -151,7 +151,7 @@ fn packable_round_trip() {
     let indexation_1 =
         IndexationPayload::new(index, [0x42, 0xff, 0x84, 0xa2, 0x42, 0xff, 0x84, 0xa2].to_vec()).unwrap();
 
-    let indexation_2 = IndexationPayload::unpack_from_slice(indexation_1.pack_to_vec()).unwrap();
+    let indexation_2 = IndexationPayload::unpack_verified(indexation_1.pack_to_vec()).unwrap();
 
     assert_eq!(indexation_1, indexation_2);
 }

--- a/bee-message/tests/indexation_payload.rs
+++ b/bee-message/tests/indexation_payload.rs
@@ -6,7 +6,7 @@ use bee_message::{
     payload::{indexation::IndexationPayload, MessagePayload},
     MESSAGE_LENGTH_RANGE,
 };
-use bee_packable::{bounded::InvalidBoundedU32, error::UnpackError, prefix::TryIntoPrefixError, Packable};
+use bee_packable::{bounded::InvalidBoundedU32, error::UnpackError, prefix::TryIntoPrefixError, Packable, PackableExt};
 use bee_test::rand::bytes::rand_bytes;
 
 #[test]

--- a/bee-message/tests/input.rs
+++ b/bee-message/tests/input.rs
@@ -34,7 +34,7 @@ fn packable_round_trip() {
     let input_1 = Input::from(UtxoInput::from(
         OutputId::new(TransactionId::new([42; TransactionId::LENGTH]), 0).unwrap(),
     ));
-    let input_2 = Input::unpack_from_slice(input_1.pack_to_vec()).unwrap();
+    let input_2 = Input::unpack_verified(input_1.pack_to_vec()).unwrap();
 
     assert_eq!(input_1, input_2);
 }
@@ -46,7 +46,7 @@ fn unpack_invalid_tag() {
     bytes.extend(vec![0, 0]);
 
     assert!(matches!(
-        Input::unpack_from_slice(bytes),
+        Input::unpack_verified(bytes),
         Err(UnpackError::Packable(MessageUnpackError::Input(
             InputUnpackError::InvalidKind(1)
         ))),

--- a/bee-message/tests/input.rs
+++ b/bee-message/tests/input.rs
@@ -7,7 +7,7 @@ use bee_message::{
     output::OutputId,
     payload::transaction::TransactionId,
 };
-use bee_packable::{error::UnpackError, Packable};
+use bee_packable::{error::UnpackError, Packable, PackableExt};
 use bee_test::rand::bytes::rand_bytes;
 
 #[test]

--- a/bee-message/tests/message.rs
+++ b/bee-message/tests/message.rs
@@ -190,7 +190,7 @@ fn packable_round_trip() {
         .finish()
         .unwrap();
 
-    let message_b = Message::unpack_from_slice(message_a.pack_to_vec()).unwrap();
+    let message_b = Message::unpack_verified(message_a.pack_to_vec()).unwrap();
 
     assert_eq!(message_a, message_b);
 }
@@ -212,7 +212,7 @@ fn unpack_valid() {
         248, 226, 27, 75, 64, 65, 70, 179, 143, 249, 27, 85, 91, 169, 46, 237, 98, 213, 205, 27,
     ];
 
-    Message::unpack_from_slice(bytes).unwrap();
+    Message::unpack_verified(bytes).unwrap();
 }
 
 #[test]
@@ -233,7 +233,7 @@ fn unpack_invalid_version() {
     ];
 
     assert!(matches!(
-        Message::unpack_from_slice(bytes),
+        Message::unpack_verified(bytes),
         Err(UnpackError::Packable(MessageUnpackError::Validation(
             ValidationError::InvalidMessageVersion(0)
         )))
@@ -258,7 +258,7 @@ fn unpack_invalid_payload_length() {
     ];
 
     assert!(matches!(
-        Message::unpack_from_slice(bytes),
+        Message::unpack_verified(bytes),
         Err(UnpackError::Packable(MessageUnpackError::Validation(
             ValidationError::PayloadLengthMismatch {
                 expected: 108,

--- a/bee-message/tests/message.rs
+++ b/bee-message/tests/message.rs
@@ -5,7 +5,7 @@ use bee_message::{
     payload::{indexation::IndexationPayload, Payload},
     Message, MessageBuilder, MessageUnpackError, ValidationError,
 };
-use bee_packable::{error::UnpackError, Packable};
+use bee_packable::{error::UnpackError, Packable, PackableExt};
 use bee_test::rand::{
     bytes::{rand_bytes, rand_bytes_array},
     message::{parents::rand_parents, payload::rand_indexation_payload},

--- a/bee-message/tests/message_id.rs
+++ b/bee-message/tests/message_id.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use bee_message::MessageId;
-use bee_packable::Packable;
+use bee_packable::{Packable, PackableExt};
 
 use core::{ops::Deref, str::FromStr};
 

--- a/bee-message/tests/message_id.rs
+++ b/bee-message/tests/message_id.rs
@@ -82,7 +82,7 @@ fn packed_len() {
 #[test]
 fn packable_round_trip() {
     let message_id_1 = MessageId::from_str(MESSAGE_ID).unwrap();
-    let message_id_2 = MessageId::unpack_from_slice(message_id_1.pack_to_vec()).unwrap();
+    let message_id_2 = MessageId::unpack_verified(message_id_1.pack_to_vec()).unwrap();
 
     assert_eq!(message_id_1, message_id_2);
 }

--- a/bee-message/tests/metadata.rs
+++ b/bee-message/tests/metadata.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use bee_message::MessageMetadata;
-use bee_packable::Packable;
+use bee_packable::{Packable, PackableExt};
 use bee_test::rand::{
     bytes::rand_bytes_array,
     message::{metadata::rand_message_metadata, payload::rand_opinion},

--- a/bee-message/tests/metadata.rs
+++ b/bee-message/tests/metadata.rs
@@ -58,7 +58,7 @@ fn packed_len() {
 #[test]
 fn packable_round_trip() {
     let metadata_a = rand_message_metadata();
-    let metadata_b = MessageMetadata::unpack_from_slice(metadata_a.pack_to_vec()).unwrap();
+    let metadata_b = MessageMetadata::unpack_verified(metadata_a.pack_to_vec()).unwrap();
 
     assert_eq!(metadata_a, metadata_b);
 }

--- a/bee-message/tests/output.rs
+++ b/bee-message/tests/output.rs
@@ -8,7 +8,7 @@ use bee_message::{
         AssetBalance, AssetId, Output, OutputUnpackError, SignatureLockedAssetOutput, SignatureLockedSingleOutput,
     },
 };
-use bee_packable::{error::UnpackError, Packable};
+use bee_packable::{error::UnpackError, Packable, PackableExt};
 use bee_test::rand::bytes::{rand_bytes, rand_bytes_array};
 
 use core::str::FromStr;

--- a/bee-message/tests/output.rs
+++ b/bee-message/tests/output.rs
@@ -54,7 +54,7 @@ fn packable_round_trip() {
         SignatureLockedSingleOutput::new(Address::from(Ed25519Address::from_str(ED25519_ADDRESS).unwrap()), 1_000)
             .unwrap(),
     );
-    let output_2 = Output::unpack_from_slice(output_1.pack_to_vec()).unwrap();
+    let output_2 = Output::unpack_verified(output_1.pack_to_vec()).unwrap();
 
     assert_eq!(output_1, output_2);
 }
@@ -65,7 +65,7 @@ fn unpack_invalid_tag() {
     bytes.extend(rand_bytes(32));
     bytes.extend(vec![128, 0, 0, 0, 0, 0, 0, 0]);
 
-    let output = Output::unpack_from_slice(bytes);
+    let output = Output::unpack_verified(bytes);
 
     assert!(matches!(
         output,

--- a/bee-message/tests/output_id.rs
+++ b/bee-message/tests/output_id.rs
@@ -7,7 +7,7 @@ use bee_message::{
     payload::transaction::TransactionId,
     util::hex_decode,
 };
-use bee_packable::{error::UnpackError, Packable};
+use bee_packable::{error::UnpackError, Packable, PackableExt};
 
 use core::str::FromStr;
 

--- a/bee-message/tests/output_id.rs
+++ b/bee-message/tests/output_id.rs
@@ -110,7 +110,7 @@ fn packed_len() {
 #[test]
 fn packable_round_trip() {
     let output_id_1 = OutputId::from_str(OUTPUT_ID).unwrap();
-    let output_id_2 = OutputId::unpack_from_slice(output_id_1.pack_to_vec()).unwrap();
+    let output_id_2 = OutputId::unpack_verified(output_id_1.pack_to_vec()).unwrap();
 
     assert_eq!(output_id_1, output_id_2);
 }
@@ -123,7 +123,7 @@ fn unpack_invalid_index() {
     ];
 
     assert!(matches!(
-        OutputId::unpack_from_slice(bytes),
+        OutputId::unpack_verified(bytes),
         Err(UnpackError::Packable(MessageUnpackError::Validation(
             ValidationError::InvalidOutputIndex(127)
         ))),

--- a/bee-message/tests/padded_index.rs
+++ b/bee-message/tests/padded_index.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use bee_message::{payload::indexation::PaddedIndex, util::hex_decode};
-use bee_packable::Packable;
+use bee_packable::{Packable, PackableExt};
 
 use core::{ops::Deref, str::FromStr};
 

--- a/bee-message/tests/padded_index.rs
+++ b/bee-message/tests/padded_index.rs
@@ -82,7 +82,7 @@ fn packed_len() {
 #[test]
 fn packable_round_trip() {
     let padded_index_1 = PaddedIndex::from_str(PADDED_INDEX).unwrap();
-    let padded_index_2 = PaddedIndex::unpack_from_slice(padded_index_1.pack_to_vec()).unwrap();
+    let padded_index_2 = PaddedIndex::unpack_verified(padded_index_1.pack_to_vec()).unwrap();
 
     assert_eq!(padded_index_1, padded_index_2);
 }

--- a/bee-message/tests/parents.rs
+++ b/bee-message/tests/parents.rs
@@ -100,7 +100,7 @@ fn packed_len() {
 #[test]
 fn pack_unpack_valid() {
     let parents_1 = rand_parents();
-    let parents_2 = Parents::unpack_from_slice(parents_1.pack_to_vec()).unwrap();
+    let parents_2 = Parents::unpack_verified(parents_1.pack_to_vec()).unwrap();
 
     assert_eq!(parents_1, parents_2);
 }
@@ -110,7 +110,7 @@ fn unpack_invalid_less_than_min() {
     let bytes = vec![0, 1];
 
     assert!(matches!(
-        Parents::unpack_from_slice(bytes),
+        Parents::unpack_verified(bytes),
         Err(UnpackError::Packable(MessageUnpackError::Validation(
             ValidationError::InvalidParentsCount(0)
         ))),
@@ -131,7 +131,7 @@ fn unpack_invalid_more_than_max() {
     ];
 
     assert!(matches!(
-        Parents::unpack_from_slice(bytes),
+        Parents::unpack_verified(bytes),
         Err(UnpackError::Packable(MessageUnpackError::Validation(
             ValidationError::InvalidParentsCount(9)
         ))),
@@ -146,7 +146,7 @@ fn unpack_invalid_no_strong_parents() {
     ];
 
     assert!(matches!(
-        Parents::unpack_from_slice(bytes),
+        Parents::unpack_verified(bytes),
         Err(UnpackError::Packable(MessageUnpackError::Validation(
             ValidationError::InvalidStrongParentsCount(0)
         ))),
@@ -165,7 +165,7 @@ fn unpack_invalid_not_sorted() {
     packed.append(&mut packed_messages);
 
     assert!(matches!(
-        Parents::unpack_from_slice(packed),
+        Parents::unpack_verified(packed),
         Err(UnpackError::Packable(MessageUnpackError::Validation(
             ValidationError::ParentsNotUniqueSorted
         ))),
@@ -185,7 +185,7 @@ fn unpack_invalid_not_unique() {
     packed.append(&mut packed_messages);
 
     assert!(matches!(
-        Parents::unpack_from_slice(packed),
+        Parents::unpack_verified(packed),
         Err(UnpackError::Packable(MessageUnpackError::Validation(
             ValidationError::ParentsNotUniqueSorted
         ))),

--- a/bee-message/tests/parents.rs
+++ b/bee-message/tests/parents.rs
@@ -5,7 +5,7 @@ use bee_message::{
     error::{MessageUnpackError, ValidationError},
     parents::{Parent, Parents},
 };
-use bee_packable::{error::UnpackError, Packable};
+use bee_packable::{error::UnpackError, Packable, PackableExt};
 use bee_test::rand::{
     message::{parents::rand_parents, rand_message_id},
     vec::rand_vec,

--- a/bee-message/tests/payload.rs
+++ b/bee-message/tests/payload.rs
@@ -30,7 +30,7 @@ fn application_message_payload_packable_round_trip() {
     let payload_1 = Payload::from(ApplicationMessagePayload::new(1));
 
     let bytes = payload_1.pack_to_vec();
-    let payload_2 = Payload::unpack_from_slice(bytes.clone()).unwrap();
+    let payload_2 = Payload::unpack_verified(bytes.clone()).unwrap();
 
     assert_eq!(payload_1, payload_2);
     assert_eq!(payload_1.kind(), ApplicationMessagePayload::KIND);
@@ -51,7 +51,7 @@ fn collective_beacon_payload_packable_round_trip() {
     );
 
     let bytes = payload_1.pack_to_vec();
-    let payload_2 = Payload::unpack_from_slice(bytes.clone()).unwrap();
+    let payload_2 = Payload::unpack_verified(bytes.clone()).unwrap();
 
     assert_eq!(payload_1, payload_2);
     assert_eq!(payload_1.kind(), CollectiveBeaconPayload::KIND);
@@ -63,7 +63,7 @@ fn data_payload_packable_round_trip() {
     let payload_1 = Payload::from(DataPayload::new(vec![0; 255]).unwrap());
 
     let bytes = payload_1.pack_to_vec();
-    let payload_2 = Payload::unpack_from_slice(bytes.clone()).unwrap();
+    let payload_2 = Payload::unpack_verified(bytes.clone()).unwrap();
 
     assert_eq!(payload_1, payload_2);
     assert_eq!(payload_1.kind(), DataPayload::KIND);
@@ -92,7 +92,7 @@ fn dkg_payload_packable_round_trip() {
     );
 
     let bytes = payload_1.pack_to_vec();
-    let payload_2 = Payload::unpack_from_slice(bytes.clone()).unwrap();
+    let payload_2 = Payload::unpack_verified(bytes.clone()).unwrap();
 
     assert_eq!(payload_1, payload_2);
     assert_eq!(payload_1.kind(), DkgPayload::KIND);
@@ -118,7 +118,7 @@ fn fpc_payload_packable_round_trip() {
     );
 
     let bytes = payload_1.pack_to_vec();
-    let payload_2 = Payload::unpack_from_slice(bytes.clone()).unwrap();
+    let payload_2 = Payload::unpack_verified(bytes.clone()).unwrap();
 
     assert_eq!(payload_1, payload_2);
     assert_eq!(payload_1.kind(), FpcPayload::KIND);
@@ -130,7 +130,7 @@ fn indexation_payload_packable_round_trip() {
     let payload_1 = Payload::from(IndexationPayload::new(rand_bytes(32), rand_bytes(64)).unwrap());
 
     let bytes = payload_1.pack_to_vec();
-    let payload_2 = Payload::unpack_from_slice(bytes.clone()).unwrap();
+    let payload_2 = Payload::unpack_verified(bytes.clone()).unwrap();
 
     assert_eq!(payload_1, payload_2);
     assert_eq!(payload_1.kind(), IndexationPayload::KIND);
@@ -150,7 +150,7 @@ fn regular_beacon_payload_packable_round_trip() {
     );
 
     let bytes = payload_1.pack_to_vec();
-    let payload_2 = Payload::unpack_from_slice(bytes.clone()).unwrap();
+    let payload_2 = Payload::unpack_verified(bytes.clone()).unwrap();
 
     assert_eq!(payload_1, payload_2);
     assert_eq!(payload_1.kind(), BeaconPayload::KIND);
@@ -170,7 +170,7 @@ fn salt_declaration_payload_packable_round_trip() {
     );
 
     let bytes = payload_1.pack_to_vec();
-    let payload_2 = Payload::unpack_from_slice(bytes.clone()).unwrap();
+    let payload_2 = Payload::unpack_verified(bytes.clone()).unwrap();
 
     assert_eq!(payload_1, payload_2);
     assert_eq!(payload_1.kind(), SaltDeclarationPayload::KIND);
@@ -210,7 +210,7 @@ fn transaction_payload_packable_round_trip() {
     );
 
     let bytes = payload_1.pack_to_vec();
-    let payload_2 = Payload::unpack_from_slice(bytes.clone()).unwrap();
+    let payload_2 = Payload::unpack_verified(bytes.clone()).unwrap();
 
     assert_eq!(payload_1, payload_2);
     assert_eq!(payload_1.kind(), TransactionPayload::KIND);
@@ -226,7 +226,7 @@ fn unpack_invalid_version() {
     bytes.extend(rand_bytes_array::<64>());
 
     assert!(matches!(
-        Payload::unpack_from_slice(bytes),
+        Payload::unpack_verified(bytes),
         Err(UnpackError::Packable(MessageUnpackError::Validation(
             ValidationError::InvalidPayloadVersion {
                 version: 1,
@@ -245,7 +245,7 @@ fn unpack_invalid_kind() {
     bytes.extend(rand_bytes_array::<64>());
 
     assert!(matches!(
-        Payload::unpack_from_slice(bytes),
+        Payload::unpack_verified(bytes),
         Err(UnpackError::Packable(MessageUnpackError::Payload(
             PayloadUnpackError::InvalidKind(18)
         ))),

--- a/bee-message/tests/payload.rs
+++ b/bee-message/tests/payload.rs
@@ -19,7 +19,7 @@ use bee_message::{
     unlock::{SignatureUnlock, UnlockBlock, UnlockBlocks},
     MessageId,
 };
-use bee_packable::{error::UnpackError, Packable};
+use bee_packable::{error::UnpackError, Packable, PackableExt};
 use bee_test::rand::{
     bytes::{rand_bytes, rand_bytes_array},
     number::rand_number,

--- a/bee-message/tests/reference_unlock.rs
+++ b/bee-message/tests/reference_unlock.rs
@@ -53,7 +53,7 @@ fn try_from_invalid() {
 #[test]
 fn unpack_invalid_index() {
     assert!(matches!(
-        ReferenceUnlock::unpack_from_slice(vec![0x2a, 0x2a]),
+        ReferenceUnlock::unpack_verified(vec![0x2a, 0x2a]),
         Err(UnpackError::Packable(MessageUnpackError::Validation(
             ValidationError::InvalidReferenceIndex(10794)
         ))),
@@ -71,7 +71,7 @@ fn packed_len() {
 #[test]
 fn packable_round_trip() {
     let reference_1 = ReferenceUnlock::try_from(42).unwrap();
-    let reference_2 = ReferenceUnlock::unpack_from_slice(reference_1.pack_to_vec()).unwrap();
+    let reference_2 = ReferenceUnlock::unpack_verified(reference_1.pack_to_vec()).unwrap();
 
     assert_eq!(reference_1, reference_2);
 }

--- a/bee-message/tests/reference_unlock.rs
+++ b/bee-message/tests/reference_unlock.rs
@@ -5,7 +5,7 @@ use bee_message::{
     error::{MessageUnpackError, ValidationError},
     unlock::ReferenceUnlock,
 };
-use bee_packable::{error::UnpackError, Packable};
+use bee_packable::{error::UnpackError, Packable, PackableExt};
 
 #[test]
 fn kind() {

--- a/bee-message/tests/regular_beacon_payload.rs
+++ b/bee-message/tests/regular_beacon_payload.rs
@@ -5,7 +5,7 @@ use bee_message::{
     payload::{drng::BeaconPayload, MessagePayload},
     util::hex_decode,
 };
-use bee_packable::Packable;
+use bee_packable::{Packable, PackableExt};
 
 const BEACON_PARTIAL_PUBLIC_KEY: &str = "55914b063d6342d89680c90b3617877c0dd5c1b88fce7e19d24904ebe56aaca9835d458d77f61\
     bb2a250805e25ab6be095f2a498419f89056157b29cb088271c93253e1b420f52d893abe4d76be718964d0f322991a253ef6a66c17ec586244\

--- a/bee-message/tests/regular_beacon_payload.rs
+++ b/bee-message/tests/regular_beacon_payload.rs
@@ -43,7 +43,7 @@ fn unpack_valid() {
     bytes.extend(hex::decode(BEACON_PARTIAL_PUBLIC_KEY).unwrap());
     bytes.extend(hex::decode(BEACON_SIGNATURE).unwrap());
 
-    assert!(BeaconPayload::unpack_from_slice(bytes).is_ok());
+    assert!(BeaconPayload::unpack_verified(bytes).is_ok());
 }
 
 #[test]
@@ -88,7 +88,7 @@ fn packable_round_trip() {
         .finish()
         .unwrap();
 
-    let beacon_b = BeaconPayload::unpack_from_slice(beacon_a.pack_to_vec()).unwrap();
+    let beacon_b = BeaconPayload::unpack_verified(beacon_a.pack_to_vec()).unwrap();
 
     assert_eq!(beacon_a, beacon_b);
 }

--- a/bee-message/tests/salt_declaration_payload.rs
+++ b/bee-message/tests/salt_declaration_payload.rs
@@ -5,7 +5,7 @@ use bee_message::payload::{
     salt_declaration::{Salt, SaltDeclarationPayload},
     MessagePayload,
 };
-use bee_packable::Packable;
+use bee_packable::{Packable, PackableExt};
 use bee_test::rand::{
     bytes::{rand_bytes, rand_bytes_array},
     number::rand_number,

--- a/bee-message/tests/salt_declaration_payload.rs
+++ b/bee-message/tests/salt_declaration_payload.rs
@@ -42,7 +42,7 @@ fn unpack_valid() {
     bytes.extend(vec![0, 0, 0, 0, 0, 0, 0, 0]);
     bytes.extend(rand_bytes_array::<64>());
 
-    let salt_declaration = SaltDeclarationPayload::unpack_from_slice(bytes);
+    let salt_declaration = SaltDeclarationPayload::unpack_verified(bytes);
 
     assert!(salt_declaration.is_ok());
 }
@@ -94,7 +94,7 @@ fn packable_round_trip() {
         .finish()
         .unwrap();
 
-    let salt_declaration_b = SaltDeclarationPayload::unpack_from_slice(salt_declaration_a.pack_to_vec()).unwrap();
+    let salt_declaration_b = SaltDeclarationPayload::unpack_verified(salt_declaration_a.pack_to_vec()).unwrap();
 
     assert_eq!(salt_declaration_a, salt_declaration_b);
 }

--- a/bee-message/tests/signature.rs
+++ b/bee-message/tests/signature.rs
@@ -5,7 +5,7 @@ use bee_message::{
     error::MessageUnpackError,
     signature::{BlsSignature, Ed25519Signature, Signature, SignatureUnpackError},
 };
-use bee_packable::{error::UnpackError, Packable};
+use bee_packable::{error::UnpackError, Packable, PackableExt};
 use bee_test::rand::bytes::rand_bytes_array;
 
 #[test]

--- a/bee-message/tests/signature.rs
+++ b/bee-message/tests/signature.rs
@@ -37,7 +37,7 @@ fn packed_len() {
 #[test]
 fn packable_round_trip() {
     let signature_1 = Signature::from(Ed25519Signature::new(rand_bytes_array(), rand_bytes_array()));
-    let signature_2 = Signature::unpack_from_slice(signature_1.pack_to_vec()).unwrap();
+    let signature_2 = Signature::unpack_verified(signature_1.pack_to_vec()).unwrap();
 
     assert_eq!(signature_1, signature_2);
 }
@@ -45,7 +45,7 @@ fn packable_round_trip() {
 #[test]
 fn unpack_invalid_kind() {
     assert!(matches!(
-        Signature::unpack_from_slice(vec![
+        Signature::unpack_verified(vec![
             4, 111, 225, 221, 28, 247, 253, 234, 110, 187, 52, 129, 153, 130, 84, 26, 7, 226, 27, 212, 145, 96, 151,
             196, 124, 135, 176, 31, 48, 0, 213, 200, 82, 227, 169, 21, 179, 253, 115, 184, 209, 107, 138, 0, 62, 252,
             20, 255, 24, 193, 203, 255, 137, 142, 158, 25, 171, 86, 195, 20, 70, 56, 136, 204, 2, 219, 254, 218, 2,

--- a/bee-message/tests/signature_locked_asset_output.rs
+++ b/bee-message/tests/signature_locked_asset_output.rs
@@ -87,7 +87,7 @@ fn packable_round_trip() {
     )
     .unwrap();
 
-    let output_b = SignatureLockedAssetOutput::unpack_from_slice(output_a.pack_to_vec()).unwrap();
+    let output_b = SignatureLockedAssetOutput::unpack_verified(output_a.pack_to_vec()).unwrap();
 
     assert_eq!(output_a, output_b);
 }

--- a/bee-message/tests/signature_locked_asset_output.rs
+++ b/bee-message/tests/signature_locked_asset_output.rs
@@ -6,7 +6,7 @@ use bee_message::{
     output::{AssetBalance, AssetId, SignatureLockedAssetOutput},
     util::hex_decode,
 };
-use bee_packable::Packable;
+use bee_packable::{Packable, PackableExt};
 use bee_test::rand::bytes::rand_bytes_array;
 
 use core::str::FromStr;

--- a/bee-message/tests/signature_locked_single_output.rs
+++ b/bee-message/tests/signature_locked_single_output.rs
@@ -7,7 +7,7 @@ use bee_message::{
     output::SignatureLockedSingleOutput,
     IOTA_SUPPLY,
 };
-use bee_packable::{error::UnpackError, Packable};
+use bee_packable::{error::UnpackError, Packable, PackableExt};
 
 use core::str::FromStr;
 

--- a/bee-message/tests/signature_locked_single_output.rs
+++ b/bee-message/tests/signature_locked_single_output.rs
@@ -58,7 +58,7 @@ fn new_invalid_more_than_max_amount() {
 #[test]
 fn unpack_invalid_amount() {
     assert!(matches!(
-        SignatureLockedSingleOutput::unpack_from_slice(vec![
+        SignatureLockedSingleOutput::unpack_verified(vec![
             0, 82, 253, 252, 7, 33, 130, 101, 79, 22, 63, 95, 15, 154, 98, 29, 114, 149, 102, 199, 77, 16, 3, 124, 77,
             123, 187, 4, 7, 209, 226, 198, 73, 0, 0, 0, 0, 0, 0, 0, 0,
         ]),
@@ -82,7 +82,7 @@ fn packable_round_trip() {
     let output_1 =
         SignatureLockedSingleOutput::new(Address::from(Ed25519Address::from_str(ED25519_ADDRESS).unwrap()), 1_000)
             .unwrap();
-    let output_2 = SignatureLockedSingleOutput::unpack_from_slice(output_1.pack_to_vec()).unwrap();
+    let output_2 = SignatureLockedSingleOutput::unpack_verified(output_1.pack_to_vec()).unwrap();
 
     assert_eq!(output_1, output_2);
 }

--- a/bee-message/tests/signature_unlock.rs
+++ b/bee-message/tests/signature_unlock.rs
@@ -5,7 +5,7 @@ use bee_message::{
     signature::{Ed25519Signature, Signature},
     unlock::SignatureUnlock,
 };
-use bee_packable::Packable;
+use bee_packable::{Packable, PackableExt};
 use bee_test::rand::bytes::rand_bytes_array;
 
 use core::ops::Deref;

--- a/bee-message/tests/signature_unlock.rs
+++ b/bee-message/tests/signature_unlock.rs
@@ -56,7 +56,7 @@ fn packable_round_trip() {
         rand_bytes_array(),
         rand_bytes_array(),
     )));
-    let signature_unlock_2 = SignatureUnlock::unpack_from_slice(signature_unlock_1.pack_to_vec()).unwrap();
+    let signature_unlock_2 = SignatureUnlock::unpack_verified(signature_unlock_1.pack_to_vec()).unwrap();
 
     assert_eq!(signature_unlock_1, signature_unlock_2);
 }

--- a/bee-message/tests/transaction_essence.rs
+++ b/bee-message/tests/transaction_essence.rs
@@ -243,7 +243,7 @@ fn unpack_invalid_input_count() {
     bytes.extend(output.pack_to_vec());
 
     assert!(matches!(
-        TransactionEssence::unpack_from_slice(bytes),
+        TransactionEssence::unpack_verified(bytes),
         Err(UnpackError::Packable(MessageUnpackError::Validation(ValidationError::InvalidInputCount(TryIntoPrefixError::Invalid(InvalidBoundedU32(n))))))
             if n == u32::try_from(inputs_len).unwrap()
     ));
@@ -277,7 +277,7 @@ fn unpack_invalid_output_count() {
     }
 
     assert!(matches!(
-        TransactionEssence::unpack_from_slice(bytes),
+        TransactionEssence::unpack_verified(bytes),
         Err(UnpackError::Packable(MessageUnpackError::Validation(
             ValidationError::InvalidOutputCount(TryIntoPrefixError::Invalid(InvalidBoundedU32(n)))
         )))
@@ -355,7 +355,7 @@ fn packable_round_trip() {
         .finish()
         .unwrap();
 
-    let essence_b = TransactionEssence::unpack_from_slice(essence_a.pack_to_vec()).unwrap();
+    let essence_b = TransactionEssence::unpack_verified(essence_a.pack_to_vec()).unwrap();
 
     assert_eq!(essence_a, essence_b);
 }

--- a/bee-message/tests/transaction_essence.rs
+++ b/bee-message/tests/transaction_essence.rs
@@ -14,7 +14,7 @@ use bee_message::{
     util::hex_decode,
     MessageUnpackError, IOTA_SUPPLY,
 };
-use bee_packable::{bounded::InvalidBoundedU32, error::UnpackError, prefix::TryIntoPrefixError, Packable};
+use bee_packable::{bounded::InvalidBoundedU32, error::UnpackError, prefix::TryIntoPrefixError, Packable, PackableExt};
 use bee_test::rand::{
     bytes::{rand_bytes, rand_bytes_array},
     number::rand_number,

--- a/bee-message/tests/transaction_id.rs
+++ b/bee-message/tests/transaction_id.rs
@@ -83,7 +83,7 @@ fn packed_len() {
 #[test]
 fn packable_round_trip() {
     let transaction_id_1 = TransactionId::from_str(TRANSACTION_ID).unwrap();
-    let transaction_id_2 = TransactionId::unpack_from_slice(transaction_id_1.pack_to_vec()).unwrap();
+    let transaction_id_2 = TransactionId::unpack_verified(transaction_id_1.pack_to_vec()).unwrap();
 
     assert_eq!(transaction_id_1, transaction_id_2);
 }

--- a/bee-message/tests/transaction_id.rs
+++ b/bee-message/tests/transaction_id.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use bee_message::payload::transaction::TransactionId;
-use bee_packable::Packable;
+use bee_packable::{Packable, PackableExt};
 
 use core::{ops::Deref, str::FromStr};
 

--- a/bee-message/tests/transaction_payload.rs
+++ b/bee-message/tests/transaction_payload.rs
@@ -231,7 +231,7 @@ fn packable_round_trip() {
         .with_unlock_blocks(unlock_blocks)
         .finish()
         .unwrap();
-    let payload_b = TransactionPayload::unpack_from_slice(payload_a.pack_to_vec()).unwrap();
+    let payload_b = TransactionPayload::unpack_verified(payload_a.pack_to_vec()).unwrap();
 
     assert_eq!(payload_a, payload_b);
     assert_eq!(payload_a.id(), payload_b.id());

--- a/bee-message/tests/transaction_payload.rs
+++ b/bee-message/tests/transaction_payload.rs
@@ -14,7 +14,7 @@ use bee_message::{
     unlock::{ReferenceUnlock, SignatureUnlock, UnlockBlock, UnlockBlocks},
     util::hex_decode,
 };
-use bee_packable::Packable;
+use bee_packable::{Packable, PackableExt};
 use bee_test::rand::{bytes::rand_bytes_array, number::rand_number};
 
 const TRANSACTION_ID: &str = "52fdfc072182654f163f5f0f9a621d729566c74d10037c4d7bbb0407d1e2c649";

--- a/bee-message/tests/unlock_block.rs
+++ b/bee-message/tests/unlock_block.rs
@@ -47,7 +47,7 @@ fn packable_round_trip() {
         rand_bytes_array(),
         rand_bytes_array(),
     ))));
-    let unlock_2 = UnlockBlock::unpack_from_slice(unlock_1.pack_to_vec()).unwrap();
+    let unlock_2 = UnlockBlock::unpack_verified(unlock_1.pack_to_vec()).unwrap();
 
     assert_eq!(unlock_1, unlock_2);
 }
@@ -58,7 +58,7 @@ fn unpack_invalid_tag() {
     bytes.extend(rand_bytes(32));
     bytes.extend(rand_bytes(64));
 
-    let unlock_block = UnlockBlock::unpack_from_slice(bytes);
+    let unlock_block = UnlockBlock::unpack_verified(bytes);
 
     assert!(matches!(
         unlock_block,

--- a/bee-message/tests/unlock_block.rs
+++ b/bee-message/tests/unlock_block.rs
@@ -6,7 +6,7 @@ use bee_message::{
     signature::{Ed25519Signature, Signature},
     unlock::{ReferenceUnlock, SignatureUnlock, UnlockBlock, UnlockBlockUnpackError},
 };
-use bee_packable::{error::UnpackError, Packable};
+use bee_packable::{error::UnpackError, Packable, PackableExt};
 use bee_test::rand::bytes::{rand_bytes, rand_bytes_array};
 
 #[test]

--- a/bee-message/tests/unlock_blocks.rs
+++ b/bee-message/tests/unlock_blocks.rs
@@ -160,7 +160,7 @@ fn unpack_invalid_unlock_block_kind() {
     bytes.extend(rand_bytes(32));
     bytes.extend(rand_bytes(64));
 
-    let unlock_blocks = UnlockBlocks::unpack_from_slice(bytes);
+    let unlock_blocks = UnlockBlocks::unpack_verified(bytes);
 
     assert!(matches!(
         unlock_blocks,
@@ -184,7 +184,7 @@ fn packable_round_trip() {
     ])
     .unwrap();
 
-    let blocks_b = UnlockBlocks::unpack_from_slice(blocks_a.pack_to_vec()).unwrap();
+    let blocks_b = UnlockBlocks::unpack_verified(blocks_a.pack_to_vec()).unwrap();
 
     assert_eq!(blocks_a, blocks_b);
 }

--- a/bee-message/tests/unlock_blocks.rs
+++ b/bee-message/tests/unlock_blocks.rs
@@ -6,7 +6,7 @@ use bee_message::{
     signature::{Ed25519Signature, Signature},
     unlock::{ReferenceUnlock, SignatureUnlock, UnlockBlock, UnlockBlockUnpackError, UnlockBlocks},
 };
-use bee_packable::{bounded::InvalidBoundedU16, error::UnpackError, prefix::TryIntoPrefixError, Packable};
+use bee_packable::{bounded::InvalidBoundedU16, error::UnpackError, prefix::TryIntoPrefixError, PackableExt};
 use bee_test::rand::bytes::{rand_bytes, rand_bytes_array};
 
 #[test]

--- a/bee-message/tests/utxo_input.rs
+++ b/bee-message/tests/utxo_input.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use bee_message::{input::UtxoInput, output::OutputId};
-use bee_packable::Packable;
+use bee_packable::{Packable, PackableExt};
 
 use core::str::FromStr;
 

--- a/bee-message/tests/utxo_input.rs
+++ b/bee-message/tests/utxo_input.rs
@@ -63,7 +63,7 @@ fn packed_len() {
 #[test]
 fn packable_round_trip() {
     let input_1 = UtxoInput::new(OutputId::from_str(OUTPUT_ID).unwrap());
-    let input_2 = UtxoInput::unpack_from_slice(input_1.pack_to_vec()).unwrap();
+    let input_2 = UtxoInput::unpack_verified(input_1.pack_to_vec()).unwrap();
 
     assert_eq!(input_1, input_2);
 }

--- a/bee-node/bee-plugin/src/hotloader.rs
+++ b/bee-node/bee-plugin/src/hotloader.rs
@@ -19,7 +19,7 @@ use std::{
     time::SystemTime,
 };
 
-const PLUGIN_CHECK_INTERVAL_MILLIS: u64 = 1000;
+const PLUGIN_VERIFY_INTERVAL_MILLIS: u64 = 1000;
 
 struct PluginInfo {
     id: PluginId,
@@ -98,7 +98,7 @@ impl PluginHotloader {
             // Removes info for files that no longer exist and loads plugins whose files did not exist before.
             self.sync_plugin_info(to_remove, last_writes).await?;
 
-            sleep(Duration::from_millis(PLUGIN_CHECK_INTERVAL_MILLIS)).await;
+            sleep(Duration::from_millis(PLUGIN_VERIFY_INTERVAL_MILLIS)).await;
         }
     }
 

--- a/bee-node/bee-plugin/src/hotloader.rs
+++ b/bee-node/bee-plugin/src/hotloader.rs
@@ -19,7 +19,7 @@ use std::{
     time::SystemTime,
 };
 
-const PLUGIN_VERIFY_INTERVAL_MILLIS: u64 = 1000;
+const PLUGIN_CHECK_INTERVAL_MILLIS: u64 = 1000;
 
 struct PluginInfo {
     id: PluginId,
@@ -98,7 +98,7 @@ impl PluginHotloader {
             // Removes info for files that no longer exist and loads plugins whose files did not exist before.
             self.sync_plugin_info(to_remove, last_writes).await?;
 
-            sleep(Duration::from_millis(PLUGIN_VERIFY_INTERVAL_MILLIS)).await;
+            sleep(Duration::from_millis(PLUGIN_CHECK_INTERVAL_MILLIS)).await;
         }
     }
 

--- a/bee-storage/bee-storage-rocksdb/Cargo.toml
+++ b/bee-storage/bee-storage-rocksdb/Cargo.toml
@@ -11,7 +11,7 @@ keywords = [ "iota", "tangle", "bee", "framework", "rocksdb" ]
 homepage = "https://www.iota.org"
 
 [dependencies]
-bee-message = { path = "../../bee-message", default-features = false }
+bee-message = { path = "../../bee-message", default-features = false, features = [ "metadata" ] }
 bee-packable = { path = "../../bee-common/bee-packable", default-features = false, features = [ "io" ] }
 bee-storage = { path = "../bee-storage", default-features = false }
 

--- a/bee-storage/bee-storage-rocksdb/src/access/fetch.rs
+++ b/bee-storage/bee-storage-rocksdb/src/access/fetch.rs
@@ -15,7 +15,7 @@ impl Fetch<u8, System> for Storage {
             .inner
             .get_cf(self.cf_handle(CF_SYSTEM)?, [*key])?
             // Unpacking from storage slice can't fail.
-            .map(|v| System::unpack_unchecked(&mut v.as_slice()).unwrap()))
+            .map(|v| System::unpack_unverified(&mut v.as_slice()).unwrap()))
     }
 }
 
@@ -25,7 +25,7 @@ impl Fetch<MessageId, Message> for Storage {
             .inner
             .get_cf(self.cf_handle(CF_MESSAGE_ID_TO_MESSAGE)?, message_id)?
             // Unpacking from storage slice can't fail.
-            .map(|v| Message::unpack_unchecked(&mut v.as_slice()).unwrap()))
+            .map(|v| Message::unpack_unverified(&mut v.as_slice()).unwrap()))
     }
 }
 
@@ -35,6 +35,6 @@ impl Fetch<MessageId, MessageMetadata> for Storage {
             .inner
             .get_cf(self.cf_handle(CF_MESSAGE_ID_TO_MESSAGE_METADATA)?, message_id)?
             // Unpacking from storage slice can't fail.
-            .map(|v| MessageMetadata::unpack_unchecked(&mut v.as_slice()).unwrap()))
+            .map(|v| MessageMetadata::unpack_unverified(&mut v.as_slice()).unwrap()))
     }
 }

--- a/bee-storage/bee-storage-rocksdb/src/access/fetch.rs
+++ b/bee-storage/bee-storage-rocksdb/src/access/fetch.rs
@@ -6,7 +6,7 @@
 use crate::{column_families::*, Storage};
 
 use bee_message::{Message, MessageId, MessageMetadata};
-use bee_packable::Packable;
+use bee_packable::PackableExt;
 use bee_storage::{access::Fetch, system::System, StorageBackend};
 
 impl Fetch<u8, System> for Storage {

--- a/bee-storage/bee-storage-rocksdb/src/access/fetch.rs
+++ b/bee-storage/bee-storage-rocksdb/src/access/fetch.rs
@@ -15,7 +15,7 @@ impl Fetch<u8, System> for Storage {
             .inner
             .get_cf(self.cf_handle(CF_SYSTEM)?, [*key])?
             // Unpacking from storage slice can't fail.
-            .map(|v| System::unpack(&mut v.as_slice()).unwrap()))
+            .map(|v| System::unpack_unchecked(&mut v.as_slice()).unwrap()))
     }
 }
 
@@ -25,7 +25,7 @@ impl Fetch<MessageId, Message> for Storage {
             .inner
             .get_cf(self.cf_handle(CF_MESSAGE_ID_TO_MESSAGE)?, message_id)?
             // Unpacking from storage slice can't fail.
-            .map(|v| Message::unpack(&mut v.as_slice()).unwrap()))
+            .map(|v| Message::unpack_unchecked(&mut v.as_slice()).unwrap()))
     }
 }
 
@@ -35,6 +35,6 @@ impl Fetch<MessageId, MessageMetadata> for Storage {
             .inner
             .get_cf(self.cf_handle(CF_MESSAGE_ID_TO_MESSAGE_METADATA)?, message_id)?
             // Unpacking from storage slice can't fail.
-            .map(|v| MessageMetadata::unpack(&mut v.as_slice()).unwrap()))
+            .map(|v| MessageMetadata::unpack_unchecked(&mut v.as_slice()).unwrap()))
     }
 }

--- a/bee-storage/bee-storage-rocksdb/src/access/insert.rs
+++ b/bee-storage/bee-storage-rocksdb/src/access/insert.rs
@@ -6,7 +6,7 @@
 use crate::{column_families::*, Storage};
 
 use bee_message::{Message, MessageId, MessageMetadata};
-use bee_packable::Packable;
+use bee_packable::PackableExt;
 use bee_storage::{access::Insert, system::System, StorageBackend};
 
 /// This would normally be `impl Insert<u8, System> for Storage` but there is no way to have a private trait impl and

--- a/bee-storage/bee-storage-rocksdb/src/access/iter.rs
+++ b/bee-storage/bee-storage-rocksdb/src/access/iter.rs
@@ -63,9 +63,9 @@ impl<'a> StorageIterator<'a, u8, System> {
     fn unpack_key_value(mut key: &[u8], mut value: &[u8]) -> (u8, System) {
         (
             // Unpacking from storage slice can't fail.
-            u8::unpack_unchecked(&mut key).unwrap(),
+            u8::unpack_unverified(&mut key).unwrap(),
             // Unpacking from storage slice can't fail.
-            System::unpack_unchecked(&mut value).unwrap(),
+            System::unpack_unverified(&mut value).unwrap(),
         )
     }
 }
@@ -74,9 +74,9 @@ impl<'a> StorageIterator<'a, MessageId, Message> {
     fn unpack_key_value(mut key: &[u8], mut value: &[u8]) -> (MessageId, Message) {
         (
             // Unpacking from storage slice can't fail.
-            MessageId::unpack_unchecked(&mut key).unwrap(),
+            MessageId::unpack_unverified(&mut key).unwrap(),
             // Unpacking from storage slice can't fail.
-            Message::unpack_unchecked(&mut value).unwrap(),
+            Message::unpack_unverified(&mut value).unwrap(),
         )
     }
 }
@@ -85,9 +85,9 @@ impl<'a> StorageIterator<'a, MessageId, MessageMetadata> {
     fn unpack_key_value(mut key: &[u8], mut value: &[u8]) -> (MessageId, MessageMetadata) {
         (
             // Unpacking from storage slice can't fail.
-            MessageId::unpack_unchecked(&mut key).unwrap(),
+            MessageId::unpack_unverified(&mut key).unwrap(),
             // Unpacking from storage slice can't fail.
-            MessageMetadata::unpack_unchecked(&mut value).unwrap(),
+            MessageMetadata::unpack_unverified(&mut value).unwrap(),
         )
     }
 }

--- a/bee-storage/bee-storage-rocksdb/src/access/iter.rs
+++ b/bee-storage/bee-storage-rocksdb/src/access/iter.rs
@@ -63,9 +63,9 @@ impl<'a> StorageIterator<'a, u8, System> {
     fn unpack_key_value(mut key: &[u8], mut value: &[u8]) -> (u8, System) {
         (
             // Unpacking from storage slice can't fail.
-            u8::unpack(&mut key).unwrap(),
+            u8::unpack_unchecked(&mut key).unwrap(),
             // Unpacking from storage slice can't fail.
-            System::unpack(&mut value).unwrap(),
+            System::unpack_unchecked(&mut value).unwrap(),
         )
     }
 }
@@ -74,9 +74,9 @@ impl<'a> StorageIterator<'a, MessageId, Message> {
     fn unpack_key_value(mut key: &[u8], mut value: &[u8]) -> (MessageId, Message) {
         (
             // Unpacking from storage slice can't fail.
-            MessageId::unpack(&mut key).unwrap(),
+            MessageId::unpack_unchecked(&mut key).unwrap(),
             // Unpacking from storage slice can't fail.
-            Message::unpack(&mut value).unwrap(),
+            Message::unpack_unchecked(&mut value).unwrap(),
         )
     }
 }
@@ -85,9 +85,9 @@ impl<'a> StorageIterator<'a, MessageId, MessageMetadata> {
     fn unpack_key_value(mut key: &[u8], mut value: &[u8]) -> (MessageId, MessageMetadata) {
         (
             // Unpacking from storage slice can't fail.
-            MessageId::unpack(&mut key).unwrap(),
+            MessageId::unpack_unchecked(&mut key).unwrap(),
             // Unpacking from storage slice can't fail.
-            MessageMetadata::unpack(&mut value).unwrap(),
+            MessageMetadata::unpack_unchecked(&mut value).unwrap(),
         )
     }
 }

--- a/bee-storage/bee-storage-rocksdb/src/access/iter.rs
+++ b/bee-storage/bee-storage-rocksdb/src/access/iter.rs
@@ -6,7 +6,7 @@
 use crate::{column_families::*, Storage};
 
 use bee_message::{Message, MessageId, MessageMetadata};
-use bee_packable::Packable;
+use bee_packable::PackableExt;
 use bee_storage::{access::AsIterator, system::System, StorageBackend};
 
 use rocksdb::{DBIterator, IteratorMode};

--- a/bee-storage/bee-storage-rocksdb/src/access/multi_fetch.rs
+++ b/bee-storage/bee-storage-rocksdb/src/access/multi_fetch.rs
@@ -25,7 +25,7 @@ impl<V: Packable, E: From<rocksdb::Error>> Iterator for MultiIter<V, E> {
             self.iter
                 .next()?
                 // Unpacking from storage slice can't fail.
-                .map(|option| option.map(|bytes| V::unpack(&mut bytes.as_slice()).unwrap()))
+                .map(|option| option.map(|bytes| V::unpack_unchecked(&mut bytes.as_slice()).unwrap()))
                 .map_err(E::from),
         )
     }

--- a/bee-storage/bee-storage-rocksdb/src/access/multi_fetch.rs
+++ b/bee-storage/bee-storage-rocksdb/src/access/multi_fetch.rs
@@ -6,7 +6,7 @@
 use crate::{column_families::*, Storage};
 
 use bee_message::{Message, MessageId, MessageMetadata};
-use bee_packable::Packable;
+use bee_packable::{Packable, PackableExt};
 use bee_storage::{access::MultiFetch, system::System, StorageBackend};
 
 use std::{marker::PhantomData, vec::IntoIter};

--- a/bee-storage/bee-storage-rocksdb/src/access/multi_fetch.rs
+++ b/bee-storage/bee-storage-rocksdb/src/access/multi_fetch.rs
@@ -25,7 +25,7 @@ impl<V: Packable, E: From<rocksdb::Error>> Iterator for MultiIter<V, E> {
             self.iter
                 .next()?
                 // Unpacking from storage slice can't fail.
-                .map(|option| option.map(|bytes| V::unpack_unchecked(&mut bytes.as_slice()).unwrap()))
+                .map(|option| option.map(|bytes| V::unpack_unverified(&mut bytes.as_slice()).unwrap()))
                 .map_err(E::from),
         )
     }

--- a/bee-storage/bee-storage-sled/src/access/fetch.rs
+++ b/bee-storage/bee-storage-sled/src/access/fetch.rs
@@ -6,7 +6,7 @@
 use crate::{trees::*, Storage};
 
 use bee_message::{Message, MessageId, MessageMetadata};
-use bee_packable::Packable;
+use bee_packable::PackableExt;
 use bee_storage::{access::Fetch, system::System, StorageBackend};
 
 impl Fetch<u8, System> for Storage {

--- a/bee-storage/bee-storage-sled/src/access/fetch.rs
+++ b/bee-storage/bee-storage-sled/src/access/fetch.rs
@@ -15,7 +15,7 @@ impl Fetch<u8, System> for Storage {
             .inner
             .get(&[key])?
             // Unpacking from storage slice can't fail.
-            .map(|v| System::unpack_unchecked(&mut v.as_ref()).unwrap()))
+            .map(|v| System::unpack_unverified(&mut v.as_ref()).unwrap()))
     }
 }
 
@@ -26,7 +26,7 @@ impl Fetch<MessageId, Message> for Storage {
             .open_tree(TREE_MESSAGE_ID_TO_MESSAGE)?
             .get(message_id)?
             // Unpacking from storage slice can't fail.
-            .map(|v| Message::unpack_unchecked(&mut v.as_ref()).unwrap()))
+            .map(|v| Message::unpack_unverified(&mut v.as_ref()).unwrap()))
     }
 }
 
@@ -37,6 +37,6 @@ impl Fetch<MessageId, MessageMetadata> for Storage {
             .open_tree(TREE_MESSAGE_ID_TO_MESSAGE_METADATA)?
             .get(message_id)?
             // Unpacking from storage slice can't fail.
-            .map(|v| MessageMetadata::unpack_unchecked(&mut v.as_ref()).unwrap()))
+            .map(|v| MessageMetadata::unpack_unverified(&mut v.as_ref()).unwrap()))
     }
 }

--- a/bee-storage/bee-storage-sled/src/access/fetch.rs
+++ b/bee-storage/bee-storage-sled/src/access/fetch.rs
@@ -15,7 +15,7 @@ impl Fetch<u8, System> for Storage {
             .inner
             .get(&[key])?
             // Unpacking from storage slice can't fail.
-            .map(|v| System::unpack(&mut v.as_ref()).unwrap()))
+            .map(|v| System::unpack_unchecked(&mut v.as_ref()).unwrap()))
     }
 }
 
@@ -26,7 +26,7 @@ impl Fetch<MessageId, Message> for Storage {
             .open_tree(TREE_MESSAGE_ID_TO_MESSAGE)?
             .get(message_id)?
             // Unpacking from storage slice can't fail.
-            .map(|v| Message::unpack(&mut v.as_ref()).unwrap()))
+            .map(|v| Message::unpack_unchecked(&mut v.as_ref()).unwrap()))
     }
 }
 
@@ -37,6 +37,6 @@ impl Fetch<MessageId, MessageMetadata> for Storage {
             .open_tree(TREE_MESSAGE_ID_TO_MESSAGE_METADATA)?
             .get(message_id)?
             // Unpacking from storage slice can't fail.
-            .map(|v| MessageMetadata::unpack(&mut v.as_ref()).unwrap()))
+            .map(|v| MessageMetadata::unpack_unchecked(&mut v.as_ref()).unwrap()))
     }
 }

--- a/bee-storage/bee-storage-sled/src/access/insert.rs
+++ b/bee-storage/bee-storage-sled/src/access/insert.rs
@@ -6,7 +6,7 @@
 use crate::{trees::*, Storage};
 
 use bee_message::{Message, MessageId, MessageMetadata};
-use bee_packable::Packable;
+use bee_packable::PackableExt;
 use bee_storage::{access::Insert, system::System, StorageBackend};
 
 /// This would normally be `impl Insert<u8, System> for Storage` but there is no way to have a private trait impl and

--- a/bee-storage/bee-storage-sled/src/access/iter.rs
+++ b/bee-storage/bee-storage-sled/src/access/iter.rs
@@ -74,9 +74,9 @@ impl<'a> StorageIterator<'a, u8, System> {
     fn unpack_key_value(mut key: &[u8], mut value: &[u8]) -> (u8, System) {
         (
             // Unpacking from storage slice can't fail.
-            u8::unpack_unchecked(&mut key).unwrap(),
+            u8::unpack_unverified(&mut key).unwrap(),
             // Unpacking from storage slice can't fail.
-            System::unpack_unchecked(&mut value).unwrap(),
+            System::unpack_unverified(&mut value).unwrap(),
         )
     }
 }
@@ -85,9 +85,9 @@ impl<'a> StorageIterator<'a, MessageId, Message> {
     fn unpack_key_value(mut key: &[u8], mut value: &[u8]) -> (MessageId, Message) {
         (
             // Unpacking from storage slice can't fail.
-            MessageId::unpack_unchecked(&mut key).unwrap(),
+            MessageId::unpack_unverified(&mut key).unwrap(),
             // Unpacking from storage slice can't fail.
-            Message::unpack_unchecked(&mut value).unwrap(),
+            Message::unpack_unverified(&mut value).unwrap(),
         )
     }
 }
@@ -96,9 +96,9 @@ impl<'a> StorageIterator<'a, MessageId, MessageMetadata> {
     fn unpack_key_value(mut key: &[u8], mut value: &[u8]) -> (MessageId, MessageMetadata) {
         (
             // Unpacking from storage slice can't fail.
-            MessageId::unpack_unchecked(&mut key).unwrap(),
+            MessageId::unpack_unverified(&mut key).unwrap(),
             // Unpacking from storage slice can't fail.
-            MessageMetadata::unpack_unchecked(&mut value).unwrap(),
+            MessageMetadata::unpack_unverified(&mut value).unwrap(),
         )
     }
 }

--- a/bee-storage/bee-storage-sled/src/access/iter.rs
+++ b/bee-storage/bee-storage-sled/src/access/iter.rs
@@ -74,9 +74,9 @@ impl<'a> StorageIterator<'a, u8, System> {
     fn unpack_key_value(mut key: &[u8], mut value: &[u8]) -> (u8, System) {
         (
             // Unpacking from storage slice can't fail.
-            u8::unpack(&mut key).unwrap(),
+            u8::unpack_unchecked(&mut key).unwrap(),
             // Unpacking from storage slice can't fail.
-            System::unpack(&mut value).unwrap(),
+            System::unpack_unchecked(&mut value).unwrap(),
         )
     }
 }
@@ -85,9 +85,9 @@ impl<'a> StorageIterator<'a, MessageId, Message> {
     fn unpack_key_value(mut key: &[u8], mut value: &[u8]) -> (MessageId, Message) {
         (
             // Unpacking from storage slice can't fail.
-            MessageId::unpack(&mut key).unwrap(),
+            MessageId::unpack_unchecked(&mut key).unwrap(),
             // Unpacking from storage slice can't fail.
-            Message::unpack(&mut value).unwrap(),
+            Message::unpack_unchecked(&mut value).unwrap(),
         )
     }
 }
@@ -96,9 +96,9 @@ impl<'a> StorageIterator<'a, MessageId, MessageMetadata> {
     fn unpack_key_value(mut key: &[u8], mut value: &[u8]) -> (MessageId, MessageMetadata) {
         (
             // Unpacking from storage slice can't fail.
-            MessageId::unpack(&mut key).unwrap(),
+            MessageId::unpack_unchecked(&mut key).unwrap(),
             // Unpacking from storage slice can't fail.
-            MessageMetadata::unpack(&mut value).unwrap(),
+            MessageMetadata::unpack_unchecked(&mut value).unwrap(),
         )
     }
 }

--- a/bee-storage/bee-storage-sled/src/access/iter.rs
+++ b/bee-storage/bee-storage-sled/src/access/iter.rs
@@ -6,7 +6,7 @@
 use crate::{trees::*, Storage};
 
 use bee_message::{Message, MessageId, MessageMetadata};
-use bee_packable::Packable;
+use bee_packable::PackableExt;
 use bee_storage::{access::AsIterator, system::System, StorageBackend};
 
 use std::marker::PhantomData;

--- a/bee-storage/bee-storage-sled/src/access/multi_fetch.rs
+++ b/bee-storage/bee-storage-sled/src/access/multi_fetch.rs
@@ -6,7 +6,7 @@
 use crate::{trees::*, Storage};
 
 use bee_message::{Message, MessageId, MessageMetadata};
-use bee_packable::Packable;
+use bee_packable::{Packable, PackableExt};
 use bee_storage::{access::MultiFetch, system::System, StorageBackend};
 
 use std::{marker::PhantomData, slice::Iter};

--- a/bee-storage/bee-storage-sled/src/access/multi_fetch.rs
+++ b/bee-storage/bee-storage-sled/src/access/multi_fetch.rs
@@ -28,7 +28,7 @@ impl<'a, K: Packable, V: Packable, E: From<sled::Error>> Iterator for DbIter<'a,
             self.db
                 .get(key)
                 // Unpacking from storage slice can't fail.
-                .map(|option| option.map(|bytes| V::unpack_unchecked(&mut bytes.as_ref()).unwrap()))
+                .map(|option| option.map(|bytes| V::unpack_unverified(&mut bytes.as_ref()).unwrap()))
                 .map_err(E::from),
         )
     }
@@ -63,7 +63,7 @@ impl<'a, K: Packable, V: Packable, E: From<sled::Error>> Iterator for TreeIter<'
             self.tree
                 .get(key)
                 // Unpacking from storage slice can't fail.
-                .map(|option| option.map(|bytes| V::unpack_unchecked(&mut bytes.as_ref()).unwrap()))
+                .map(|option| option.map(|bytes| V::unpack_unverified(&mut bytes.as_ref()).unwrap()))
                 .map_err(E::from),
         )
     }

--- a/bee-storage/bee-storage-sled/src/access/multi_fetch.rs
+++ b/bee-storage/bee-storage-sled/src/access/multi_fetch.rs
@@ -28,7 +28,7 @@ impl<'a, K: Packable, V: Packable, E: From<sled::Error>> Iterator for DbIter<'a,
             self.db
                 .get(key)
                 // Unpacking from storage slice can't fail.
-                .map(|option| option.map(|bytes| V::unpack(&mut bytes.as_ref()).unwrap()))
+                .map(|option| option.map(|bytes| V::unpack_unchecked(&mut bytes.as_ref()).unwrap()))
                 .map_err(E::from),
         )
     }
@@ -63,7 +63,7 @@ impl<'a, K: Packable, V: Packable, E: From<sled::Error>> Iterator for TreeIter<'
             self.tree
                 .get(key)
                 // Unpacking from storage slice can't fail.
-                .map(|option| option.map(|bytes| V::unpack(&mut bytes.as_ref()).unwrap()))
+                .map(|option| option.map(|bytes| V::unpack_unchecked(&mut bytes.as_ref()).unwrap()))
                 .map_err(E::from),
         )
     }

--- a/bee-test/src/rand/message/payload/transaction.rs
+++ b/bee-test/src/rand/message/payload/transaction.rs
@@ -13,7 +13,7 @@ use bee_message::{
     payload::transaction::{TransactionEssence, TransactionId, TransactionPayload},
     unlock::UnlockBlocks,
 };
-use bee_packable::Packable;
+use bee_packable::PackableExt;
 
 /// Generates a random [`TransactionId`].
 pub fn rand_transaction_id() -> TransactionId {
@@ -23,10 +23,10 @@ pub fn rand_transaction_id() -> TransactionId {
 /// Generates a random [`TransactionPayload`].
 pub fn rand_transaction_payload() -> TransactionPayload {
     let mut inputs = rand_vec(rand_input, rand_number_range(1..=127));
-    inputs.sort_by(|a, b| Packable::pack_to_vec(a).partial_cmp(&Packable::pack_to_vec(b)).unwrap());
+    inputs.sort_by_key(PackableExt::pack_to_vec);
 
     let mut outputs = rand_outputs(rand_number_range(1..127));
-    outputs.sort_by(|a, b| Packable::pack_to_vec(a).partial_cmp(&Packable::pack_to_vec(b)).unwrap());
+    outputs.sort_by_key(PackableExt::pack_to_vec);
 
     let unlock_blocks = rand_unlocks(inputs.len());
 


### PR DESCRIPTION
# Description of change

This change updates `Packable::unpack` to be generic over the constant `VERIFY: bool` allowing each implementation to specify which checks can be skipped when `CHECK == false`. It also adds two new default methods `unpack_verified` and `unpack_unverified` which are equivalent to `unpack::<_, true>` and `unpack::<_, false>` respectively, but using `SliceUnpacker` instead of a generic `Unpacker`.

## Type of change

Choose a type of change, and delete any options that are not relevant.

- Enhancement (a non-breaking change which adds functionality)

## How the change has been tested

All the `bee` crates using `bee-packable` were updated and their tests are passing.

## Change checklist

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that new and existing unit tests pass locally with my changes
- [x] I have updated the CHANGELOG.md, if my changes are significant enough
