### PR TITLE
Use the `depinfo` backend for `cargo-udeps`

### DIFF
--- a/.github/workflows/udeps.yml
+++ b/.github/workflows/udeps.yml
@@ -48,4 +48,4 @@ jobs:
     - uses: actions-rs/cargo@v1
       with:
         command: udeps
-        args: --all-targets --all-features
+        args: --all-targets --all-features --backend=depinfo


### PR DESCRIPTION
The main reason for this change is that the `save-analysis` API is hardly maintained and causes some ICEs that propagate to the `cargo-udeps` workflow. Also `depinfo` is planned to be stabilized meaning that `cargo-udeps` could eventually run in rust stable using this backend.