### PR TITLE
Fix clippy by allowing `enum_variant_names`

### DIFF
--- a/bee-tangle/src/urts.rs
+++ b/bee-tangle/src/urts.rs
@@ -11,6 +11,7 @@ use rand::seq::IteratorRandom;
 
 use std::time::Instant;
 
+#[allow(clippy::enum_variant_names)]
 enum Score {
     NonLazy,
     SemiLazy,


### PR DESCRIPTION
# Description of change

This makes the CI clippy tests pass again. I've not changed the names, so that they stay in sync with terms in the [RFCs](https://github.com/iotaledger/protocol-rfcs/blob/master/text/0008-uniform-random-tip-selection/0008-uniform-random-tip-selection.md)

## Change checklist

Tick the boxes that are relevant to your changes, and delete any items that are not.

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that new and existing unit tests pass locally with my changes
- [x] I have updated the CHANGELOG.md, if my changes are significant enough
