### PR TITLE
Implement `Packable` for buffers that use unbounded integer prefixes

### DIFF
--- a/bee-common/bee-packable/src/packable/prefix.rs
+++ b/bee-common/bee-packable/src/packable/prefix.rs
@@ -23,8 +23,7 @@ use core::{
     marker::PhantomData,
 };
 
-/// Semantic error raised when converting a [`Vec`] into a [`VecPrefix`] or `Box<[_]>` into a
-/// `[BoxedSlicePrefix]`.
+/// Semantic error raised when converting a [`Vec`] into a [`VecPrefix`] or `Box<[_]>` into a `[BoxedSlicePrefix]`.
 #[derive(Debug)]
 pub enum TryIntoPrefixError<E> {
     /// The prefix length was truncated.

--- a/bee-common/bee-packable/src/packable/prefix.rs
+++ b/bee-common/bee-packable/src/packable/prefix.rs
@@ -106,14 +106,14 @@ impl<T, B: Bounded> Default for VecPrefix<T, B> {
 }
 
 macro_rules! impl_vec_prefix {
-    ($ty:ident, $bounded:ident, $err:ident) => {
-        impl<T, const MIN: $ty, const MAX: $ty> TryFrom<Vec<T>> for VecPrefix<T, $bounded<MIN, MAX>> {
-            type Error = TryIntoPrefixError<$err<MIN, MAX>>;
+    ($ty:ty, $bounded:ty, $err:ty, $unpack_err:ty, $map_err:expr, $($generics:tt)*) => {
+        impl<T, $($generics)*> TryFrom<Vec<T>> for VecPrefix<T, $bounded> {
+            type Error = TryIntoPrefixError<$err>;
 
             fn try_from(vec: Vec<T>) -> Result<Self, Self::Error> {
                 let len = vec.len();
                 let _ =
-                    $bounded::<MIN, MAX>::try_from($ty::try_from(len).map_err(|_| TryIntoPrefixError::Truncated(len))?)
+                    <$bounded>::try_from(<$ty>::try_from(len).map_err(|_| TryIntoPrefixError::Truncated(len))?)
                         .map_err(TryIntoPrefixError::Invalid)?;
 
                 Ok(Self {
@@ -123,29 +123,29 @@ macro_rules! impl_vec_prefix {
             }
         }
 
-        impl<'a, T, const MIN: $ty, const MAX: $ty> TryFrom<&'a Vec<T>> for &'a VecPrefix<T, $bounded<MIN, MAX>> {
-            type Error = TryIntoPrefixError<$err<MIN, MAX>>;
+        impl<'a, T, $($generics)*> TryFrom<&'a Vec<T>> for &'a VecPrefix<T, $bounded> {
+            type Error = TryIntoPrefixError<$err>;
 
             fn try_from(vec: &Vec<T>) -> Result<Self, Self::Error> {
                 let len = vec.len();
                 let _ =
-                    $bounded::<MIN, MAX>::try_from($ty::try_from(len).map_err(|_| TryIntoPrefixError::Truncated(len))?)
+                    <$bounded>::try_from(<$ty>::try_from(len).map_err(|_| TryIntoPrefixError::Truncated(len))?)
                         .map_err(TryIntoPrefixError::Invalid)?;
 
                 // SAFETY: `Vec<T>` and `VecPrefix<T, B>` have the same layout.
-                Ok(unsafe { &*(vec as *const Vec<T> as *const VecPrefix<T, $bounded<MIN, MAX>>) })
+                Ok(unsafe { &*(vec as *const Vec<T> as *const VecPrefix<T, $bounded>) })
             }
         }
 
         /// We cannot provide a [`From`] implementation because [`Vec`] is not from this crate.
         #[allow(clippy::from_over_into)]
-        impl<T, const MIN: $ty, const MAX: $ty> Into<Vec<T>> for VecPrefix<T, $bounded<MIN, MAX>> {
+        impl<T, $($generics)*> Into<Vec<T>> for VecPrefix<T, $bounded> {
             fn into(self) -> Vec<T> {
                 self.inner
             }
         }
 
-        impl<T, const MIN: $ty, const MAX: $ty> core::ops::Deref for VecPrefix<T, $bounded<MIN, MAX>> {
+        impl<T, $($generics)*> core::ops::Deref for VecPrefix<T, $bounded> {
             type Target = Vec<T>;
 
             fn deref(&self) -> &Self::Target {
@@ -153,8 +153,8 @@ macro_rules! impl_vec_prefix {
             }
         }
 
-        impl<T: Packable, const MIN: $ty, const MAX: $ty> Packable for VecPrefix<T, $bounded<MIN, MAX>> {
-            type UnpackError = UnpackPrefixError<T::UnpackError, $err<MIN, MAX>>;
+        impl<T: Packable, $($generics)*> Packable for VecPrefix<T, $bounded> {
+            type UnpackError = $unpack_err;
 
             fn pack<P: Packer>(&self, packer: &mut P) -> Result<(), P::Error> {
                 // The length of any dynamically-sized sequence must be prefixed.
@@ -172,8 +172,8 @@ macro_rules! impl_vec_prefix {
                 unpacker: &mut U,
             ) -> Result<Self, UnpackError<Self::UnpackError, U::Error>> {
                 // The length of any dynamically-sized sequence must be prefixed.
-                let len = <$bounded<MIN, MAX>>::unpack::<_, VERIFY>(unpacker)
-                    .map_packable_err(UnpackPrefixError::Prefix)?
+                let len: $ty = <$bounded>::unpack::<_, VERIFY>(unpacker)
+                    .map_packable_err($map_err)?
                     .into();
 
                 let mut inner = Vec::with_capacity(len as usize);
@@ -192,10 +192,15 @@ macro_rules! impl_vec_prefix {
     };
 }
 
-impl_vec_prefix!(u8, BoundedU8, InvalidBoundedU8);
-impl_vec_prefix!(u16, BoundedU16, InvalidBoundedU16);
-impl_vec_prefix!(u32, BoundedU32, InvalidBoundedU32);
-impl_vec_prefix!(u64, BoundedU64, InvalidBoundedU64);
+impl_vec_prefix!(u8, u8, Infallible, T::UnpackError, |err| match err {},);
+impl_vec_prefix!(u16, u16, Infallible, T::UnpackError, |err| match err {},);
+impl_vec_prefix!(u32, u32, Infallible, T::UnpackError, |err| match err {},);
+impl_vec_prefix!(u64, u64, Infallible, T::UnpackError, |err| match err {},);
+
+impl_vec_prefix!(u8, BoundedU8<MIN, MAX>, InvalidBoundedU8<MIN, MAX>, UnpackPrefixError<T::UnpackError, InvalidBoundedU8<MIN, MAX>>, UnpackPrefixError::Prefix, const MIN: u8, const MAX: u8);
+impl_vec_prefix!(u16, BoundedU16<MIN, MAX>, InvalidBoundedU16<MIN, MAX>, UnpackPrefixError<T::UnpackError, InvalidBoundedU16<MIN, MAX>>, UnpackPrefixError::Prefix, const MIN: u16, const MAX: u16);
+impl_vec_prefix!(u32, BoundedU32<MIN, MAX>, InvalidBoundedU32<MIN, MAX>, UnpackPrefixError<T::UnpackError, InvalidBoundedU32<MIN, MAX>>, UnpackPrefixError::Prefix, const MIN: u32, const MAX: u32);
+impl_vec_prefix!(u64, BoundedU64<MIN, MAX>, InvalidBoundedU64<MIN, MAX>, UnpackPrefixError<T::UnpackError, InvalidBoundedU64<MIN, MAX>>, UnpackPrefixError::Prefix, const MIN: u64, const MAX: u64);
 
 /// Wrapper type for `Box<[T]>` with a length prefix.
 /// The boxed slice's prefix bounds are provided by `B`, where `B` is a [`Bounded`] type.
@@ -218,14 +223,14 @@ impl<T, B: Bounded> Default for BoxedSlicePrefix<T, B> {
 }
 
 macro_rules! impl_boxed_slice_prefix {
-    ($ty:ident, $bounded:ident, $err:ident) => {
-        impl<T, const MIN: $ty, const MAX: $ty> TryFrom<Box<[T]>> for BoxedSlicePrefix<T, $bounded<MIN, MAX>> {
-            type Error = TryIntoPrefixError<$err<MIN, MAX>>;
+    ($ty:ty, $bounded:ty, $err:ty, $unpack_err:ty, $map_err:expr, $($generics:tt)*) => {
+        impl<T, $($generics)*> TryFrom<Box<[T]>> for BoxedSlicePrefix<T, $bounded> {
+            type Error = TryIntoPrefixError<$err>;
 
             fn try_from(boxed_slice: Box<[T]>) -> Result<Self, Self::Error> {
                 let len = boxed_slice.len();
                 let _ =
-                    $bounded::<MIN, MAX>::try_from($ty::try_from(len).map_err(|_| TryIntoPrefixError::Truncated(len))?)
+                    <$bounded>::try_from(<$ty>::try_from(len).map_err(|_| TryIntoPrefixError::Truncated(len))?)
                         .map_err(TryIntoPrefixError::Invalid)?;
 
                 Ok(Self {
@@ -235,31 +240,31 @@ macro_rules! impl_boxed_slice_prefix {
             }
         }
 
-        impl<'a, T, const MIN: $ty, const MAX: $ty> TryFrom<&'a Box<[T]>>
-            for &'a BoxedSlicePrefix<T, $bounded<MIN, MAX>>
+        impl<'a, T, $($generics)*> TryFrom<&'a Box<[T]>>
+            for &'a BoxedSlicePrefix<T, $bounded>
         {
-            type Error = TryIntoPrefixError<$err<MIN, MAX>>;
+            type Error = TryIntoPrefixError<$err>;
 
             fn try_from(boxed_slice: &Box<[T]>) -> Result<Self, Self::Error> {
                 let len = boxed_slice.len();
                 let _ =
-                    $bounded::<MIN, MAX>::try_from($ty::try_from(len).map_err(|_| TryIntoPrefixError::Truncated(len))?)
+                    <$bounded>::try_from(<$ty>::try_from(len).map_err(|_| TryIntoPrefixError::Truncated(len))?)
                         .map_err(TryIntoPrefixError::Invalid)?;
 
                 // SAFETY: `Box<[T]>` and `BoxedSlicePrefix<T, B>` have the same layout.
-                Ok(unsafe { &*(boxed_slice as *const Box<[T]> as *const BoxedSlicePrefix<T, $bounded<MIN, MAX>>) })
+                Ok(unsafe { &*(boxed_slice as *const Box<[T]> as *const BoxedSlicePrefix<T, $bounded>) })
             }
         }
 
         /// We cannot provide a [`From`] implementation because [`Vec`] is not from this crate.
         #[allow(clippy::from_over_into)]
-        impl<T, const MIN: $ty, const MAX: $ty> Into<Box<[T]>> for BoxedSlicePrefix<T, $bounded<MIN, MAX>> {
+        impl<T, $($generics)*> Into<Box<[T]>> for BoxedSlicePrefix<T, $bounded> {
             fn into(self) -> Box<[T]> {
                 self.inner
             }
         }
 
-        impl<T, const MIN: $ty, const MAX: $ty> core::ops::Deref for BoxedSlicePrefix<T, $bounded<MIN, MAX>> {
+        impl<T, $($generics)*> core::ops::Deref for BoxedSlicePrefix<T, $bounded> {
             type Target = Box<[T]>;
 
             fn deref(&self) -> &Self::Target {
@@ -267,8 +272,8 @@ macro_rules! impl_boxed_slice_prefix {
             }
         }
 
-        impl<T: Packable, const MIN: $ty, const MAX: $ty> Packable for BoxedSlicePrefix<T, $bounded<MIN, MAX>> {
-            type UnpackError = UnpackPrefixError<T::UnpackError, $err<MIN, MAX>>;
+        impl<T: Packable, $($generics)*> Packable for BoxedSlicePrefix<T, $bounded> {
+            type UnpackError = $unpack_err;
 
             fn pack<P: Packer>(&self, packer: &mut P) -> Result<(), P::Error> {
                 // The length of any dynamically-sized sequence must be prefixed.
@@ -286,8 +291,8 @@ macro_rules! impl_boxed_slice_prefix {
                 unpacker: &mut U,
             ) -> Result<Self, UnpackError<Self::UnpackError, U::Error>> {
                 // The length of any dynamically-sized sequence must be prefixed.
-                let len = <$bounded<MIN, MAX>>::unpack::<_, VERIFY>(unpacker)
-                    .map_packable_err(UnpackPrefixError::Prefix)?
+                let len: $ty = <$bounded>::unpack::<_, VERIFY>(unpacker)
+                    .map_packable_err($map_err)?
                     .into();
 
                 let mut inner = Vec::with_capacity(len as usize);
@@ -306,7 +311,12 @@ macro_rules! impl_boxed_slice_prefix {
     };
 }
 
-impl_boxed_slice_prefix!(u8, BoundedU8, InvalidBoundedU8);
-impl_boxed_slice_prefix!(u16, BoundedU16, InvalidBoundedU16);
-impl_boxed_slice_prefix!(u32, BoundedU32, InvalidBoundedU32);
-impl_boxed_slice_prefix!(u64, BoundedU64, InvalidBoundedU64);
+impl_boxed_slice_prefix!(u8, u8, Infallible, T::UnpackError, |err| match err {},);
+impl_boxed_slice_prefix!(u16, u16, Infallible, T::UnpackError, |err| match err {},);
+impl_boxed_slice_prefix!(u32, u32, Infallible, T::UnpackError, |err| match err {},);
+impl_boxed_slice_prefix!(u64, u64, Infallible, T::UnpackError, |err| match err {},);
+
+impl_boxed_slice_prefix!(u8, BoundedU8<MIN, MAX>, InvalidBoundedU8<MIN, MAX>, UnpackPrefixError<T::UnpackError, InvalidBoundedU8<MIN, MAX>>, UnpackPrefixError::Prefix, const MIN: u8, const MAX: u8);
+impl_boxed_slice_prefix!(u16, BoundedU16<MIN, MAX>, InvalidBoundedU16<MIN, MAX>, UnpackPrefixError<T::UnpackError, InvalidBoundedU16<MIN, MAX>>, UnpackPrefixError::Prefix, const MIN: u16, const MAX: u16);
+impl_boxed_slice_prefix!(u32, BoundedU32<MIN, MAX>, InvalidBoundedU32<MIN, MAX>, UnpackPrefixError<T::UnpackError, InvalidBoundedU32<MIN, MAX>>, UnpackPrefixError::Prefix, const MIN: u32, const MAX: u32);
+impl_boxed_slice_prefix!(u64, BoundedU64<MIN, MAX>, InvalidBoundedU64<MIN, MAX>, UnpackPrefixError<T::UnpackError, InvalidBoundedU64<MIN, MAX>>, UnpackPrefixError::Prefix, const MIN: u64, const MAX: u64);

--- a/bee-common/bee-packable/tests/boxed_slice_prefix.rs
+++ b/bee-common/bee-packable/tests/boxed_slice_prefix.rs
@@ -13,6 +13,25 @@ use bee_packable::{
     PackableExt,
 };
 
+#[test]
+fn boxed_slice_prefix_from_boxed_slice_invalid_error() {
+    let boxed_slice = vec![0u8; 16].into_boxed_slice();
+    let prefixed = BoxedSlicePrefix::<u8, BoundedU32<1, 8>>::try_from(boxed_slice);
+
+    assert!(matches!(
+        prefixed,
+        Err(TryIntoPrefixError::Invalid(InvalidBoundedU32(16)))
+    ));
+}
+
+#[test]
+fn boxed_slice_prefix_from_boxed_slice_truncated_error() {
+    let boxed_slice = vec![0u8; 257].into_boxed_slice();
+    let prefixed = BoxedSlicePrefix::<u8, u8>::try_from(boxed_slice);
+
+    assert!(matches!(prefixed, Err(TryIntoPrefixError::Truncated(257))));
+}
+
 macro_rules! impl_packable_test_for_boxed_slice_prefix {
     ($packable_boxed_slice_prefix:ident, $packable_boxed_slice_prefix_invalid_length:ident, $ty:ty) => {
         #[test]
@@ -127,22 +146,3 @@ impl_packable_test_for_bounded_boxed_slice_prefix!(
     1,
     64
 );
-
-#[test]
-fn packable_boxed_slice_prefix_from_boxed_slice_invalid_error() {
-    let boxed_slice = vec![0u8; 16].into_boxed_slice();
-    let prefixed = BoxedSlicePrefix::<u8, BoundedU32<1, 8>>::try_from(boxed_slice);
-
-    assert!(matches!(
-        prefixed,
-        Err(TryIntoPrefixError::Invalid(InvalidBoundedU32(16)))
-    ));
-}
-
-#[test]
-fn packable_boxed_slice_prefix_from_boxed_slice_truncated_error() {
-    let boxed_slice = vec![0u8; 257].into_boxed_slice();
-    let prefixed = BoxedSlicePrefix::<u8, u8>::try_from(boxed_slice);
-
-    assert!(matches!(prefixed, Err(TryIntoPrefixError::Truncated(257))));
-}

--- a/bee-common/bee-packable/tests/boxed_slice_prefix.rs
+++ b/bee-common/bee-packable/tests/boxed_slice_prefix.rs
@@ -13,6 +13,7 @@ use bee_packable::{
     PackableExt,
 };
 macro_rules! impl_packable_test_for_boxed_slice_prefix {
+
     ($packable_boxed_slice_prefix:ident, $packable_boxed_slice_prefix_invalid_length:ident, $ty:ty) => {
         #[test]
         fn $packable_boxed_slice_prefix() {

--- a/bee-common/bee-packable/tests/boxed_slice_prefix.rs
+++ b/bee-common/bee-packable/tests/boxed_slice_prefix.rs
@@ -1,0 +1,147 @@
+// Copyright 2021 IOTA Stiftung
+// SPDX-License-Identifier: Apache-2.0
+
+mod common;
+
+use bee_packable::{
+    bounded::{
+        BoundedU16, BoundedU32, BoundedU64, BoundedU8, InvalidBoundedU16, InvalidBoundedU32, InvalidBoundedU64,
+        InvalidBoundedU8,
+    },
+    error::UnpackError,
+    prefix::{BoxedSlicePrefix, TryIntoPrefixError, UnpackPrefixError},
+    PackableExt,
+};
+macro_rules! impl_packable_test_for_boxed_slice_prefix {
+    ($packable_boxed_slice_prefix:ident, $packable_boxed_slice_prefix_invalid_length:ident, $ty:ty) => {
+        #[test]
+        fn $packable_boxed_slice_prefix() {
+            assert_eq!(
+                common::generic_test(
+                    <&BoxedSlicePrefix<Option<u32>, $ty>>::try_from(&vec![Some(0u32), None].into_boxed_slice())
+                        .unwrap()
+                )
+                .0
+                .len(),
+                core::mem::size_of::<$ty>()
+                    + (core::mem::size_of::<u8>() + core::mem::size_of::<u32>())
+                    + core::mem::size_of::<u8>()
+            );
+        }
+    };
+}
+
+macro_rules! impl_packable_test_for_bounded_boxed_slice_prefix {
+    ($packable_boxed_slice_prefix:ident, $packable_boxed_slice_prefix_invalid_length:ident, $ty:ty, $bounded:ident, $err:ident, $min:expr, $max:expr) => {
+        #[test]
+        fn $packable_boxed_slice_prefix() {
+            assert_eq!(
+                common::generic_test(
+                    <&BoxedSlicePrefix<Option<u32>, $bounded<$min, $max>>>::try_from(
+                        &vec![Some(0u32), None].into_boxed_slice()
+                    )
+                    .unwrap()
+                )
+                .0
+                .len(),
+                core::mem::size_of::<$ty>()
+                    + (core::mem::size_of::<u8>() + core::mem::size_of::<u32>())
+                    + core::mem::size_of::<u8>()
+            );
+        }
+
+        #[test]
+        fn $packable_boxed_slice_prefix_invalid_length() {
+            const LEN: usize = $max + 1;
+
+            let mut bytes = vec![0u8; LEN + 1].into_boxed_slice();
+            bytes[0] = LEN as u8;
+
+            let prefixed = BoxedSlicePrefix::<u8, $bounded<$min, $max>>::unpack_verified(bytes);
+
+            const LEN_AS_TY: $ty = LEN as $ty;
+
+            assert!(matches!(
+                prefixed,
+                Err(UnpackError::Packable(UnpackPrefixError::Prefix($err(LEN_AS_TY)))),
+            ));
+        }
+    };
+}
+
+impl_packable_test_for_boxed_slice_prefix!(
+    packable_boxed_slice_prefix_u8,
+    packable_boxed_slice_prefix_invalid_length_u8,
+    u8
+);
+impl_packable_test_for_boxed_slice_prefix!(
+    packable_boxed_slice_prefix_u16,
+    packable_boxed_slice_prefix_invalid_length_u16,
+    u16
+);
+impl_packable_test_for_boxed_slice_prefix!(
+    packable_boxed_slice_prefix_u32,
+    packable_boxed_slice_prefix_invalid_length_u32,
+    u32
+);
+impl_packable_test_for_boxed_slice_prefix!(
+    packable_boxed_slice_prefix_u64,
+    packable_boxed_slice_prefix_invalid_length_u64,
+    u64
+);
+
+impl_packable_test_for_bounded_boxed_slice_prefix!(
+    packable_boxed_slice_prefix_bounded_u8,
+    packable_boxed_slice_prefix_invalid_length_bounded_u8,
+    u8,
+    BoundedU8,
+    InvalidBoundedU8,
+    1,
+    64
+);
+impl_packable_test_for_bounded_boxed_slice_prefix!(
+    packable_boxed_slice_prefix_bounded_u16,
+    packable_boxed_slice_prefix_invalid_length_bounded_u16,
+    u16,
+    BoundedU16,
+    InvalidBoundedU16,
+    1,
+    64
+);
+impl_packable_test_for_bounded_boxed_slice_prefix!(
+    packable_boxed_slice_prefix_bounded_u32,
+    packable_boxed_slice_prefix_invalid_length_bounded_u32,
+    u32,
+    BoundedU32,
+    InvalidBoundedU32,
+    1,
+    64
+);
+impl_packable_test_for_bounded_boxed_slice_prefix!(
+    packable_boxed_slice_prefix_bounded_u64,
+    packable_boxed_slice_prefix_invalid_length_bounded_u64,
+    u64,
+    BoundedU64,
+    InvalidBoundedU64,
+    1,
+    64
+);
+
+#[test]
+fn packable_boxed_slice_prefix_from_boxed_slice_invalid_error() {
+    let boxed_slice = vec![0u8; 16].into_boxed_slice();
+    let prefixed = BoxedSlicePrefix::<u8, BoundedU32<1, 8>>::try_from(boxed_slice);
+
+    assert!(matches!(
+        prefixed,
+        Err(TryIntoPrefixError::Invalid(InvalidBoundedU32(16)))
+    ));
+}
+
+#[test]
+fn packable_boxed_slice_prefix_from_boxed_slice_truncated_error() {
+    let boxed_slice = vec![0u8; 257].into_boxed_slice();
+    let prefixed = BoxedSlicePrefix::<u8, u8>::try_from(boxed_slice);
+
+    assert!(matches!(prefixed, Err(TryIntoPrefixError::Truncated(257))));
+}

--- a/bee-common/bee-packable/tests/boxed_slice_prefix.rs
+++ b/bee-common/bee-packable/tests/boxed_slice_prefix.rs
@@ -12,8 +12,8 @@ use bee_packable::{
     prefix::{BoxedSlicePrefix, TryIntoPrefixError, UnpackPrefixError},
     PackableExt,
 };
-macro_rules! impl_packable_test_for_boxed_slice_prefix {
 
+macro_rules! impl_packable_test_for_boxed_slice_prefix {
     ($packable_boxed_slice_prefix:ident, $packable_boxed_slice_prefix_invalid_length:ident, $ty:ty) => {
         #[test]
         fn $packable_boxed_slice_prefix() {

--- a/bee-common/bee-packable/tests/vec_prefix.rs
+++ b/bee-common/bee-packable/tests/vec_prefix.rs
@@ -13,6 +13,25 @@ use bee_packable::{
     PackableExt,
 };
 
+#[test]
+fn packable_vec_prefix_from_vec_invalid_error() {
+    let vec = vec![0u8; 16];
+    let prefixed = VecPrefix::<u8, BoundedU32<1, 8>>::try_from(vec);
+
+    assert!(matches!(
+        prefixed,
+        Err(TryIntoPrefixError::Invalid(InvalidBoundedU32(16)))
+    ));
+}
+
+#[test]
+fn packable_vec_prefix_from_vec_truncated_error() {
+    let vec = vec![0u8; 257];
+    let prefixed = VecPrefix::<u8, u8>::try_from(vec);
+
+    assert!(matches!(prefixed, Err(TryIntoPrefixError::Truncated(257))));
+}
+
 macro_rules! impl_packable_test_for_vec_prefix {
     ($packable_vec_prefix:ident, $packable_vec_prefix_invalid_length:ident, $ty:ty) => {
         #[test]
@@ -105,22 +124,3 @@ impl_packable_test_for_bounded_vec_prefix!(
     1,
     64
 );
-
-#[test]
-fn packable_vec_prefix_from_vec_invalid_error() {
-    let vec = vec![0u8; 16];
-    let prefixed = VecPrefix::<u8, BoundedU32<1, 8>>::try_from(vec);
-
-    assert!(matches!(
-        prefixed,
-        Err(TryIntoPrefixError::Invalid(InvalidBoundedU32(16)))
-    ));
-}
-
-#[test]
-fn packable_vec_prefix_from_vec_truncated_error() {
-    let vec = vec![0u8; 257];
-    let prefixed = VecPrefix::<u8, u8>::try_from(vec);
-
-    assert!(matches!(prefixed, Err(TryIntoPrefixError::Truncated(257))));
-}

--- a/bee-common/bee-packable/tests/vec_prefix.rs
+++ b/bee-common/bee-packable/tests/vec_prefix.rs
@@ -12,6 +12,7 @@ use bee_packable::{
     prefix::{TryIntoPrefixError, UnpackPrefixError, VecPrefix},
     PackableExt,
 };
+
 macro_rules! impl_packable_test_for_vec_prefix {
     ($packable_vec_prefix:ident, $packable_vec_prefix_invalid_length:ident, $ty:ty) => {
         #[test]


### PR DESCRIPTION
# Description of change

This PR implements `Packable` for `VecPrefix<T, B>` and `BoxedSlicePrefix<T, B>` with `B = {u8, u16, u32, u64}`.

## Type of change

- Enhancement (a non-breaking change which adds functionality)

## How the change has been tested

New tests were added.

## Change checklist

Tick the boxes that are relevant to your changes, and delete any items that are not.

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that new and existing unit tests pass locally with my changes
- [x] I have updated the CHANGELOG.md, if my changes are significant enough
