### PR TITLE
Add option to print banner with version or not

### DIFF
--- a/bee-node/src/banner.rs
+++ b/bee-node/src/banner.rs
@@ -17,8 +17,11 @@ pub fn print_banner_and_version(print_banner: bool) {
 ██████╦╝█████╗  █████╗
 ██╔══██╗██╔══╝  ██╔══╝
 ██████╦╝███████╗███████╗
-╚═════╝ ╚══════╝╚══════╝"
-        )
+╚═════╝ ╚══════╝╚══════╝
+{: ^24}\n",
+            version
+        );
+    } else {
+        println!("{}", version);
     }
-    println!("{: ^24}\n", version);
 }

--- a/bee-node/src/banner.rs
+++ b/bee-node/src/banner.rs
@@ -3,21 +3,22 @@
 
 use crate::constants::{BEE_GIT_COMMIT, BEE_VERSION};
 
-pub fn print_banner_and_version() {
+pub fn print_banner_and_version(print_banner: bool) {
     let version = if BEE_GIT_COMMIT.is_empty() {
         BEE_VERSION.to_owned()
     } else {
         BEE_VERSION.to_owned() + "-" + &BEE_GIT_COMMIT[0..7]
     };
-    println!(
-        "
+    if print_banner {
+        println!(
+            "
 ██████╗ ███████╗███████╗
 ██╔══██╗██╔════╝██╔════╝
 ██████╦╝█████╗  █████╗
 ██╔══██╗██╔══╝  ██╔══╝
 ██████╦╝███████╗███████╗
-╚═════╝ ╚══════╝╚══════╝
-{: ^24}\n",
-        version
-    );
+╚═════╝ ╚══════╝╚══════╝"
+        )
+    }
+    println!("{: ^24}\n", version);
 }

--- a/bee-node/src/main.rs
+++ b/bee-node/src/main.rs
@@ -22,11 +22,12 @@ async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
         return tools::exec(tool).map_err(|e| e.into());
     }
 
-    print_banner_and_version();
-
     if cli.version() {
+        print_banner_and_version(false);
         return Ok(());
     }
+
+    print_banner_and_version(true);
 
     let config = match NodeConfigBuilder::from_file(cli.config().unwrap_or(&CONFIG_PATH.to_owned())) {
         Ok(builder) => builder.with_cli_args(cli.clone()).finish(),


### PR DESCRIPTION
# Description of change

I made this change so that the banner doesn't get printed if the version flag is used.

## Type of change

- Enhancement (a non-breaking change which adds functionality)

## How the change has been tested

Tested locally with executing `bee` and `bee -v`.

## Change checklist

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that new and existing unit tests pass locally with my changes
- [ ] I have updated the CHANGELOG.md, if my changes are significant enough
