### PR TITLE
Avoid wrappers for `no_std` packers and unpackers

### DIFF
--- a/bee-common/bee-packable-derive/tests/fail/incorrect_tag_enum.stderr
+++ b/bee-common/bee-packable-derive/tests/fail/incorrect_tag_enum.stderr
@@ -7,7 +7,7 @@ error[E0308]: mismatched types
 help: change the type of the numeric literal from `u32` to `u8`
    |
 14 |     #[packable(tag = 0u8)]
-   |                      ~~~
+   |                       ~~
 
 error[E0308]: mismatched types
   --> tests/fail/incorrect_tag_enum.rs:10:10

--- a/bee-common/bee-packable-derive/tests/fail/invalid_packable_with.stderr
+++ b/bee-common/bee-packable-derive/tests/fail/invalid_packable_with.stderr
@@ -1,6 +1,8 @@
 error[E0593]: function is expected to take 1 argument, but it takes 0 arguments
   --> tests/fail/invalid_packable_with.rs:11:46
    |
+10 | #[derive(Packable)]
+   |          -------- required by a bound introduced by this call
 11 | #[packable(unpack_error = Impossible, with = Impossible::new)]
    |                                              ^^^^^^^^^^^^^^^ expected function that takes 1 argument
 ...

--- a/bee-common/bee-packable/src/error.rs
+++ b/bee-common/bee-packable/src/error.rs
@@ -15,8 +15,8 @@ mod sealed {
 
 /// Trait providing utility methods for [`Result`] values that use [`UnpackError`] as the `Err` variant.
 ///
-/// The main disadvantage of using `Result<_, UnpackError<_, _>>` is that error coercion must be
-/// done explicitly. This trait attempts to ease these conversions.
+/// The main disadvantage of using `Result<_, UnpackError<_, _>>` is that error coercion must be done explicitly.
+/// This trait attempts to ease these conversions.
 ///
 /// This trait is sealed and cannot be implemented by any other type.
 pub trait UnpackErrorExt<T, U, V>: sealed::Sealed + Sized {

--- a/bee-common/bee-packable/src/error.rs
+++ b/bee-common/bee-packable/src/error.rs
@@ -94,8 +94,8 @@ impl<T> From<Infallible> for UnknownTagError<T> {
     }
 }
 
-/// Error type to be raised when [`SliceUnpacker`](`crate::unpacker::SliceUnpacker`) does not have enough bytes to
-/// unpack something or when [`SlicePacker`]('crate::packer::SlicePacker') does not have enough space to pack something.
+/// Error type to be raised when [`&[u8]`] does not have enough bytes to unpack something or when
+/// [`SlicePacker`]('crate::packer::SlicePacker') does not have enough space to pack something.
 #[derive(Debug)]
 pub struct UnexpectedEOF {
     /// The required number of bytes.

--- a/bee-common/bee-packable/src/lib.rs
+++ b/bee-common/bee-packable/src/lib.rs
@@ -3,9 +3,8 @@
 
 //! A module that provides a [`Packable`] trait to serialize and deserialize types.
 //!
-//! For more information about the design of this crate please read the [`Packable`],
-//! [`unpacker`], [`packer`], [`UnpackError`](error::UnpackError) and
-//! [`UnpackErrorExt`](error::UnpackErrorExt) documentation.
+//! For more information about the design of this crate please read the [`Packable`], [`unpacker`], [`packer`],
+//! [`UnpackError`](error::UnpackError) and [`UnpackErrorExt`](error::UnpackErrorExt) documentation.
 //!
 //! # Motivation
 //!
@@ -15,10 +14,10 @@
 //!
 //! ## The old `Packable` trait
 //!
-//! The need for a serialization API existed before Coordicide. Efforts to satisfy this need
-//! culminated with the introduction of the `Packable` trait in the `bee-common` crate during the
-//! Chrysalis part 2 period. Most of the design decisions behind this crate were done to simplify
-//! the serialization of the [IOTA protocol messages](https://github.com/iotaledger/protocol-rfcs/pull/0017).
+//! The need for a serialization API existed before Coordicide. Efforts to satisfy this need culminated with the
+//! introduction of the `Packable` trait in the `bee-common` crate during the Chrysalis part 2 period.
+//! Most of the design decisions behind this crate were done to simplify the serialization of the
+//! [IOTA protocol messages](https://github.com/iotaledger/protocol-rfcs/pull/0017).
 //! The proposed trait was the following:
 //!
 //! ```
@@ -36,30 +35,28 @@
 //!         Self: Sized;
 //! }
 //! ```
-//! The main issue with this trait is that it cannot be used in a `no_std` environment because it
-//! depends explicitly on the [`std::io`] API, whose transition to the [`core`] crate has not been
-//! decided yet.  Another issue is that the `Error` type is used to represent three different kinds
-//! of errors:
+//! The main issue with this trait is that it cannot be used in a `no_std` environment because it depends explicitly on
+//! the [`std::io`] API, whose transition to the [`core`] crate has not been decided yet.
+//! Another issue is that the `Error` type is used to represent three different kinds of errors:
 //!
 //! - Writing errors: Raised when there are issues while writing bytes.
 //! - Reading errors: Raised when there are issues while reading bytes.
-//! - Deserialization errors: Raised when the bytes being used to create a value are invalid for
-//! the data layout of such value.
+//! - Deserialization errors: Raised when the bytes being used to create a value are invalid for the data layout of such
+//! value.
 //!
 //! # Replacing [`std::io`]
 //!
-//! We introduced the [`Packer`](packer::Packer) and [`Unpacker`](unpacker::Unpacker) taits to
-//! abstract away any IO operation without relying on [`std::io`]. This has the additional benefit
-//! of allowing us to pack and unpack values from different kinds of buffers.
+//! We introduced the [`Packer`](packer::Packer) and [`Unpacker`](unpacker::Unpacker) taits to abstract away any IO
+//! operation without relying on [`std::io`]. This has the additional benefit of allowing us to pack and unpack values
+//! from different kinds of buffers.
 //!
 //! # Types that implement [`Packable`]
 //!
-//! The [`Packable`] trait is implemented for every integer type by encoding the value as an array
-//! of bytes in little-endian order. Booleans are packed following Rust's data layout, meaning that
-//! `true` is packed as a `1` byte and `false` as a `0` byte. However, boolean unpacking is less
-//! strict and unpacks any non-zero byte as `true`. Additional implementations of [`Packable`] are
-//! provided for [`Vec<T>`](std::vec::Vec), `Box<[T]>`, `[T; N]` and [`Option<T>`] if T implements
-//! [`Packable`].
+//! The [`Packable`] trait is implemented for every integer type by encoding the value as an array of bytes in
+//! little-endian order. Booleans are packed following Rust's data layout, meaning that `true` is packed as a `1` byte
+//! and `false` as a `0` byte. However, boolean unpacking is less strict and unpacks any non-zero byte as `true`.
+//! Additional implementations of [`Packable`] are provided for [`Vec<T>`](std::vec::Vec), `Box<[T]>`, `[T; N]` and
+//! [`Option<T>`] if T implements [`Packable`].
 //!
 //! Check the [`Packable`] `impl` section for further information.
 

--- a/bee-common/bee-packable/src/packable/array.rs
+++ b/bee-common/bee-packable/src/packable/array.rs
@@ -25,8 +25,8 @@ impl<T: Packable, const N: usize> Packable for [T; N] {
 
         for item in array.iter_mut() {
             let unpacked = T::unpack::<_, VERIFY>(unpacker)?;
-            // Safety: each `item` is only visited once so we are never overwriting nor dropping
-            // values that are already initialized.
+            // Safety: each `item` is only visited once so we are never overwriting nor dropping values that are already
+            // initialized.
             unsafe {
                 item.as_mut_ptr().write(unpacked);
             }

--- a/bee-common/bee-packable/src/packable/mod.rs
+++ b/bee-common/bee-packable/src/packable/mod.rs
@@ -16,8 +16,8 @@ mod integer;
 
 use crate::{
     error::{UnexpectedEOF, UnpackError},
-    packer::{LenPacker, Packer, VecPacker},
-    unpacker::{SliceUnpacker, Unpacker},
+    packer::{LenPacker, Packer},
+    unpacker::Unpacker,
 };
 
 pub use bee_packable_derive::Packable;
@@ -131,19 +131,19 @@ impl<P: Packable> PackableExt for P {
     }
 
     fn pack_to_vec(&self) -> Vec<u8> {
-        let mut packer = VecPacker::with_capacity(self.packed_len());
+        let mut packer = Vec::with_capacity(self.packed_len());
 
         // Packing to a `VecPacker` cannot fail.
         self.pack(&mut packer).unwrap();
 
-        packer.into_vec()
+        packer
     }
 
     /// Unpacks this value from a type that implements [`AsRef<[u8]>`].
     fn unpack_verified<T: AsRef<[u8]>>(
         bytes: T,
     ) -> Result<Self, UnpackError<<Self as Packable>::UnpackError, UnexpectedEOF>> {
-        Self::unpack::<_, true>(&mut SliceUnpacker::new(bytes.as_ref()))
+        Self::unpack::<_, true>(&mut bytes.as_ref())
     }
 
     /// Unpacks this value from a type that implements [`AsRef<[u8]>`] skipping some syntatical
@@ -151,6 +151,6 @@ impl<P: Packable> PackableExt for P {
     fn unpack_unverified<T: AsRef<[u8]>>(
         bytes: T,
     ) -> Result<Self, UnpackError<<Self as Packable>::UnpackError, UnexpectedEOF>> {
-        Self::unpack::<_, false>(&mut SliceUnpacker::new(bytes.as_ref()))
+        Self::unpack::<_, false>(&mut bytes.as_ref())
     }
 }

--- a/bee-common/bee-packable/src/packable/mod.rs
+++ b/bee-common/bee-packable/src/packable/mod.rs
@@ -28,13 +28,11 @@ use core::{convert::AsRef, fmt::Debug};
 /// A type that can be packed and unpacked.
 ///
 /// Almost all basic sized types implement this trait. This trait can be derived using the
-/// [`Packable`](bee_packable_derive::Packable) macro. The following example shows how to implement
-/// this trait manually.
+/// [`Packable`](bee_packable_derive::Packable) macro. The following example shows how to implement this trait manually.
 ///
 /// # Example
 ///
-/// We will implement [`Packable`] for a type that encapsulates optional integer values (like
-/// `Option<i32>`).
+/// We will implement [`Packable`] for a type that encapsulates optional integer values (like `Option<i32>`).
 ///
 /// Following the conventions from the [IOTA protocol messages RFC](https:///github.com/iotaledger/protocol-rfcs/pull/0017),
 /// we will use an integer prefix as a tag to determine which variant of the enum is being packed.
@@ -85,16 +83,15 @@ use core::{convert::AsRef, fmt::Debug};
 pub trait Packable: Sized {
     /// The error type that can be returned if some semantic error occurs while unpacking.
     ///
-    /// It is recommended to use [`Infallible`](core::convert::Infallible) if this kind of error is
-    /// impossible or [`UnknownTagError`](crate::error::UnknownTagError) when implementing this
-    /// trait for an enum.
+    /// It is recommended to use [`Infallible`](core::convert::Infallible) if this kind of error is impossible or
+    /// [`UnknownTagError`](crate::error::UnknownTagError) when implementing this trait for an enum.
     type UnpackError: Debug;
 
     /// Packs this value into the given [`Packer`].
     fn pack<P: Packer>(&self, packer: &mut P) -> Result<(), P::Error>;
 
-    /// Unpacks this value from the given [`Unpacker`]. The `VERIFY` generic parameter can be used
-    /// to skip additional syntactic checks.
+    /// Unpacks this value from the given [`Unpacker`]. The `VERIFY` generic parameter can be used to skip additional
+    /// syntactic checks.
     fn unpack<U: Unpacker, const VERIFY: bool>(
         unpacker: &mut U,
     ) -> Result<Self, UnpackError<Self::UnpackError, U::Error>>;
@@ -102,8 +99,8 @@ pub trait Packable: Sized {
 
 /// Extension trait for types that implement [`Packable`].
 pub trait PackableExt: Packable {
-    /// Returns the length in bytes of the value after being packed. The returned value always
-    /// matches the number of bytes written using `pack`.
+    /// Returns the length in bytes of the value after being packed. The returned value always matches the number of
+    /// bytes written using `pack`.
     fn packed_len(&self) -> usize;
 
     /// Convenience method that packs this value into a [`Vec<u8>`].
@@ -146,8 +143,7 @@ impl<P: Packable> PackableExt for P {
         Self::unpack::<_, true>(&mut bytes.as_ref())
     }
 
-    /// Unpacks this value from a type that implements [`AsRef<[u8]>`] skipping some syntatical
-    /// checks.
+    /// Unpacks this value from a type that implements [`AsRef<[u8]>`] skipping some syntatical checks.
     fn unpack_unverified<T: AsRef<[u8]>>(
         bytes: T,
     ) -> Result<Self, UnpackError<<Self as Packable>::UnpackError, UnexpectedEOF>> {

--- a/bee-common/bee-packable/src/packable/prefix.rs
+++ b/bee-common/bee-packable/src/packable/prefix.rs
@@ -23,8 +23,7 @@ use core::{
     marker::PhantomData,
 };
 
-/// Semantic error raised when converting a [`Vec`] into a [`VecPrefix`] or `Box<[_]>` into a
-/// [`BoxedSlicePrefix`].
+/// Semantic error raised when converting a [`Vec`] into a [`VecPrefix`] or `Box<[_]>` into a [`BoxedSlicePrefix`].
 #[derive(Debug)]
 pub enum TryIntoPrefixError<E> {
     /// The prefix length was truncated.

--- a/bee-common/bee-packable/src/packer/io.rs
+++ b/bee-common/bee-packable/src/packer/io.rs
@@ -5,12 +5,38 @@ extern crate std;
 
 use crate::packer::Packer;
 
-use std::io::{self, Write};
+use std::{
+    io::{self, Write},
+    ops::Deref,
+};
 
-impl<W: Write> Packer for W {
+/// A [`Packer`] backed by [`Write`].
+pub struct IoPacker<W: Write>(W);
+
+impl<W: Write> IoPacker<W> {
+    /// Create a new [`Packer`] from a value that implements [`Write`].
+    pub fn new(writer: W) -> Self {
+        Self(writer)
+    }
+
+    /// Consume the value to return the inner value that implements [`Write`].
+    pub fn into_inner(self) -> W {
+        self.0
+    }
+}
+
+impl<W: Write> Deref for IoPacker<W> {
+    type Target = W;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+impl<W: Write> Packer for IoPacker<W> {
     type Error = io::Error;
 
     fn pack_bytes<B: AsRef<[u8]>>(&mut self, bytes: B) -> Result<(), Self::Error> {
-        self.write_all(bytes.as_ref())
+        self.0.write_all(bytes.as_ref())
     }
 }

--- a/bee-common/bee-packable/src/packer/io.rs
+++ b/bee-common/bee-packable/src/packer/io.rs
@@ -14,12 +14,12 @@ use std::{
 pub struct IoPacker<W: Write>(W);
 
 impl<W: Write> IoPacker<W> {
-    /// Create a new [`Packer`] from a value that implements [`Write`].
+    /// Creates a new [`Packer`] from a value that implements [`Write`].
     pub fn new(writer: W) -> Self {
         Self(writer)
     }
 
-    /// Consume the value to return the inner value that implements [`Write`].
+    /// Consumes the value to return the inner value that implements [`Write`].
     pub fn into_inner(self) -> W {
         self.0
     }

--- a/bee-common/bee-packable/src/packer/mod.rs
+++ b/bee-common/bee-packable/src/packer/mod.rs
@@ -3,8 +3,8 @@
 
 //! A module to pack any value that implements [`Packable`](crate::Packable).
 //!
-//! The [`Packer`] trait represents types that can be used to write bytes into it. It can be
-//! thought as a `no_std` friendly alternative to the [`Write`](std::io::Write) trait.
+//! The [`Packer`] trait represents types that can be used to write bytes into it. It can be thought as a `no_std`
+//! friendly alternative to the [`Write`](std::io::Write) trait.
 
 #[cfg(feature = "io")]
 mod io;
@@ -23,8 +23,7 @@ pub trait Packer {
     /// An error type representing any error related to writing bytes.
     type Error;
 
-    /// Writes a sequence of bytes into the [`Packer`]. The totality of `bytes` must be written
-    /// into the packer. This method **must** fail if the packer does not have enough space to
-    /// fulfill the request.
+    /// Writes a sequence of bytes into the [`Packer`]. The totality of `bytes` must be written into the packer.
+    /// This method **must** fail if the packer does not have enough space to fulfill the request.
     fn pack_bytes<B: AsRef<[u8]>>(&mut self, bytes: B) -> Result<(), Self::Error>;
 }

--- a/bee-common/bee-packable/src/packer/mod.rs
+++ b/bee-common/bee-packable/src/packer/mod.rs
@@ -14,8 +14,9 @@ mod vec;
 
 pub(crate) use len::LenPacker;
 
+#[cfg(feature = "io")]
+pub use io::IoPacker;
 pub use slice::SlicePacker;
-pub use vec::VecPacker;
 
 /// A type that can pack any value that implements [`Packable`](crate::Packable).
 pub trait Packer {

--- a/bee-common/bee-packable/src/packer/slice.rs
+++ b/bee-common/bee-packable/src/packer/slice.rs
@@ -10,7 +10,7 @@ pub struct SlicePacker<'a> {
 }
 
 impl<'a> SlicePacker<'a> {
-    /// Create a new [`SlicePacker`] from a `&mut [u8]`.
+    /// Creates a new [`SlicePacker`] from a `&mut [u8]`.
     pub fn new(slice: &'a mut [u8]) -> Self {
         Self { slice, offset: 0 }
     }

--- a/bee-common/bee-packable/src/packer/vec.rs
+++ b/bee-common/bee-packable/src/packer/vec.rs
@@ -6,52 +6,13 @@ extern crate alloc;
 use crate::packer::Packer;
 
 use alloc::vec::Vec;
-use core::{convert::Infallible, ops::Deref};
+use core::convert::Infallible;
 
-/// A [`Packer`] backed by a [`Vec<u8>`].
-#[derive(Default)]
-pub struct VecPacker(Vec<u8>);
-
-impl VecPacker {
-    /// Creates a new, empty packer.
-    pub fn new() -> Self {
-        Self::default()
-    }
-
-    /// Creates an empty packer with an initial capacity.
-    pub fn with_capacity(capacity: usize) -> Self {
-        Self(Vec::with_capacity(capacity))
-    }
-
-    /// Consumes the [`VecPacker`] and returns the inner [`Vec<u8>`].
-    pub fn into_vec(self) -> Vec<u8> {
-        self.0
-    }
-
-    /// Returns the number of packed bytes.
-    pub fn len(&self) -> usize {
-        self.0.len()
-    }
-
-    /// Returns `true` if no bytes have been packed yet.
-    pub fn is_empty(&self) -> bool {
-        self.0.is_empty()
-    }
-}
-
-impl Packer for VecPacker {
+impl Packer for Vec<u8> {
     type Error = Infallible;
 
     fn pack_bytes<B: AsRef<[u8]>>(&mut self, bytes: B) -> Result<(), Self::Error> {
-        self.0.extend_from_slice(bytes.as_ref());
+        self.extend_from_slice(bytes.as_ref());
         Ok(())
-    }
-}
-
-impl Deref for VecPacker {
-    type Target = Vec<u8>;
-
-    fn deref(&self) -> &Self::Target {
-        &self.0
     }
 }

--- a/bee-common/bee-packable/src/unpacker/io.rs
+++ b/bee-common/bee-packable/src/unpacker/io.rs
@@ -5,12 +5,38 @@ extern crate std;
 
 use crate::unpacker::Unpacker;
 
-use std::io::{self, Read};
+use std::{
+    io::{self, Read},
+    ops::Deref,
+};
 
-impl<R: Read> Unpacker for R {
+/// An [`Unpacker`] backed by [`Read`].
+pub struct IoUnpacker<R: Read>(R);
+
+impl<R: Read> IoUnpacker<R> {
+    /// Create a new [`Unpacker`] from a value that implements [`Read`].
+    pub fn new(writer: R) -> Self {
+        Self(writer)
+    }
+
+    /// Consume the value to return the inner value that implements [`Read`].
+    pub fn into_inner(self) -> R {
+        self.0
+    }
+}
+
+impl<R: Read> Deref for IoUnpacker<R> {
+    type Target = R;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+impl<R: Read> Unpacker for IoUnpacker<R> {
     type Error = io::Error;
 
     fn unpack_bytes<B: AsMut<[u8]>>(&mut self, mut bytes: B) -> Result<(), Self::Error> {
-        self.read_exact(bytes.as_mut())
+        self.0.read_exact(bytes.as_mut())
     }
 }

--- a/bee-common/bee-packable/src/unpacker/io.rs
+++ b/bee-common/bee-packable/src/unpacker/io.rs
@@ -14,12 +14,12 @@ use std::{
 pub struct IoUnpacker<R: Read>(R);
 
 impl<R: Read> IoUnpacker<R> {
-    /// Create a new [`Unpacker`] from a value that implements [`Read`].
+    /// Creates a new [`Unpacker`] from a value that implements [`Read`].
     pub fn new(writer: R) -> Self {
         Self(writer)
     }
 
-    /// Consume the value to return the inner value that implements [`Read`].
+    /// Consumes the value to return the inner value that implements [`Read`].
     pub fn into_inner(self) -> R {
         self.0
     }

--- a/bee-common/bee-packable/src/unpacker/mod.rs
+++ b/bee-common/bee-packable/src/unpacker/mod.rs
@@ -10,7 +10,8 @@
 mod io;
 mod slice;
 
-pub use slice::SliceUnpacker;
+#[cfg(feature = "io")]
+pub use io::IoUnpacker;
 
 /// A type that can unpack any value that implements [`Packable`](crate::Packable).
 pub trait Unpacker: Sized {

--- a/bee-common/bee-packable/src/unpacker/mod.rs
+++ b/bee-common/bee-packable/src/unpacker/mod.rs
@@ -3,8 +3,8 @@
 
 //! A module to unpack any value that implements [`Packable`](crate::Packable).
 //!
-//! The [`Unpacker`] trait represents types that can be used to read bytes from it. It can be
-//! thought as a `no_std` friendly alternative to the [`Read`](std::io::Read) trait.
+//! The [`Unpacker`] trait represents types that can be used to read bytes from it. It can be thought as a `no_std`
+//! friendly alternative to the [`Read`](std::io::Read) trait.
 
 #[cfg(feature = "io")]
 mod io;
@@ -18,8 +18,7 @@ pub trait Unpacker: Sized {
     /// An error type representing any error related to reading bytes.
     type Error;
 
-    /// Reads a sequence of bytes from the [`Unpacker`]. This sequence must be long enough to fill
-    /// `bytes` completely. This method **must** fail if the unpacker does not have enough bytes to
-    /// fulfill the request.
+    /// Reads a sequence of bytes from the [`Unpacker`]. This sequence must be long enough to fill `bytes` completely.
+    /// This method **must** fail if the unpacker does not have enough bytes to fulfill the request.
     fn unpack_bytes<B: AsMut<[u8]>>(&mut self, bytes: B) -> Result<(), Self::Error>;
 }

--- a/bee-common/bee-packable/src/unpacker/slice.rs
+++ b/bee-common/bee-packable/src/unpacker/slice.rs
@@ -3,32 +3,22 @@
 
 use crate::{error::UnexpectedEOF, unpacker::Unpacker};
 
-/// An [`Unpacker`] backed by a `&[u8]`.
-pub struct SliceUnpacker<'u>(&'u [u8]);
-
-impl<'u> SliceUnpacker<'u> {
-    /// Creates a new unpacker from a byte slice.
-    pub fn new(slice: &'u [u8]) -> Self {
-        Self(slice)
-    }
-}
-
-impl<'u> Unpacker for SliceUnpacker<'u> {
+impl<'u> Unpacker for &'u [u8] {
     type Error = UnexpectedEOF;
 
     fn unpack_bytes<B: AsMut<[u8]>>(&mut self, mut bytes: B) -> Result<(), Self::Error> {
         let slice = bytes.as_mut();
         let len = slice.len();
 
-        if self.0.len() >= len {
-            let (head, tail) = self.0.split_at(len);
-            self.0 = tail;
+        if self.len() >= len {
+            let (head, tail) = self.split_at(len);
+            *self = tail;
             slice.copy_from_slice(head);
             Ok(())
         } else {
             Err(UnexpectedEOF {
                 required: len,
-                had: self.0.len(),
+                had: self.len(),
             })
         }
     }

--- a/bee-common/bee-packable/tests/bool.rs
+++ b/bee-common/bee-packable/tests/bool.rs
@@ -3,7 +3,7 @@
 
 mod common;
 
-use bee_packable::{packer::VecPacker, Packable, PackableExt};
+use bee_packable::{Packable, PackableExt};
 
 #[test]
 fn packable_bool() {
@@ -13,7 +13,7 @@ fn packable_bool() {
 
 #[test]
 fn packable_bool_packed_non_zero_bytes_are_truthy() {
-    let mut packer = VecPacker::default();
+    let mut packer = Vec::default();
     42u8.pack(&mut packer).unwrap();
 
     let is_true = bool::unpack_verified(&mut packer.as_slice()).unwrap();

--- a/bee-common/bee-packable/tests/common/mod.rs
+++ b/bee-common/bee-packable/tests/common/mod.rs
@@ -1,7 +1,11 @@
 // Copyright 2021 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
-use bee_packable::{packer::SlicePacker, Packable, PackableExt};
+use bee_packable::{
+    packer::{IoPacker, SlicePacker},
+    unpacker::IoUnpacker,
+    Packable, PackableExt,
+};
 
 use core::fmt::Debug;
 
@@ -44,18 +48,19 @@ where
     P: Packable + Eq + Debug,
     P::UnpackError: Debug,
 {
-    // Tests for VecPacker and SliceUnpacker
+    // Tests for `Vec` and `&[u8]`
 
     let mut vec = Vec::new();
     packable.pack(&mut vec).unwrap();
     let unpacked = P::unpack_verified(&mut vec.as_slice()).unwrap();
     assert_eq!(packable, &unpacked);
 
-    // Tests for Read and Write
+    // Tests for `Read` and `Write`
 
-    let mut vec = Vec::new();
-    packable.pack(&mut vec).unwrap();
-    let unpacked = P::unpack_verified(&mut vec.as_slice()).unwrap();
+    let mut packer = IoPacker::new(Vec::new());
+    packable.pack(&mut packer).unwrap();
+    let mut unpacker = IoUnpacker::new(packer.as_slice());
+    let unpacked = P::unpack::<_, true>(&mut unpacker).unwrap();
     assert_eq!(packable, &unpacked);
 
     generic_test_pack_to_slice_unpack_verified(packable);

--- a/bee-common/bee-packable/tests/common/mod.rs
+++ b/bee-common/bee-packable/tests/common/mod.rs
@@ -1,10 +1,7 @@
 // Copyright 2021 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
-use bee_packable::{
-    packer::{SlicePacker, VecPacker},
-    Packable, PackableExt,
-};
+use bee_packable::{packer::SlicePacker, Packable, PackableExt};
 
 use core::fmt::Debug;
 
@@ -49,16 +46,16 @@ where
 {
     // Tests for VecPacker and SliceUnpacker
 
-    let mut vec_packer = VecPacker::new();
-    packable.pack(&mut vec_packer).unwrap();
-    let unpacked = P::unpack_verified(&mut vec_packer.as_slice()).unwrap();
+    let mut vec = Vec::new();
+    packable.pack(&mut vec).unwrap();
+    let unpacked = P::unpack_verified(&mut vec.as_slice()).unwrap();
     assert_eq!(packable, &unpacked);
 
     // Tests for Read and Write
 
     let mut vec = Vec::new();
     packable.pack(&mut vec).unwrap();
-    let unpacked = P::unpack_verified(&mut vec_packer.as_slice()).unwrap();
+    let unpacked = P::unpack_verified(&mut vec.as_slice()).unwrap();
     assert_eq!(packable, &unpacked);
 
     generic_test_pack_to_slice_unpack_verified(packable);


### PR DESCRIPTION
# Description of change

This PR removes the `VecPacker` and `SliceUnpacker` types and implements `Packer` and `Unpacker` for `Vec<u8>` and `&[u8]` directly.

In contrast, it also adds two new wrapper types `IoPacker` and `IoUnpacker` that implement `Packer` or `Unpacker` if the wrapped type implements `Read` or `Write` respectively.

This is done because using the crate without `std` should be the sensible default and it should be as simple as possible. In contrast, using `std` requires an extra step to make it work now.

## Type of change
- Breaking change (fix or feature that would cause existing functionality to not work 

## How the change has been tested

The whole branch compiles and passes tests without issue.

## Change checklist

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that new and existing unit tests pass locally with my changes
- [x] I have updated the CHANGELOG.md, if my changes are significant enough
