### PR TITLE
Detect unknown idents inside attributes for the `bee-packable-derive` macro

### DIFF
--- a/bee-common/bee-packable-derive/src/attribute/mod.rs
+++ b/bee-common/bee-packable-derive/src/attribute/mod.rs
@@ -71,7 +71,14 @@ fn parse_key(key: &'static str, input: ParseStream) -> syn::Result<()> {
 }
 
 fn known_ident(ident: &Ident) -> syn::Result<()> {
-    const KNOWN_IDENTS: &[&str] = &["pack_error", "unpack_error", "tag_type", "tag", "with", "with_error"];
+    const KNOWN_IDENTS: &[&str] = &[
+        "unpack_error",
+        "unpack_error_with",
+        "tag_type",
+        "tag",
+        "with",
+        "with_error",
+    ];
 
     if KNOWN_IDENTS.iter().any(|known_ident| ident == known_ident) {
         Ok(())

--- a/bee-common/bee-packable-derive/tests/fail/unknown_ident.rs
+++ b/bee-common/bee-packable-derive/tests/fail/unknown_ident.rs
@@ -1,0 +1,14 @@
+// Copyright 2021 IOTA Stiftung
+// SPDX-License-Identifier: Apache-2.0
+
+#![allow(unused_imports)]
+
+use bee_packable::Packable;
+
+use core::convert::Infallible;
+
+#[derive(Packable)]
+#[packable(unknown_ident = true)]
+pub struct Unit;
+
+fn main() {}

--- a/bee-common/bee-packable-derive/tests/fail/unknown_ident.stderr
+++ b/bee-common/bee-packable-derive/tests/fail/unknown_ident.stderr
@@ -1,0 +1,5 @@
+error: unknown ident `unknown_ident`
+  --> tests/fail/unknown_ident.rs:11:12
+   |
+11 | #[packable(unknown_ident = true)]
+   |            ^^^^^^^^^^^^^


### PR DESCRIPTION
# Description of change

This PR changes the inner workings of the `#[derive(Packable)]` macro so it can detect unknown identifiers inside `#[packable(...)]` attributes.

## Type of change

Choose a type of change, and delete any options that are not relevant.

- Enhancement (a non-breaking change which adds functionality)

## How the change has been tested

the `bee-packable-derive` test suite was updated.

## Change checklist

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that new and existing unit tests pass locally with my changes
- [x] I have updated the CHANGELOG.md, if my changes are significant enough