### PR TITLE
Preallocate `TritBuf` in `b1t6::encode`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -438,7 +438,7 @@ dependencies = [
 
 [[package]]
 name = "bee-ternary"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "autocfg",
  "num-traits",

--- a/bee-crypto/Cargo.toml
+++ b/bee-crypto/Cargo.toml
@@ -11,7 +11,7 @@ keywords = [ "iota", "tangle", "bee", "framework", "crypto" ]
 homepage = "https://www.iota.org"
 
 [dependencies]
-bee-ternary = { version = "0.5.0", path = "../bee-ternary", default-features = false }
+bee-ternary = { version = "0.5.1", path = "../bee-ternary", default-features = false }
 
 byteorder = {version = "1.4.3", default-features = false }
 lazy_static = {version = "1.4.0", default-features = false }

--- a/bee-message/Cargo.toml
+++ b/bee-message/Cargo.toml
@@ -13,7 +13,7 @@ homepage = "https://www.iota.org"
 [dependencies]
 bee-common = { version = "0.5.0", path = "../bee-common/bee-common", default-features = false }
 bee-pow = { version = "0.1.0", path = "../bee-pow", default-features = false }
-bee-ternary = { version = "0.5.0", path = "../bee-ternary", default-features = false, features = [ "serde1" ] }
+bee-ternary = { version = "0.5.1", path = "../bee-ternary", default-features = false, features = [ "serde1" ] }
 
 bech32 = { version = "0.8.1", default-features = false }
 bytemuck = { version = "1.7.2", default-features = false }

--- a/bee-pow/Cargo.toml
+++ b/bee-pow/Cargo.toml
@@ -12,7 +12,7 @@ homepage = "https://www.iota.org"
 
 [dependencies]
 bee-crypto = { version = "0.2.1-alpha", path = "../bee-crypto", default-features = false }
-bee-ternary = { version = "0.5.0", path = "../bee-ternary", default-features = false }
+bee-ternary = { version = "0.5.1", path = "../bee-ternary", default-features = false }
 
 iota-crypto = { version = "0.7.0", default-features = false, features = [ "blake2b", "digest" ] }
 thiserror = { version = "1.0.30", default-features = false }

--- a/bee-signing/Cargo.toml
+++ b/bee-signing/Cargo.toml
@@ -13,7 +13,7 @@ homepage = "https://www.iota.org"
 [dependencies]
 bee-common-derive = { version = "0.1.1-alpha", path = "../bee-common/bee-common-derive", default-features = false }
 bee-crypto = { version = "0.2.1-alpha", path = "../bee-crypto", default-features = false }
-bee-ternary = { version = "0.5.0", path = "../bee-ternary", default-features = false }
+bee-ternary = { version = "0.5.1", path = "../bee-ternary", default-features = false }
 
 rand = { version = "0.8.4", default-features = false, features = [ "std", "std_rng" ] }
 sha3 = { version = "0.9.1", default-features = false }

--- a/bee-ternary/CHANGELOG.md
+++ b/bee-ternary/CHANGELOG.md
@@ -19,7 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Security -->
 
-## 0.5.1 - 2021-11-15
+## 0.5.1 - 2021-11-16
 
 ### Added
 

--- a/bee-ternary/CHANGELOG.md
+++ b/bee-ternary/CHANGELOG.md
@@ -23,7 +23,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- Preallocate `TritBuf` in `b1t6::encode` for better performance
+- Preallocate `TritBuf` in `b1t6::encode` for better performance.
 
 ## 0.5.0 - 2021-09-27
 

--- a/bee-ternary/CHANGELOG.md
+++ b/bee-ternary/CHANGELOG.md
@@ -24,6 +24,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - `.capacity()` for `TritBuf`;
+- Expose `TRITS_PER_BYTE` for `RawEncoding`s;
 
 ### Changed
 

--- a/bee-ternary/CHANGELOG.md
+++ b/bee-ternary/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Preallocate `TritBuf` in `b1t6::encode`
+
 ### Deprecated
 
 ### Removed

--- a/bee-ternary/CHANGELOG.md
+++ b/bee-ternary/CHANGELOG.md
@@ -21,6 +21,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## 0.5.1 - 2021-11-15
 
+### Added
+
+- `.capacity()` for `TritBuf`;
+
 ### Changed
 
 - Preallocate `TritBuf` in `b1t6::encode` for better performance;

--- a/bee-ternary/CHANGELOG.md
+++ b/bee-ternary/CHANGELOG.md
@@ -11,8 +11,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- Preallocate `TritBuf` in `b1t6::encode`
-
 ### Deprecated
 
 ### Removed
@@ -20,6 +18,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 ### Security -->
+
+## 0.5.1 - 2021-11-15
+
+### Changed
+
+- Preallocate `TritBuf` in `b1t6::encode` for better performance
 
 ## 0.5.0 - 2021-09-27
 

--- a/bee-ternary/CHANGELOG.md
+++ b/bee-ternary/CHANGELOG.md
@@ -23,81 +23,81 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- Preallocate `TritBuf` in `b1t6::encode` for better performance.
+- Preallocate `TritBuf` in `b1t6::encode` for better performance;
 
 ## 0.5.0 - 2021-09-27
 
 ### Added
 
-- `{RawEncodingBuf, TritBuf, T1B1Buf, T2B1Buf, T3B1Buf, T4B1Buf, T5B1Buf}::clear`.
+- `{RawEncodingBuf, TritBuf, T1B1Buf, T2B1Buf, T3B1Buf, T4B1Buf, T5B1Buf}::clear`;
 
 ## 0.4.2-alpha - 2021-03-30
 
 ### Added
 
-- `PartialOrd` and `Eq` implementations for `TritBuf`.
-- `Eq` implementation for `Trits`.
+- `PartialOrd` and `Eq` implementations for `TritBuf`;
+- `Eq` implementation for `Trits`;
 
 ## 0.4.1-alpha - 2021-03-15
 
 ### Fixed
 
-- B1T6 decoding.
+- B1T6 decoding;
 
 ## 0.4.0-alpha - 2021-01-18
 
 ### Added
 
-- B1T6 bytes-as-trits encoding and decoding support.
+- B1T6 bytes-as-trits encoding and decoding support;
 
 ## 0.3.4-alpha - 2020-11-13
 
 ### Added
 
-- Added proper `i128`/`u128` support detection.
+- Added proper `i128`/`u128` support detection;
 
 ## 0.3.3-alpha - 2020-11-06
 
 ### Fixed
 
-- `TryFrom<Trits>` implemented for `u128` and `i128` only when `cfg(has_i128)`.
+- `TryFrom<Trits>` implemented for `u128` and `i128` only when `cfg(has_i128)`;
 
 ## 0.3.2-alpha - 2020-10-19
 
 ### Added
 
-- `with_capacity` constructor for the buffers of every trit encoding.
+- `with_capacity` constructor for the buffers of every trit encoding;
 
 ## 0.3.1-alpha - 2020-07-23
 
 ### Added
 
-- Conversions between `&[Trit]` and `&Trits<T1B1<T>>`.
+- Conversions between `&[Trit]` and `&Trits<T1B1<T>>`;
 
 ### Removed
 
-- A useless conversion to same type.
+- A useless conversion to same type;
 
 ## 0.3.0-alpha - 2020-07-20
 
 ### Added
 
-- Support for arbitrary trit to numeric type conversion.
+- Support for arbitrary trit to numeric type conversion;
 
 ## 0.2.0-alpha - 2020-07-17
 
 ### Added
 
-- Binary/ternary numeric conversion.
-- FromStr implementation for TryteBuf.
-- TritBuf::from_i8s and TritBuf::from_u8s.
+- Binary/ternary numeric conversion;
+- FromStr implementation for TryteBuf;
+- TritBuf::from_i8s and TritBuf::from_u8s;
 
 ## 0.1.0-alpha - 2020-06-12
 
 ### Added
 
-- Efficient manipulation of ternary buffers (trits and trytes).
-- Multiple encoding schemes.
-- Extensible design that allows it to sit on top of existing data structures, avoiding unnecessary allocation and copying.
-- An array of utility functions to allow for easy manipulation of ternary data.
-- Zero-cost conversion between trit and tryte formats (i.e: no slower than the equivalent code would be if hand-written).
+- Efficient manipulation of ternary buffers (trits and trytes);
+- Multiple encoding schemes;
+- Extensible design that allows it to sit on top of existing data structures, avoiding unnecessary allocation and copying;
+- An array of utility functions to allow for easy manipulation of ternary data;
+- Zero-cost conversion between trit and tryte formats (i.e: no slower than the equivalent code would be if hand-written);

--- a/bee-ternary/Cargo.toml
+++ b/bee-ternary/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bee-ternary"
-version = "0.5.0"
+version = "0.5.1"
 authors = [ "IOTA Stiftung" ]
 edition = "2021"
 description = "Ergonomic ternary manipulation utilities"

--- a/bee-ternary/src/b1t6.rs
+++ b/bee-ternary/src/b1t6.rs
@@ -3,8 +3,9 @@
 
 use crate::{Btrit, RawEncoding, RawEncodingBuf, TritBuf, Trits, Tryte};
 
-const TRITS_PER_BYTE: usize = 2;
+const TRYTES_PER_BYTE: usize = 2;
 const TRITS_PER_TRYTE: usize = 3;
+const TRITS_PER_BYTE: usize = TRYTES_PER_BYTE * TRITS_PER_TRYTE;
 
 /// An error that may be emitted when decoding a B1T6 trit slice.
 #[derive(Debug)]
@@ -32,7 +33,7 @@ pub fn encode<T: RawEncodingBuf>(bytes: &[u8]) -> TritBuf<T>
 where
     T::Slice: RawEncoding<Trit = Btrit>,
 {
-    let mut trits = TritBuf::with_capacity(bytes.len() * 6);
+    let mut trits = TritBuf::with_capacity(bytes.len() * TRITS_PER_BYTE);
 
     for byte in bytes {
         let (t1, t2) = encode_group(*byte);

--- a/bee-ternary/src/b1t6.rs
+++ b/bee-ternary/src/b1t6.rs
@@ -19,7 +19,7 @@ pub fn decode(src: &Trits) -> Result<Vec<u8>, DecodeError> {
     assert!(src.len() % TRITS_PER_BYTE == 0);
     src.iter_trytes()
         .step_by(TRYTES_PER_BYTE)
-        .zip(src[TRITS_PER_TRYTE..].iter_trytes().step_by(2))
+        .zip(src[TRITS_PER_TRYTE..].iter_trytes().step_by(TRYTES_PER_BYTE))
         .map(|(a, b)| decode_group(a, b).ok_or(DecodeError::InvalidTrytes([a, b])))
         .collect()
 }

--- a/bee-ternary/src/b1t6.rs
+++ b/bee-ternary/src/b1t6.rs
@@ -32,7 +32,7 @@ pub fn encode<T: RawEncodingBuf>(bytes: &[u8]) -> TritBuf<T>
 where
     T::Slice: RawEncoding<Trit = Btrit>,
 {
-    let mut trits = TritBuf::new();
+    let mut trits = TritBuf::with_capacity(bytes.len() * 6);
 
     for byte in bytes {
         let (t1, t2) = encode_group(*byte);

--- a/bee-ternary/src/b1t6.rs
+++ b/bee-ternary/src/b1t6.rs
@@ -18,7 +18,7 @@ pub enum DecodeError {
 pub fn decode(src: &Trits) -> Result<Vec<u8>, DecodeError> {
     assert!(src.len() % TRITS_PER_BYTE == 0);
     src.iter_trytes()
-        .step_by(2)
+        .step_by(TRYTES_PER_BYTE)
         .zip(src[TRITS_PER_TRYTE..].iter_trytes().step_by(2))
         .map(|(a, b)| decode_group(a, b).ok_or(DecodeError::InvalidTrytes([a, b])))
         .collect()

--- a/bee-ternary/src/lib.rs
+++ b/bee-ternary/src/lib.rs
@@ -790,6 +790,11 @@ impl<T: RawEncodingBuf> TritBuf<T> {
     pub fn as_slice_mut(&mut self) -> &mut Trits<T::Slice> {
         unsafe { &mut *(self.0.as_slice_mut() as *mut T::Slice as *mut Trits<T::Slice>) }
     }
+
+    /// Returns the number of trits the `TritBuf` can hold without reallocating.
+    pub fn capacity(&self) -> usize {
+        self.0.capacity()
+    }
 }
 
 impl TritBuf<T3B1Buf> {

--- a/bee-ternary/src/raw.rs
+++ b/bee-ternary/src/raw.rs
@@ -15,6 +15,9 @@ pub trait RawEncoding {
     /// The trit buffer encoding associated with this trit slice encoding.
     type Buf: RawEncodingBuf<Slice = Self>;
 
+    /// The number of trits that fit into this trit slice encoding.
+    const TRITS_PER_BYTE: usize;
+
     /// Get an empty slice of this encoding
     fn empty() -> &'static Self;
 

--- a/bee-ternary/src/raw.rs
+++ b/bee-ternary/src/raw.rs
@@ -92,6 +92,9 @@ pub trait RawEncodingBuf {
     /// View the trits in this buffer as a mutable slice.
     fn as_slice_mut(&mut self) -> &mut Self::Slice;
 
+    /// Returns the number of trits the buffer can hold.
+    fn capacity(&self) -> usize;
+
     /// Convert this encoding into another encoding.
     /// TODO: Rename this `reencode`
     #[allow(clippy::wrong_self_convention)]

--- a/bee-ternary/src/t1b1.rs
+++ b/bee-ternary/src/t1b1.rs
@@ -161,4 +161,8 @@ where
     fn as_slice_mut(&mut self) -> &mut Self::Slice {
         unsafe { &mut *(Self::Slice::make(self.0.as_ptr() as _, 0, self.0.len()) as *mut _) }
     }
+
+    fn capacity(&self) -> usize {
+        self.0.capacity()
+    }
 }

--- a/bee-ternary/src/t1b1.rs
+++ b/bee-ternary/src/t1b1.rs
@@ -45,6 +45,8 @@ where
     type Trit = T;
     type Buf = T1B1Buf<T>;
 
+    const TRITS_PER_BYTE: usize = TRITS_PER_BYTE;
+
     fn empty() -> &'static Self {
         unsafe { &*Self::make(&[] as *const _, 0, 0) }
     }
@@ -165,6 +167,6 @@ where
     }
 
     fn capacity(&self) -> usize {
-        self.0.capacity() * TRITS_PER_BYTE
+        self.0.capacity() * Self::Slice::TRITS_PER_BYTE
     }
 }

--- a/bee-ternary/src/t1b1.rs
+++ b/bee-ternary/src/t1b1.rs
@@ -5,6 +5,8 @@ use crate::{trit::ShiftTernary, Btrit, RawEncoding, RawEncodingBuf, Trit};
 
 use std::{hash, marker::PhantomData, ops::Range};
 
+const TRITS_PER_BYTE: usize = 1;
+
 /// An encoding scheme slice that uses a single byte to represent one trit.
 #[repr(transparent)]
 pub struct T1B1<T: Trit = Btrit> {
@@ -163,6 +165,6 @@ where
     }
 
     fn capacity(&self) -> usize {
-        self.0.capacity()
+        self.0.capacity() * TRITS_PER_BYTE
     }
 }

--- a/bee-ternary/src/t1b1.rs
+++ b/bee-ternary/src/t1b1.rs
@@ -5,8 +5,6 @@ use crate::{trit::ShiftTernary, Btrit, RawEncoding, RawEncodingBuf, Trit};
 
 use std::{hash, marker::PhantomData, ops::Range};
 
-const TRITS_PER_BYTE: usize = 1;
-
 /// An encoding scheme slice that uses a single byte to represent one trit.
 #[repr(transparent)]
 pub struct T1B1<T: Trit = Btrit> {
@@ -45,7 +43,7 @@ where
     type Trit = T;
     type Buf = T1B1Buf<T>;
 
-    const TRITS_PER_BYTE: usize = TRITS_PER_BYTE;
+    const TRITS_PER_BYTE: usize = 1;
 
     fn empty() -> &'static Self {
         unsafe { &*Self::make(&[] as *const _, 0, 0) }

--- a/bee-ternary/src/t1b1.rs
+++ b/bee-ternary/src/t1b1.rs
@@ -5,6 +5,8 @@ use crate::{trit::ShiftTernary, Btrit, RawEncoding, RawEncodingBuf, Trit};
 
 use std::{hash, marker::PhantomData, ops::Range};
 
+const TRITS_PER_BYTE: usize = 1;
+
 /// An encoding scheme slice that uses a single byte to represent one trit.
 #[repr(transparent)]
 pub struct T1B1<T: Trit = Btrit> {
@@ -43,7 +45,7 @@ where
     type Trit = T;
     type Buf = T1B1Buf<T>;
 
-    const TRITS_PER_BYTE: usize = 1;
+    const TRITS_PER_BYTE: usize = TRITS_PER_BYTE;
 
     fn empty() -> &'static Self {
         unsafe { &*Self::make(&[] as *const _, 0, 0) }

--- a/bee-ternary/src/t2b1.rs
+++ b/bee-ternary/src/t2b1.rs
@@ -54,6 +54,8 @@ impl RawEncoding for T2B1 {
     type Trit = Btrit;
     type Buf = T2B1Buf;
 
+    const TRITS_PER_BYTE: usize = TRITS_PER_BYTE;
+
     fn empty() -> &'static Self {
         unsafe { &*Self::make(&[] as *const _, 0, 0) }
     }
@@ -64,12 +66,20 @@ impl RawEncoding for T2B1 {
 
     fn as_i8_slice(&self) -> &[i8] {
         assert!(self.len_offset().1 == 0);
-        unsafe { std::slice::from_raw_parts(self as *const _ as *const _, (self.len() + TRITS_PER_BYTE - 1) / TRITS_PER_BYTE) }
+        unsafe {
+            std::slice::from_raw_parts(
+                self as *const _ as *const _,
+                (self.len() + TRITS_PER_BYTE - 1) / TRITS_PER_BYTE,
+            )
+        }
     }
 
     unsafe fn as_i8_slice_mut(&mut self) -> &mut [i8] {
         assert!(self.len_offset().1 == 0);
-        std::slice::from_raw_parts_mut(self as *mut _ as *mut _, (self.len() + TRITS_PER_BYTE - 1) / TRITS_PER_BYTE)
+        std::slice::from_raw_parts_mut(
+            self as *mut _ as *mut _,
+            (self.len() + TRITS_PER_BYTE - 1) / TRITS_PER_BYTE,
+        )
     }
 
     unsafe fn get_unchecked(&self, index: usize) -> Self::Trit {
@@ -153,7 +163,12 @@ impl RawEncodingBuf for T2B1Buf {
             self.0.pop().map(|b| extract(b, 0))
         } else {
             let last_index = self.0.len() - 1;
-            unsafe { Some(extract(*self.0.get_unchecked(last_index), (self.1 + TRITS_PER_BYTE - 1) % TRITS_PER_BYTE)) }
+            unsafe {
+                Some(extract(
+                    *self.0.get_unchecked(last_index),
+                    (self.1 + TRITS_PER_BYTE - 1) % TRITS_PER_BYTE,
+                ))
+            }
         };
         self.1 -= 1;
         val

--- a/bee-ternary/src/t2b1.rs
+++ b/bee-ternary/src/t2b1.rs
@@ -5,8 +5,7 @@ use crate::{Btrit, RawEncoding, RawEncodingBuf, ShiftTernary, Utrit};
 
 use std::ops::Range;
 
-// Trits Per Byte
-const TPB: usize = 2;
+const TRITS_PER_BYTE: usize = 2;
 // Number required to push a byte between balanced and unbalanced representations
 const BAL: i8 = 4;
 
@@ -16,12 +15,12 @@ pub struct T2B1([()]);
 
 impl T2B1 {
     unsafe fn make(ptr: *const i8, offset: usize, len: usize) -> *const Self {
-        let len = (len << 2) | (offset % TPB);
-        std::mem::transmute((ptr.add(offset / TPB), len))
+        let len = (len << 2) | (offset % TRITS_PER_BYTE);
+        std::mem::transmute((ptr.add(offset / TRITS_PER_BYTE), len))
     }
 
     unsafe fn ptr(&self, index: usize) -> *const i8 {
-        let byte_offset = (self.len_offset().1 + index) / TPB;
+        let byte_offset = (self.len_offset().1 + index) / TRITS_PER_BYTE;
         (self.0.as_ptr() as *const i8).add(byte_offset)
     }
 
@@ -32,7 +31,7 @@ impl T2B1 {
 
 fn extract(x: i8, elem: usize) -> Btrit {
     debug_assert!(
-        elem < TPB,
+        elem < TRITS_PER_BYTE,
         "Attempted to extract invalid element {} from balanced T2B1 trit",
         elem
     );
@@ -41,7 +40,7 @@ fn extract(x: i8, elem: usize) -> Btrit {
 
 fn insert(x: i8, elem: usize, trit: Btrit) -> i8 {
     debug_assert!(
-        elem < TPB,
+        elem < TRITS_PER_BYTE,
         "Attempted to insert invalid element {} into balanced T2B1 trit",
         elem
     );
@@ -65,29 +64,29 @@ impl RawEncoding for T2B1 {
 
     fn as_i8_slice(&self) -> &[i8] {
         assert!(self.len_offset().1 == 0);
-        unsafe { std::slice::from_raw_parts(self as *const _ as *const _, (self.len() + TPB - 1) / TPB) }
+        unsafe { std::slice::from_raw_parts(self as *const _ as *const _, (self.len() + TRITS_PER_BYTE - 1) / TRITS_PER_BYTE) }
     }
 
     unsafe fn as_i8_slice_mut(&mut self) -> &mut [i8] {
         assert!(self.len_offset().1 == 0);
-        std::slice::from_raw_parts_mut(self as *mut _ as *mut _, (self.len() + TPB - 1) / TPB)
+        std::slice::from_raw_parts_mut(self as *mut _ as *mut _, (self.len() + TRITS_PER_BYTE - 1) / TRITS_PER_BYTE)
     }
 
     unsafe fn get_unchecked(&self, index: usize) -> Self::Trit {
         let b = self.ptr(index).read();
-        extract(b, (self.len_offset().1 + index) % TPB)
+        extract(b, (self.len_offset().1 + index) % TRITS_PER_BYTE)
     }
 
     unsafe fn set_unchecked(&mut self, index: usize, trit: Self::Trit) {
         let b = self.ptr(index).read();
-        let b = insert(b, (self.len_offset().1 + index) % TPB, trit);
+        let b = insert(b, (self.len_offset().1 + index) % TRITS_PER_BYTE, trit);
         (self.ptr(index) as *mut i8).write(b);
     }
 
     unsafe fn slice_unchecked(&self, range: Range<usize>) -> &Self {
         &*Self::make(
             self.ptr(range.start),
-            (self.len_offset().1 + range.start) % TPB,
+            (self.len_offset().1 + range.start) % TRITS_PER_BYTE,
             range.end - range.start,
         )
     }
@@ -95,7 +94,7 @@ impl RawEncoding for T2B1 {
     unsafe fn slice_unchecked_mut(&mut self, range: Range<usize>) -> &mut Self {
         &mut *(Self::make(
             self.ptr(range.start),
-            (self.len_offset().1 + range.start) % TPB,
+            (self.len_offset().1 + range.start) % TRITS_PER_BYTE,
             range.end - range.start,
         ) as *mut Self)
     }
@@ -105,12 +104,12 @@ impl RawEncoding for T2B1 {
     }
 
     unsafe fn from_raw_unchecked(b: &[i8], num_trits: usize) -> &Self {
-        assert!(num_trits <= b.len() * TPB);
+        assert!(num_trits <= b.len() * TRITS_PER_BYTE);
         &*Self::make(b.as_ptr() as *const _, 0, num_trits)
     }
 
     unsafe fn from_raw_unchecked_mut(b: &mut [i8], num_trits: usize) -> &mut Self {
-        assert!(num_trits <= b.len() * TPB);
+        assert!(num_trits <= b.len() * TRITS_PER_BYTE);
         &mut *(Self::make(b.as_ptr() as *const _, 0, num_trits) as *mut _)
     }
 }
@@ -127,7 +126,7 @@ impl RawEncodingBuf for T2B1Buf {
     }
 
     fn with_capacity(cap: usize) -> Self {
-        let cap = (cap / TPB) + (cap % TPB);
+        let cap = (cap / TRITS_PER_BYTE) + (cap % TRITS_PER_BYTE);
         Self(Vec::with_capacity(cap), 0)
     }
 
@@ -137,12 +136,12 @@ impl RawEncodingBuf for T2B1Buf {
     }
 
     fn push(&mut self, trit: <Self::Slice as RawEncoding>::Trit) {
-        if self.1 % TPB == 0 {
+        if self.1 % TRITS_PER_BYTE == 0 {
             self.0.push(insert(0, 0, trit));
         } else {
             let last_index = self.0.len() - 1;
             let b = unsafe { self.0.get_unchecked_mut(last_index) };
-            *b = insert(*b, self.1 % TPB, trit);
+            *b = insert(*b, self.1 % TRITS_PER_BYTE, trit);
         }
         self.1 += 1;
     }
@@ -150,11 +149,11 @@ impl RawEncodingBuf for T2B1Buf {
     fn pop(&mut self) -> Option<<Self::Slice as RawEncoding>::Trit> {
         let val = if self.1 == 0 {
             return None;
-        } else if self.1 % TPB == 1 {
+        } else if self.1 % TRITS_PER_BYTE == 1 {
             self.0.pop().map(|b| extract(b, 0))
         } else {
             let last_index = self.0.len() - 1;
-            unsafe { Some(extract(*self.0.get_unchecked(last_index), (self.1 + TPB - 1) % TPB)) }
+            unsafe { Some(extract(*self.0.get_unchecked(last_index), (self.1 + TRITS_PER_BYTE - 1) % TRITS_PER_BYTE)) }
         };
         self.1 -= 1;
         val
@@ -169,6 +168,6 @@ impl RawEncodingBuf for T2B1Buf {
     }
 
     fn capacity(&self) -> usize {
-        self.0.capacity()
+        self.0.capacity() * TRITS_PER_BYTE
     }
 }

--- a/bee-ternary/src/t2b1.rs
+++ b/bee-ternary/src/t2b1.rs
@@ -167,4 +167,8 @@ impl RawEncodingBuf for T2B1Buf {
     fn as_slice_mut(&mut self) -> &mut Self::Slice {
         unsafe { &mut *(Self::Slice::make(self.0.as_ptr() as _, 0, self.1) as *mut _) }
     }
+
+    fn capacity(&self) -> usize {
+        self.0.capacity()
+    }
 }

--- a/bee-ternary/src/t2b1.rs
+++ b/bee-ternary/src/t2b1.rs
@@ -7,7 +7,7 @@ use std::ops::Range;
 
 const TRITS_PER_BYTE: usize = 2;
 // Number required to push a byte between balanced and unbalanced representations
-const BAL: i8 = 4;
+const BALANCE_DIFF: i8 = 4;
 
 /// An encoding scheme slice that uses a single byte to represent two trits.
 #[repr(transparent)]
@@ -35,7 +35,7 @@ fn extract(x: i8, elem: usize) -> Btrit {
         "Attempted to extract invalid element {} from balanced T2B1 trit",
         elem
     );
-    Utrit::from_u8((((x + BAL) / 3i8.pow(elem as u32)) % 3) as u8).shift()
+    Utrit::from_u8((((x + BALANCE_DIFF) / 3i8.pow(elem as u32)) % 3) as u8).shift()
 }
 
 fn insert(x: i8, elem: usize, trit: Btrit) -> i8 {
@@ -45,9 +45,9 @@ fn insert(x: i8, elem: usize, trit: Btrit) -> i8 {
         elem
     );
     let utrit = trit.shift();
-    let ux = x + BAL;
+    let ux = x + BALANCE_DIFF;
     let ux = ux + (utrit.into_u8() as i8 - (ux / 3i8.pow(elem as u32)) % 3) * 3i8.pow(elem as u32);
-    ux - BAL
+    ux - BALANCE_DIFF
 }
 
 impl RawEncoding for T2B1 {
@@ -110,7 +110,7 @@ impl RawEncoding for T2B1 {
     }
 
     fn is_valid(b: i8) -> bool {
-        b >= -BAL && b <= BAL
+        b >= -BALANCE_DIFF && b <= BALANCE_DIFF
     }
 
     unsafe fn from_raw_unchecked(b: &[i8], num_trits: usize) -> &Self {

--- a/bee-ternary/src/t3b1.rs
+++ b/bee-ternary/src/t3b1.rs
@@ -7,7 +7,7 @@ use std::ops::Range;
 
 const TRITS_PER_BYTE: usize = 3;
 // Number required to push a byte between balanced and unbalanced representations
-const BAL: i8 = 13;
+const BALANCE_DIFF: i8 = 13;
 
 /// An encoding scheme slice that uses a single byte to represent three trits.
 #[repr(transparent)]
@@ -35,7 +35,7 @@ fn extract(x: i8, elem: usize) -> Btrit {
         "Attempted to extract invalid element {} from balanced T4B1 trit",
         elem
     );
-    Utrit::from_u8((((x + BAL) / 3i8.pow(elem as u32)) % 3) as u8).shift()
+    Utrit::from_u8((((x + BALANCE_DIFF) / 3i8.pow(elem as u32)) % 3) as u8).shift()
 }
 
 fn insert(x: i8, elem: usize, trit: Btrit) -> i8 {
@@ -46,10 +46,10 @@ fn insert(x: i8, elem: usize, trit: Btrit) -> i8 {
     );
     let utrit = trit.shift();
     debug_assert!(x >= -13 && x <= 13);
-    let ux = x + BAL;
+    let ux = x + BALANCE_DIFF;
     let ux = ux + (utrit.into_u8() as i8 - (ux / 3i8.pow(elem as u32)) % 3) * 3i8.pow(elem as u32);
-    debug_assert!(ux - BAL >= -13 && ux - BAL <= 13);
-    ux - BAL
+    debug_assert!(ux - BALANCE_DIFF >= -13 && ux - BALANCE_DIFF <= 13);
+    ux - BALANCE_DIFF
 }
 
 impl RawEncoding for T3B1 {
@@ -112,7 +112,7 @@ impl RawEncoding for T3B1 {
     }
 
     fn is_valid(b: i8) -> bool {
-        b >= -BAL && b <= BAL
+        b >= -BALANCE_DIFF && b <= BALANCE_DIFF
     }
 
     unsafe fn from_raw_unchecked(b: &[i8], num_trits: usize) -> &Self {

--- a/bee-ternary/src/t3b1.rs
+++ b/bee-ternary/src/t3b1.rs
@@ -5,8 +5,7 @@ use crate::{Btrit, RawEncoding, RawEncodingBuf, ShiftTernary, Utrit};
 
 use std::ops::Range;
 
-// Trits Per Byte
-const TPB: usize = 3;
+const TRITS_PER_BYTE: usize = 3;
 // Number required to push a byte between balanced and unbalanced representations
 const BAL: i8 = 13;
 
@@ -16,12 +15,12 @@ pub struct T3B1([()]);
 
 impl T3B1 {
     pub(crate) unsafe fn make(ptr: *const i8, offset: usize, len: usize) -> *const Self {
-        let len = (len << 2) | (offset % TPB);
-        std::mem::transmute((ptr.add(offset / TPB), len))
+        let len = (len << 2) | (offset % TRITS_PER_BYTE);
+        std::mem::transmute((ptr.add(offset / TRITS_PER_BYTE), len))
     }
 
     unsafe fn ptr(&self, index: usize) -> *const i8 {
-        let byte_offset = (self.len_offset().1 + index) / TPB;
+        let byte_offset = (self.len_offset().1 + index) / TRITS_PER_BYTE;
         (self.0.as_ptr() as *const i8).add(byte_offset)
     }
 
@@ -32,7 +31,7 @@ impl T3B1 {
 
 fn extract(x: i8, elem: usize) -> Btrit {
     debug_assert!(
-        elem < TPB,
+        elem < TRITS_PER_BYTE,
         "Attempted to extract invalid element {} from balanced T4B1 trit",
         elem
     );
@@ -41,7 +40,7 @@ fn extract(x: i8, elem: usize) -> Btrit {
 
 fn insert(x: i8, elem: usize, trit: Btrit) -> i8 {
     debug_assert!(
-        elem < TPB,
+        elem < TRITS_PER_BYTE,
         "Attempted to insert invalid element {} into balanced T3B1 trit",
         elem
     );
@@ -67,29 +66,29 @@ impl RawEncoding for T3B1 {
 
     fn as_i8_slice(&self) -> &[i8] {
         assert!(self.len_offset().1 == 0);
-        unsafe { std::slice::from_raw_parts(self as *const _ as *const _, (self.len() + TPB - 1) / TPB) }
+        unsafe { std::slice::from_raw_parts(self as *const _ as *const _, (self.len() + TRITS_PER_BYTE - 1) / TRITS_PER_BYTE) }
     }
 
     unsafe fn as_i8_slice_mut(&mut self) -> &mut [i8] {
         assert!(self.len_offset().1 == 0);
-        std::slice::from_raw_parts_mut(self as *mut _ as *mut _, (self.len() + TPB - 1) / TPB)
+        std::slice::from_raw_parts_mut(self as *mut _ as *mut _, (self.len() + TRITS_PER_BYTE - 1) / TRITS_PER_BYTE)
     }
 
     unsafe fn get_unchecked(&self, index: usize) -> Self::Trit {
         let b = self.ptr(index).read();
-        extract(b, (self.len_offset().1 + index) % TPB)
+        extract(b, (self.len_offset().1 + index) % TRITS_PER_BYTE)
     }
 
     unsafe fn set_unchecked(&mut self, index: usize, trit: Self::Trit) {
         let b = self.ptr(index).read();
-        let b = insert(b, (self.len_offset().1 + index) % TPB, trit);
+        let b = insert(b, (self.len_offset().1 + index) % TRITS_PER_BYTE, trit);
         (self.ptr(index) as *mut i8).write(b);
     }
 
     unsafe fn slice_unchecked(&self, range: Range<usize>) -> &Self {
         &*Self::make(
             self.ptr(range.start),
-            (self.len_offset().1 + range.start) % TPB,
+            (self.len_offset().1 + range.start) % TRITS_PER_BYTE,
             range.end - range.start,
         )
     }
@@ -97,7 +96,7 @@ impl RawEncoding for T3B1 {
     unsafe fn slice_unchecked_mut(&mut self, range: Range<usize>) -> &mut Self {
         &mut *(Self::make(
             self.ptr(range.start),
-            (self.len_offset().1 + range.start) % TPB,
+            (self.len_offset().1 + range.start) % TRITS_PER_BYTE,
             range.end - range.start,
         ) as *mut Self)
     }
@@ -107,12 +106,12 @@ impl RawEncoding for T3B1 {
     }
 
     unsafe fn from_raw_unchecked(b: &[i8], num_trits: usize) -> &Self {
-        assert!(num_trits <= b.len() * TPB);
+        assert!(num_trits <= b.len() * TRITS_PER_BYTE);
         &*Self::make(b.as_ptr() as *const _, 0, num_trits)
     }
 
     unsafe fn from_raw_unchecked_mut(b: &mut [i8], num_trits: usize) -> &mut Self {
-        assert!(num_trits <= b.len() * TPB);
+        assert!(num_trits <= b.len() * TRITS_PER_BYTE);
         &mut *(Self::make(b.as_ptr() as *const _, 0, num_trits) as *mut _)
     }
 }
@@ -129,7 +128,7 @@ impl RawEncodingBuf for T3B1Buf {
     }
 
     fn with_capacity(cap: usize) -> Self {
-        let cap = (cap / TPB) + (cap % TPB != 0) as usize;
+        let cap = (cap / TRITS_PER_BYTE) + (cap % TRITS_PER_BYTE != 0) as usize;
         Self(Vec::with_capacity(cap), 0)
     }
 
@@ -139,14 +138,14 @@ impl RawEncodingBuf for T3B1Buf {
     }
 
     fn push(&mut self, trit: <Self::Slice as RawEncoding>::Trit) {
-        if self.1 % TPB == 0 {
+        if self.1 % TRITS_PER_BYTE == 0 {
             let b = insert(0, 0, trit);
             debug_assert!(T3B1::is_valid(b));
             self.0.push(b);
         } else {
             let last_index = self.0.len() - 1;
             let b = unsafe { self.0.get_unchecked_mut(last_index) };
-            *b = insert(*b, self.1 % TPB, trit);
+            *b = insert(*b, self.1 % TRITS_PER_BYTE, trit);
             debug_assert!(T3B1::is_valid(*b));
         }
         self.1 += 1;
@@ -155,11 +154,11 @@ impl RawEncodingBuf for T3B1Buf {
     fn pop(&mut self) -> Option<<Self::Slice as RawEncoding>::Trit> {
         let val = if self.1 == 0 {
             return None;
-        } else if self.1 % TPB == 1 {
+        } else if self.1 % TRITS_PER_BYTE == 1 {
             self.0.pop().map(|b| extract(b, 0))
         } else {
             let last_index = self.0.len() - 1;
-            unsafe { Some(extract(*self.0.get_unchecked(last_index), (self.1 + TPB - 1) % TPB)) }
+            unsafe { Some(extract(*self.0.get_unchecked(last_index), (self.1 + TRITS_PER_BYTE - 1) % TRITS_PER_BYTE)) }
         };
         self.1 -= 1;
         val
@@ -174,6 +173,6 @@ impl RawEncodingBuf for T3B1Buf {
     }
 
     fn capacity(&self) -> usize {
-        self.0.capacity()
+        self.0.capacity() * TRITS_PER_BYTE
     }
 }

--- a/bee-ternary/src/t3b1.rs
+++ b/bee-ternary/src/t3b1.rs
@@ -172,4 +172,8 @@ impl RawEncodingBuf for T3B1Buf {
     fn as_slice_mut(&mut self) -> &mut Self::Slice {
         unsafe { &mut *(Self::Slice::make(self.0.as_ptr() as _, 0, self.1) as *mut _) }
     }
+
+    fn capacity(&self) -> usize {
+        self.0.capacity()
+    }
 }

--- a/bee-ternary/src/t3b1.rs
+++ b/bee-ternary/src/t3b1.rs
@@ -56,6 +56,8 @@ impl RawEncoding for T3B1 {
     type Trit = Btrit;
     type Buf = T3B1Buf;
 
+    const TRITS_PER_BYTE: usize = TRITS_PER_BYTE;
+
     fn empty() -> &'static Self {
         unsafe { &*Self::make(&[] as *const _, 0, 0) }
     }
@@ -66,12 +68,20 @@ impl RawEncoding for T3B1 {
 
     fn as_i8_slice(&self) -> &[i8] {
         assert!(self.len_offset().1 == 0);
-        unsafe { std::slice::from_raw_parts(self as *const _ as *const _, (self.len() + TRITS_PER_BYTE - 1) / TRITS_PER_BYTE) }
+        unsafe {
+            std::slice::from_raw_parts(
+                self as *const _ as *const _,
+                (self.len() + TRITS_PER_BYTE - 1) / TRITS_PER_BYTE,
+            )
+        }
     }
 
     unsafe fn as_i8_slice_mut(&mut self) -> &mut [i8] {
         assert!(self.len_offset().1 == 0);
-        std::slice::from_raw_parts_mut(self as *mut _ as *mut _, (self.len() + TRITS_PER_BYTE - 1) / TRITS_PER_BYTE)
+        std::slice::from_raw_parts_mut(
+            self as *mut _ as *mut _,
+            (self.len() + TRITS_PER_BYTE - 1) / TRITS_PER_BYTE,
+        )
     }
 
     unsafe fn get_unchecked(&self, index: usize) -> Self::Trit {
@@ -158,7 +168,12 @@ impl RawEncodingBuf for T3B1Buf {
             self.0.pop().map(|b| extract(b, 0))
         } else {
             let last_index = self.0.len() - 1;
-            unsafe { Some(extract(*self.0.get_unchecked(last_index), (self.1 + TRITS_PER_BYTE - 1) % TRITS_PER_BYTE)) }
+            unsafe {
+                Some(extract(
+                    *self.0.get_unchecked(last_index),
+                    (self.1 + TRITS_PER_BYTE - 1) % TRITS_PER_BYTE,
+                ))
+            }
         };
         self.1 -= 1;
         val

--- a/bee-ternary/src/t4b1.rs
+++ b/bee-ternary/src/t4b1.rs
@@ -54,6 +54,8 @@ impl RawEncoding for T4B1 {
     type Trit = Btrit;
     type Buf = T4B1Buf;
 
+    const TRITS_PER_BYTE: usize = TRITS_PER_BYTE;
+
     fn empty() -> &'static Self {
         unsafe { &*Self::make(&[] as *const _, 0, 0) }
     }
@@ -64,12 +66,20 @@ impl RawEncoding for T4B1 {
 
     fn as_i8_slice(&self) -> &[i8] {
         assert!(self.len_offset().1 == 0);
-        unsafe { std::slice::from_raw_parts(self as *const _ as *const _, (self.len() + TRITS_PER_BYTE - 1) / TRITS_PER_BYTE) }
+        unsafe {
+            std::slice::from_raw_parts(
+                self as *const _ as *const _,
+                (self.len() + TRITS_PER_BYTE - 1) / TRITS_PER_BYTE,
+            )
+        }
     }
 
     unsafe fn as_i8_slice_mut(&mut self) -> &mut [i8] {
         assert!(self.len_offset().1 == 0);
-        std::slice::from_raw_parts_mut(self as *mut _ as *mut _, (self.len() + TRITS_PER_BYTE - 1) / TRITS_PER_BYTE)
+        std::slice::from_raw_parts_mut(
+            self as *mut _ as *mut _,
+            (self.len() + TRITS_PER_BYTE - 1) / TRITS_PER_BYTE,
+        )
     }
 
     unsafe fn get_unchecked(&self, index: usize) -> Self::Trit {
@@ -153,7 +163,12 @@ impl RawEncodingBuf for T4B1Buf {
             self.0.pop().map(|b| extract(b, 0))
         } else {
             let last_index = self.0.len() - 1;
-            unsafe { Some(extract(*self.0.get_unchecked(last_index), (self.1 + TRITS_PER_BYTE - 1) % TRITS_PER_BYTE)) }
+            unsafe {
+                Some(extract(
+                    *self.0.get_unchecked(last_index),
+                    (self.1 + TRITS_PER_BYTE - 1) % TRITS_PER_BYTE,
+                ))
+            }
         };
         self.1 -= 1;
         val

--- a/bee-ternary/src/t4b1.rs
+++ b/bee-ternary/src/t4b1.rs
@@ -5,8 +5,7 @@ use crate::{Btrit, RawEncoding, RawEncodingBuf, ShiftTernary, Utrit};
 
 use std::ops::Range;
 
-// Trits Per Byte
-const TPB: usize = 4;
+const TRITS_PER_BYTE: usize = 4;
 // Number required to push a byte between balanced and unbalanced representationsconst TPB: usize = 4;
 const BAL: i8 = 40;
 
@@ -16,12 +15,12 @@ pub struct T4B1([()]);
 
 impl T4B1 {
     unsafe fn make(ptr: *const i8, offset: usize, len: usize) -> *const Self {
-        let len = (len << 2) | (offset % TPB);
-        std::mem::transmute((ptr.add(offset / TPB), len))
+        let len = (len << 2) | (offset % TRITS_PER_BYTE);
+        std::mem::transmute((ptr.add(offset / TRITS_PER_BYTE), len))
     }
 
     unsafe fn ptr(&self, index: usize) -> *const i8 {
-        let byte_offset = (self.len_offset().1 + index) / TPB;
+        let byte_offset = (self.len_offset().1 + index) / TRITS_PER_BYTE;
         (self.0.as_ptr() as *const i8).add(byte_offset)
     }
 
@@ -32,7 +31,7 @@ impl T4B1 {
 
 fn extract(x: i8, elem: usize) -> Btrit {
     debug_assert!(
-        elem < TPB,
+        elem < TRITS_PER_BYTE,
         "Attempted to extract invalid element {} from balanced T4B1 trit",
         elem
     );
@@ -41,7 +40,7 @@ fn extract(x: i8, elem: usize) -> Btrit {
 
 fn insert(x: i8, elem: usize, trit: Btrit) -> i8 {
     debug_assert!(
-        elem < TPB,
+        elem < TRITS_PER_BYTE,
         "Attempted to insert invalid element {} into balanced T4B1 trit",
         elem
     );
@@ -65,29 +64,29 @@ impl RawEncoding for T4B1 {
 
     fn as_i8_slice(&self) -> &[i8] {
         assert!(self.len_offset().1 == 0);
-        unsafe { std::slice::from_raw_parts(self as *const _ as *const _, (self.len() + TPB - 1) / TPB) }
+        unsafe { std::slice::from_raw_parts(self as *const _ as *const _, (self.len() + TRITS_PER_BYTE - 1) / TRITS_PER_BYTE) }
     }
 
     unsafe fn as_i8_slice_mut(&mut self) -> &mut [i8] {
         assert!(self.len_offset().1 == 0);
-        std::slice::from_raw_parts_mut(self as *mut _ as *mut _, (self.len() + TPB - 1) / TPB)
+        std::slice::from_raw_parts_mut(self as *mut _ as *mut _, (self.len() + TRITS_PER_BYTE - 1) / TRITS_PER_BYTE)
     }
 
     unsafe fn get_unchecked(&self, index: usize) -> Self::Trit {
         let b = self.ptr(index).read();
-        extract(b, (self.len_offset().1 + index) % TPB)
+        extract(b, (self.len_offset().1 + index) % TRITS_PER_BYTE)
     }
 
     unsafe fn set_unchecked(&mut self, index: usize, trit: Self::Trit) {
         let b = self.ptr(index).read();
-        let b = insert(b, (self.len_offset().1 + index) % TPB, trit);
+        let b = insert(b, (self.len_offset().1 + index) % TRITS_PER_BYTE, trit);
         (self.ptr(index) as *mut i8).write(b);
     }
 
     unsafe fn slice_unchecked(&self, range: Range<usize>) -> &Self {
         &*Self::make(
             self.ptr(range.start),
-            (self.len_offset().1 + range.start) % TPB,
+            (self.len_offset().1 + range.start) % TRITS_PER_BYTE,
             range.end - range.start,
         )
     }
@@ -95,7 +94,7 @@ impl RawEncoding for T4B1 {
     unsafe fn slice_unchecked_mut(&mut self, range: Range<usize>) -> &mut Self {
         &mut *(Self::make(
             self.ptr(range.start),
-            (self.len_offset().1 + range.start) % TPB,
+            (self.len_offset().1 + range.start) % TRITS_PER_BYTE,
             range.end - range.start,
         ) as *mut Self)
     }
@@ -105,12 +104,12 @@ impl RawEncoding for T4B1 {
     }
 
     unsafe fn from_raw_unchecked(b: &[i8], num_trits: usize) -> &Self {
-        assert!(num_trits <= b.len() * TPB);
+        assert!(num_trits <= b.len() * TRITS_PER_BYTE);
         &*Self::make(b.as_ptr() as *const _, 0, num_trits)
     }
 
     unsafe fn from_raw_unchecked_mut(b: &mut [i8], num_trits: usize) -> &mut Self {
-        assert!(num_trits <= b.len() * TPB);
+        assert!(num_trits <= b.len() * TRITS_PER_BYTE);
         &mut *(Self::make(b.as_ptr() as *const _, 0, num_trits) as *mut _)
     }
 }
@@ -127,7 +126,7 @@ impl RawEncodingBuf for T4B1Buf {
     }
 
     fn with_capacity(cap: usize) -> Self {
-        let cap = (cap / TPB) + (cap % TPB != 0) as usize;
+        let cap = (cap / TRITS_PER_BYTE) + (cap % TRITS_PER_BYTE != 0) as usize;
         Self(Vec::with_capacity(cap), 0)
     }
 
@@ -137,12 +136,12 @@ impl RawEncodingBuf for T4B1Buf {
     }
 
     fn push(&mut self, trit: <Self::Slice as RawEncoding>::Trit) {
-        if self.1 % TPB == 0 {
+        if self.1 % TRITS_PER_BYTE == 0 {
             self.0.push(insert(0, 0, trit));
         } else {
             let last_index = self.0.len() - 1;
             let b = unsafe { self.0.get_unchecked_mut(last_index) };
-            *b = insert(*b, self.1 % TPB, trit);
+            *b = insert(*b, self.1 % TRITS_PER_BYTE, trit);
         }
         self.1 += 1;
     }
@@ -150,11 +149,11 @@ impl RawEncodingBuf for T4B1Buf {
     fn pop(&mut self) -> Option<<Self::Slice as RawEncoding>::Trit> {
         let val = if self.1 == 0 {
             return None;
-        } else if self.1 % TPB == 1 {
+        } else if self.1 % TRITS_PER_BYTE == 1 {
             self.0.pop().map(|b| extract(b, 0))
         } else {
             let last_index = self.0.len() - 1;
-            unsafe { Some(extract(*self.0.get_unchecked(last_index), (self.1 + TPB - 1) % TPB)) }
+            unsafe { Some(extract(*self.0.get_unchecked(last_index), (self.1 + TRITS_PER_BYTE - 1) % TRITS_PER_BYTE)) }
         };
         self.1 -= 1;
         val
@@ -169,6 +168,6 @@ impl RawEncodingBuf for T4B1Buf {
     }
 
     fn capacity(&self) -> usize {
-        self.0.capacity()
+        self.0.capacity() * TRITS_PER_BYTE
     }
 }

--- a/bee-ternary/src/t4b1.rs
+++ b/bee-ternary/src/t4b1.rs
@@ -167,4 +167,8 @@ impl RawEncodingBuf for T4B1Buf {
     fn as_slice_mut(&mut self) -> &mut Self::Slice {
         unsafe { &mut *(Self::Slice::make(self.0.as_ptr() as _, 0, self.1) as *mut _) }
     }
+
+    fn capacity(&self) -> usize {
+        self.0.capacity()
+    }
 }

--- a/bee-ternary/src/t4b1.rs
+++ b/bee-ternary/src/t4b1.rs
@@ -7,7 +7,7 @@ use std::ops::Range;
 
 const TRITS_PER_BYTE: usize = 4;
 // Number required to push a byte between balanced and unbalanced representationsconst TPB: usize = 4;
-const BAL: i8 = 40;
+const BALANCE_DIFF: i8 = 40;
 
 /// An encoding scheme slice that uses a single byte to represent four trits.
 #[repr(transparent)]
@@ -35,7 +35,7 @@ fn extract(x: i8, elem: usize) -> Btrit {
         "Attempted to extract invalid element {} from balanced T4B1 trit",
         elem
     );
-    Utrit::from_u8((((x + BAL) / 3i8.pow(elem as u32)) % 3) as u8).shift()
+    Utrit::from_u8((((x + BALANCE_DIFF) / 3i8.pow(elem as u32)) % 3) as u8).shift()
 }
 
 fn insert(x: i8, elem: usize, trit: Btrit) -> i8 {
@@ -45,9 +45,9 @@ fn insert(x: i8, elem: usize, trit: Btrit) -> i8 {
         elem
     );
     let utrit = trit.shift();
-    let ux = x + BAL;
+    let ux = x + BALANCE_DIFF;
     let ux = ux + (utrit.into_u8() as i8 - (ux / 3i8.pow(elem as u32)) % 3) * 3i8.pow(elem as u32);
-    ux - BAL
+    ux - BALANCE_DIFF
 }
 
 impl RawEncoding for T4B1 {
@@ -110,7 +110,7 @@ impl RawEncoding for T4B1 {
     }
 
     fn is_valid(b: i8) -> bool {
-        b >= -BAL && b <= BAL
+        b >= -BALANCE_DIFF && b <= BALANCE_DIFF
     }
 
     unsafe fn from_raw_unchecked(b: &[i8], num_trits: usize) -> &Self {

--- a/bee-ternary/src/t5b1.rs
+++ b/bee-ternary/src/t5b1.rs
@@ -5,8 +5,7 @@ use crate::{Btrit, RawEncoding, RawEncodingBuf, ShiftTernary, Utrit};
 
 use std::ops::Range;
 
-// Trits Per Byte
-const TPB: usize = 5;
+const TRITS_PER_BYTE: usize = 5;
 // Number required to push a byte between balanced and unbalanced representations
 const BAL: i8 = 121;
 
@@ -16,12 +15,12 @@ pub struct T5B1([()]);
 
 impl T5B1 {
     unsafe fn make(ptr: *const i8, offset: usize, len: usize) -> *const Self {
-        let len = (len << 3) | (offset % TPB);
-        std::mem::transmute((ptr.add(offset / TPB), len))
+        let len = (len << 3) | (offset % TRITS_PER_BYTE);
+        std::mem::transmute((ptr.add(offset / TRITS_PER_BYTE), len))
     }
 
     unsafe fn ptr(&self, index: usize) -> *const i8 {
-        let byte_offset = (self.len_offset().1 + index) / TPB;
+        let byte_offset = (self.len_offset().1 + index) / TRITS_PER_BYTE;
         (self.0.as_ptr() as *const i8).add(byte_offset)
     }
 
@@ -32,7 +31,7 @@ impl T5B1 {
 
 fn extract(x: i8, elem: usize) -> Btrit {
     debug_assert!(
-        elem < TPB,
+        elem < TRITS_PER_BYTE,
         "Attempted to extract invalid element {} from balanced T5B1 trit",
         elem
     );
@@ -41,7 +40,7 @@ fn extract(x: i8, elem: usize) -> Btrit {
 
 fn insert(x: i8, elem: usize, trit: Btrit) -> i8 {
     debug_assert!(
-        elem < TPB,
+        elem < TRITS_PER_BYTE,
         "Attempted to insert invalid element {} into balanced T5B1 trit",
         elem
     );
@@ -65,29 +64,29 @@ impl RawEncoding for T5B1 {
 
     fn as_i8_slice(&self) -> &[i8] {
         assert!(self.len_offset().1 == 0);
-        unsafe { std::slice::from_raw_parts(self as *const _ as *const _, (self.len() + TPB - 1) / TPB) }
+        unsafe { std::slice::from_raw_parts(self as *const _ as *const _, (self.len() + TRITS_PER_BYTE - 1) / TRITS_PER_BYTE) }
     }
 
     unsafe fn as_i8_slice_mut(&mut self) -> &mut [i8] {
         assert!(self.len_offset().1 == 0);
-        std::slice::from_raw_parts_mut(self as *mut _ as *mut _, (self.len() + TPB - 1) / TPB)
+        std::slice::from_raw_parts_mut(self as *mut _ as *mut _, (self.len() + TRITS_PER_BYTE - 1) / TRITS_PER_BYTE)
     }
 
     unsafe fn get_unchecked(&self, index: usize) -> Self::Trit {
         let b = self.ptr(index).read();
-        extract(b, (self.len_offset().1 + index) % TPB)
+        extract(b, (self.len_offset().1 + index) % TRITS_PER_BYTE)
     }
 
     unsafe fn set_unchecked(&mut self, index: usize, trit: Self::Trit) {
         let b = self.ptr(index).read();
-        let b = insert(b, (self.len_offset().1 + index) % TPB, trit);
+        let b = insert(b, (self.len_offset().1 + index) % TRITS_PER_BYTE, trit);
         (self.ptr(index) as *mut i8).write(b);
     }
 
     unsafe fn slice_unchecked(&self, range: Range<usize>) -> &Self {
         &*Self::make(
             self.ptr(range.start),
-            (self.len_offset().1 + range.start) % TPB,
+            (self.len_offset().1 + range.start) % TRITS_PER_BYTE,
             range.end - range.start,
         )
     }
@@ -95,7 +94,7 @@ impl RawEncoding for T5B1 {
     unsafe fn slice_unchecked_mut(&mut self, range: Range<usize>) -> &mut Self {
         &mut *(Self::make(
             self.ptr(range.start),
-            (self.len_offset().1 + range.start) % TPB,
+            (self.len_offset().1 + range.start) % TRITS_PER_BYTE,
             range.end - range.start,
         ) as *mut Self)
     }
@@ -105,12 +104,12 @@ impl RawEncoding for T5B1 {
     }
 
     unsafe fn from_raw_unchecked(b: &[i8], num_trits: usize) -> &Self {
-        assert!(num_trits <= b.len() * TPB);
+        assert!(num_trits <= b.len() * TRITS_PER_BYTE);
         &*Self::make(b.as_ptr() as *const _, 0, num_trits)
     }
 
     unsafe fn from_raw_unchecked_mut(b: &mut [i8], num_trits: usize) -> &mut Self {
-        assert!(num_trits <= b.len() * TPB);
+        assert!(num_trits <= b.len() * TRITS_PER_BYTE);
         &mut *(Self::make(b.as_ptr() as *const _, 0, num_trits) as *mut _)
     }
 }
@@ -127,7 +126,7 @@ impl RawEncodingBuf for T5B1Buf {
     }
 
     fn with_capacity(cap: usize) -> Self {
-        let cap = (cap / TPB) + (cap % TPB != 0) as usize;
+        let cap = (cap / TRITS_PER_BYTE) + (cap % TRITS_PER_BYTE != 0) as usize;
         Self(Vec::with_capacity(cap), 0)
     }
 
@@ -137,12 +136,12 @@ impl RawEncodingBuf for T5B1Buf {
     }
 
     fn push(&mut self, trit: <Self::Slice as RawEncoding>::Trit) {
-        if self.1 % TPB == 0 {
+        if self.1 % TRITS_PER_BYTE == 0 {
             self.0.push(insert(0, 0, trit));
         } else {
             let last_index = self.0.len() - 1;
             let b = unsafe { self.0.get_unchecked_mut(last_index) };
-            *b = insert(*b, self.1 % TPB, trit);
+            *b = insert(*b, self.1 % TRITS_PER_BYTE, trit);
         }
         self.1 += 1;
     }
@@ -150,11 +149,11 @@ impl RawEncodingBuf for T5B1Buf {
     fn pop(&mut self) -> Option<<Self::Slice as RawEncoding>::Trit> {
         let val = if self.1 == 0 {
             return None;
-        } else if self.1 % TPB == 1 {
+        } else if self.1 % TRITS_PER_BYTE == 1 {
             self.0.pop().map(|b| extract(b, 0))
         } else {
             let last_index = self.0.len() - 1;
-            unsafe { Some(extract(*self.0.get_unchecked(last_index), (self.1 + TPB - 1) % TPB)) }
+            unsafe { Some(extract(*self.0.get_unchecked(last_index), (self.1 + TRITS_PER_BYTE - 1) % TRITS_PER_BYTE)) }
         };
         self.1 -= 1;
         val
@@ -169,6 +168,6 @@ impl RawEncodingBuf for T5B1Buf {
     }
 
     fn capacity(&self) -> usize {
-        self.0.capacity()
+        self.0.capacity() * TRITS_PER_BYTE
     }
 }

--- a/bee-ternary/src/t5b1.rs
+++ b/bee-ternary/src/t5b1.rs
@@ -7,7 +7,7 @@ use std::ops::Range;
 
 const TRITS_PER_BYTE: usize = 5;
 // Number required to push a byte between balanced and unbalanced representations
-const BAL: i8 = 121;
+const BALANCE_DIFF: i8 = 121;
 
 /// An encoding scheme slice that uses a single byte to represent five trits.
 #[repr(transparent)]
@@ -35,7 +35,7 @@ fn extract(x: i8, elem: usize) -> Btrit {
         "Attempted to extract invalid element {} from balanced T5B1 trit",
         elem
     );
-    Utrit::from_u8((((x as i16 + BAL as i16) / 3i16.pow(elem as u32)) % 3) as u8).shift()
+    Utrit::from_u8((((x as i16 + BALANCE_DIFF as i16) / 3i16.pow(elem as u32)) % 3) as u8).shift()
 }
 
 fn insert(x: i8, elem: usize, trit: Btrit) -> i8 {
@@ -45,9 +45,9 @@ fn insert(x: i8, elem: usize, trit: Btrit) -> i8 {
         elem
     );
     let utrit = trit.shift();
-    let ux = x as i16 + BAL as i16;
+    let ux = x as i16 + BALANCE_DIFF as i16;
     let ux = ux + (utrit.into_u8() as i16 - (ux / 3i16.pow(elem as u32)) % 3) * 3i16.pow(elem as u32);
-    (ux - BAL as i16) as i8
+    (ux - BALANCE_DIFF as i16) as i8
 }
 
 impl RawEncoding for T5B1 {
@@ -110,7 +110,7 @@ impl RawEncoding for T5B1 {
     }
 
     fn is_valid(b: i8) -> bool {
-        b >= -BAL && b <= BAL
+        b >= -BALANCE_DIFF && b <= BALANCE_DIFF
     }
 
     unsafe fn from_raw_unchecked(b: &[i8], num_trits: usize) -> &Self {

--- a/bee-ternary/src/t5b1.rs
+++ b/bee-ternary/src/t5b1.rs
@@ -167,4 +167,8 @@ impl RawEncodingBuf for T5B1Buf {
     fn as_slice_mut(&mut self) -> &mut Self::Slice {
         unsafe { &mut *(Self::Slice::make(self.0.as_ptr() as _, 0, self.1) as *mut _) }
     }
+
+    fn capacity(&self) -> usize {
+        self.0.capacity()
+    }
 }

--- a/bee-ternary/src/t5b1.rs
+++ b/bee-ternary/src/t5b1.rs
@@ -54,6 +54,8 @@ impl RawEncoding for T5B1 {
     type Trit = Btrit;
     type Buf = T5B1Buf;
 
+    const TRITS_PER_BYTE: usize = TRITS_PER_BYTE;
+
     fn empty() -> &'static Self {
         unsafe { &*Self::make(&[] as *const _, 0, 0) }
     }
@@ -64,12 +66,20 @@ impl RawEncoding for T5B1 {
 
     fn as_i8_slice(&self) -> &[i8] {
         assert!(self.len_offset().1 == 0);
-        unsafe { std::slice::from_raw_parts(self as *const _ as *const _, (self.len() + TRITS_PER_BYTE - 1) / TRITS_PER_BYTE) }
+        unsafe {
+            std::slice::from_raw_parts(
+                self as *const _ as *const _,
+                (self.len() + TRITS_PER_BYTE - 1) / TRITS_PER_BYTE,
+            )
+        }
     }
 
     unsafe fn as_i8_slice_mut(&mut self) -> &mut [i8] {
         assert!(self.len_offset().1 == 0);
-        std::slice::from_raw_parts_mut(self as *mut _ as *mut _, (self.len() + TRITS_PER_BYTE - 1) / TRITS_PER_BYTE)
+        std::slice::from_raw_parts_mut(
+            self as *mut _ as *mut _,
+            (self.len() + TRITS_PER_BYTE - 1) / TRITS_PER_BYTE,
+        )
     }
 
     unsafe fn get_unchecked(&self, index: usize) -> Self::Trit {
@@ -153,7 +163,12 @@ impl RawEncodingBuf for T5B1Buf {
             self.0.pop().map(|b| extract(b, 0))
         } else {
             let last_index = self.0.len() - 1;
-            unsafe { Some(extract(*self.0.get_unchecked(last_index), (self.1 + TRITS_PER_BYTE - 1) % TRITS_PER_BYTE)) }
+            unsafe {
+                Some(extract(
+                    *self.0.get_unchecked(last_index),
+                    (self.1 + TRITS_PER_BYTE - 1) % TRITS_PER_BYTE,
+                ))
+            }
         };
         self.1 -= 1;
         val

--- a/bee-test/Cargo.toml
+++ b/bee-test/Cargo.toml
@@ -14,7 +14,7 @@ homepage = "https://www.iota.org"
 bee-ledger = { version = "0.5.0", path = "../bee-ledger", default-features = false }
 bee-message = { version = "0.1.5", path = "../bee-message", default-features = false }
 bee-tangle = { version = "0.2.0", path = "../bee-tangle", default-features = false }
-bee-ternary = { version = "0.5.0", path = "../bee-ternary", default-features = false, features = [ "serde1" ] }
+bee-ternary = { version = "0.5.1", path = "../bee-ternary", default-features = false, features = [ "serde1" ] }
 
 bytemuck = { version = "1.7.2", default-features = false }
 rand = { version = "0.8.4", default-features = false }

--- a/bee-test/src/ternary.rs
+++ b/bee-test/src/ternary.rs
@@ -10,15 +10,20 @@ use rand::prelude::*;
 
 use std::ops::Range;
 
-/// Generates a random i8 trit.
-pub fn gen_trit() -> i8 {
+/// Generates a random balanced i8 trit.
+pub fn gen_trit_balanced() -> i8 {
     (thread_rng().gen::<u8>() % 3) as i8 - 1
 }
 
+/// Generates a random unbalanced i8 trit.
+pub fn gen_trit_unbalanced() -> i8 {
+    (thread_rng().gen::<u8>() % 3) as i8
+}
+
 /// Generates a buffer of balanced trits.
-pub fn gen_buf<T: raw::RawEncodingBuf>(len: Range<usize>) -> (TritBuf<T>, Vec<i8>) {
+pub fn gen_buf_balanced<T: raw::RawEncodingBuf>(len: Range<usize>) -> (TritBuf<T>, Vec<i8>) {
     let len = thread_rng().gen_range(len.start..len.end);
-    let trits = (0..len).map(|_| gen_trit()).collect::<Vec<_>>();
+    let trits = (0..len).map(|_| gen_trit_balanced()).collect::<Vec<_>>();
     (
         trits
             .iter()
@@ -31,7 +36,7 @@ pub fn gen_buf<T: raw::RawEncodingBuf>(len: Range<usize>) -> (TritBuf<T>, Vec<i8
 /// Generates a buffer of unbalanced trits.
 pub fn gen_buf_unbalanced<T: raw::RawEncodingBuf>(len: Range<usize>) -> (TritBuf<T>, Vec<i8>) {
     let len = thread_rng().gen_range(len.start..len.end);
-    let trits = (0..len).map(|_| gen_trit() + 1).collect::<Vec<_>>();
+    let trits = (0..len).map(|_| gen_trit_unbalanced()).collect::<Vec<_>>();
     (
         trits
             .iter()

--- a/bee-test/tests/ternary/buf.rs
+++ b/bee-test/tests/ternary/buf.rs
@@ -116,13 +116,13 @@ where
 }
 
 fn with_capacity_generic<T: raw::RawEncodingBuf>() {
-    let cap = 243; // TODO: Use random capacity
+    let cap = thread_rng().gen_range(1..1000);
     let mut buf = TritBuf::<T>::with_capacity(cap);
-    assert_eq!(buf.capacity(), cap);
+    assert!(buf.capacity() < (cap + <T::Slice as raw::RawEncoding>::TRITS_PER_BYTE));
     for _ in 0..cap {
         buf.push(<T::Slice as raw::RawEncoding>::Trit::zero());
     }
-    assert_eq!(buf.capacity(), cap);
+    assert!(buf.capacity() < (cap + <T::Slice as raw::RawEncoding>::TRITS_PER_BYTE));
 }
 
 #[test]

--- a/bee-test/tests/ternary/buf.rs
+++ b/bee-test/tests/ternary/buf.rs
@@ -115,6 +115,16 @@ where
     });
 }
 
+fn with_capacity_generic<T: raw::RawEncodingBuf>() {
+    let cap = 243; // TODO: Use random capacity
+    let mut buf = TritBuf::<T>::with_capacity(cap);
+    assert_eq!(buf.capacity(), cap);
+    for _ in 0..cap {
+        buf.push(<T::Slice as raw::RawEncoding>::Trit::zero());
+    }
+    assert_eq!(buf.capacity(), cap);
+}
+
 #[test]
 fn create() {
     create_generic::<T1B1Buf<Btrit>>();
@@ -170,4 +180,14 @@ fn encode() {
     encode_generic::<T4B1Buf, T3B1Buf>();
     encode_generic::<T5B1Buf, T2B1Buf>();
     encode_generic::<T5B1Buf, T3B1Buf>();
+}
+
+#[test]
+fn with_capacity() {
+    with_capacity_generic::<T1B1Buf<Btrit>>();
+    with_capacity_generic::<T1B1Buf<Utrit>>();
+    with_capacity_generic::<T2B1Buf>();
+    with_capacity_generic::<T3B1Buf>();
+    with_capacity_generic::<T4B1Buf>();
+    with_capacity_generic::<T5B1Buf>();
 }

--- a/bee-test/tests/ternary/buf.rs
+++ b/bee-test/tests/ternary/buf.rs
@@ -122,6 +122,7 @@ fn with_capacity_generic<T: raw::RawEncodingBuf>() {
     for _ in 0..cap {
         buf.push(<T::Slice as raw::RawEncoding>::Trit::zero());
     }
+    assert!(buf.capacity() >= cap);
     assert!(buf.capacity() < (cap + <T::Slice as raw::RawEncoding>::TRITS_PER_BYTE));
 }
 

--- a/bee-test/tests/ternary/buf.rs
+++ b/bee-test/tests/ternary/buf.rs
@@ -16,7 +16,7 @@ fn create_generic<T: raw::RawEncodingBuf>() {
         assert!(buf.len() == 0);
     });
     fuzz(100, || {
-        let trits = gen_buf::<T>(0..1000).1;
+        let trits = gen_buf_balanced::<T>(0..1000).1;
         let buf: TritBuf<T> = trits
             .iter()
             .map(|t| <T::Slice as raw::RawEncoding>::Trit::try_from(*t).ok().unwrap())
@@ -43,11 +43,11 @@ fn create_unbalanced<T: raw::RawEncodingBuf>() {
 
 fn push_pop_generic<T: raw::RawEncodingBuf>() {
     fuzz(100, || {
-        let (mut a, mut b) = gen_buf::<T>(0..100);
+        let (mut a, mut b) = gen_buf_balanced::<T>(0..100);
 
         for _ in 0..1000 {
             if thread_rng().gen() {
-                let trit = gen_trit();
+                let trit = gen_trit_balanced();
                 a.push(trit.try_into().unwrap_or_else(|_| unreachable!()));
                 b.push(trit);
             } else {
@@ -66,7 +66,7 @@ fn push_pop_generic_unbalanced<T: raw::RawEncodingBuf>() {
 
         for _ in 0..1000 {
             if thread_rng().gen() {
-                let trit = gen_trit() + 1;
+                let trit = gen_trit_unbalanced();
                 a.push(trit.try_into().unwrap_or_else(|_| unreachable!()));
                 b.push(trit);
             } else {
@@ -81,7 +81,7 @@ fn push_pop_generic_unbalanced<T: raw::RawEncodingBuf>() {
 
 fn eq_generic<T: raw::RawEncodingBuf + Clone>() {
     fuzz(100, || {
-        let a = gen_buf::<T>(0..1000).0;
+        let a = gen_buf_balanced::<T>(0..1000).0;
         let b = a.clone();
 
         assert_eq!(a, b);
@@ -102,7 +102,7 @@ where
     U::Slice: raw::RawEncoding<Trit = <T::Slice as raw::RawEncoding>::Trit>,
 {
     fuzz(100, || {
-        let a = gen_buf::<T>(0..100).0;
+        let a = gen_buf_balanced::<T>(0..100).0;
         let b = a.encode::<U>();
 
         assert_eq!(a, b);

--- a/bee-test/tests/ternary/serde.rs
+++ b/bee-test/tests/ternary/serde.rs
@@ -10,7 +10,7 @@ fn serialize_generic<T: raw::RawEncodingBuf>()
 where
     <T::Slice as RawEncoding>::Trit: Serialize,
 {
-    let (a, a_i8) = gen_buf::<T>(0..1000);
+    let (a, a_i8) = gen_buf_balanced::<T>(0..1000);
     assert_eq!(
         serde_json::to_string(&a).unwrap(),
         format!("[{}]", a_i8.iter().map(|t| t.to_string()).collect::<Vec<_>>().join(",")),
@@ -32,7 +32,7 @@ fn deserialize_generic<T: raw::RawEncodingBuf>()
 where
     <T::Slice as RawEncoding>::Trit: DeserializeOwned,
 {
-    let (a, a_i8) = gen_buf::<T>(0..1000);
+    let (a, a_i8) = gen_buf_balanced::<T>(0..1000);
     assert_eq!(
         serde_json::from_str::<TritBuf<T>>(&format!(
             "[{}]",

--- a/bee-test/tests/ternary/slice.rs
+++ b/bee-test/tests/ternary/slice.rs
@@ -9,7 +9,7 @@ use rand::prelude::*;
 fn get_generic<T: raw::RawEncodingBuf + Clone>() {
     println!("{}", std::any::type_name::<T>());
     fuzz(100, || {
-        let (a, a_i8) = gen_buf::<T>(1..1000);
+        let (a, a_i8) = gen_buf_balanced::<T>(1..1000);
 
         fuzz(25, || {
             assert_eq!(a.get(a.len() + thread_rng().gen_range(0..20)), None);
@@ -66,7 +66,7 @@ fn get_generic_unbalanced<T: raw::RawEncodingBuf + Clone>() {
 fn set_generic<T: raw::RawEncodingBuf + Clone>() {
     println!("{}", std::any::type_name::<T>());
     fuzz(100, || {
-        let (mut a, mut a_i8) = gen_buf::<T>(1..1000);
+        let (mut a, mut a_i8) = gen_buf_balanced::<T>(1..1000);
 
         fuzz(100, || {
             let mut sl = a.as_slice_mut();
@@ -147,7 +147,7 @@ fn set_generic_unbalanced<T: raw::RawEncodingBuf + Clone>() {
 
 fn chunks_generic<T: raw::RawEncodingBuf + Clone>() {
     fuzz(100, || {
-        let (a, a_i8) = gen_buf::<T>(2..1000);
+        let (a, a_i8) = gen_buf_balanced::<T>(2..1000);
 
         let chunk_len = thread_rng().gen_range(1..a.len());
         for (a, a_i8) in a.chunks(chunk_len).zip(a_i8.chunks(chunk_len)) {
@@ -178,7 +178,7 @@ fn chunks_generic_unbalanced<T: raw::RawEncodingBuf + Clone>() {
 }
 
 fn set_panic_generic<T: raw::RawEncodingBuf + Clone>() {
-    let mut a = gen_buf::<T>(0..1000).0;
+    let mut a = gen_buf_balanced::<T>(0..1000).0;
     let len = a.len();
     a.set(len, <T::Slice as raw::RawEncoding>::Trit::zero());
 }
@@ -233,7 +233,7 @@ fn chunks() {
 #[test]
 fn chunks_mut() {
     fuzz(100, || {
-        let (mut a, mut a_i8) = gen_buf::<T1B1Buf>(2..1000);
+        let (mut a, mut a_i8) = gen_buf_balanced::<T1B1Buf>(2..1000);
 
         let chunk_len = thread_rng().gen_range(1..a.len());
         for (a, a_i8) in a.chunks_mut(chunk_len).zip(a_i8.chunks_mut(chunk_len)) {


### PR DESCRIPTION
# Description of change

Remove extra allocations by using `TritBuf::with_capacity()` within `b1t6::encode`.

## Links to any relevant issues

This might also improve the performance numbers from #808. 

## Type of change

Choose a type of change, and delete any options that are not relevant.

- Bug fix (a non-breaking change which fixes an issue)

## How the change has been tested

Running the test cases.

Make sure to provide instructions for the maintainer as well as any relevant configurations.

## Change checklist

Tick the boxes that are relevant to your changes, and delete any items that are not.

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that new and existing unit tests pass locally with my changes
- [x] I have updated the CHANGELOG.md, if my changes are significant enough
