### PR TITLE
Use panicking constants to ensure unique tags in `bee-packable-derive`

### DIFF
--- a/bee-common/bee-packable-derive/src/trait_impl.rs
+++ b/bee-common/bee-packable-derive/src/trait_impl.rs
@@ -54,7 +54,7 @@ impl TraitImpl {
                 let mut pack_arms = Vec::with_capacity(len);
                 let mut unpack_arms = Vec::with_capacity(len);
                 let mut tag_decls = Vec::with_capacity(len);
-                let mut tag_idents_and_variants = Vec::with_capacity(len);
+                let mut tag_variants_and_idents = Vec::with_capacity(len);
 
                 for (index, VariantInfo { tag, inner }) in info.variants_info.into_iter().enumerate() {
                     let variant_ident = inner.path.segments.last().unwrap().clone();
@@ -77,13 +77,13 @@ impl TraitImpl {
 
                     tag_decls.push(quote!(const #tag_ident: #tag_type = #tag;));
 
-                    tag_idents_and_variants.push((tag_ident, variant_ident));
+                    tag_variants_and_idents.push((tag_ident, variant_ident));
                 }
 
                 let mut tag_asserts = Vec::with_capacity(len * (len - 1) / 2);
 
-                for (i, (fst, fst_variant)) in tag_idents_and_variants.iter().enumerate() {
-                    if let Some(idents_and_variants) = tag_idents_and_variants.get((i + 1)..) {
+                for (index, (fst, fst_variant)) in tag_variants_and_idents.iter().enumerate() {
+                    if let Some(idents_and_variants) = tag_variants_and_idents.get((index + 1)..) {
                         for (snd, snd_variant) in idents_and_variants {
                             let tag_assert = quote!(
                                 const _: () = assert!(#fst != #snd, concat!("The tags for the variants `", stringify!(#fst_variant), "` and `", stringify!(#snd_variant) ,"` of enum `", stringify!(#enum_ident), "` are equal"));

--- a/bee-common/bee-packable-derive/tests/fail/duplicated_tag_enum.rs
+++ b/bee-common/bee-packable-derive/tests/fail/duplicated_tag_enum.rs
@@ -1,7 +1,7 @@
 // Copyright 2021 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
-#![allow(unused_imports)]
+#![allow(unused_imports, unreachable_patterns)]
 
 use bee_packable::{error::UnknownTagError, Packable};
 

--- a/bee-common/bee-packable-derive/tests/fail/duplicated_tag_enum.stderr
+++ b/bee-common/bee-packable-derive/tests/fail/duplicated_tag_enum.stderr
@@ -1,12 +1,7 @@
-error: unreachable pattern
-  --> tests/fail/duplicated_tag_enum.rs:16:22
-   |
-16 |     #[packable(tag = 0)]
-   |                      ^
-   |
-note: the lint level is defined here
+error[E0080]: evaluation of constant value failed
   --> tests/fail/duplicated_tag_enum.rs:10:10
    |
 10 | #[derive(Packable)]
-   |          ^^^^^^^^
-   = note: this error originates in the derive macro `Packable` (in Nightly builds, run with -Z macro-backtrace for more info)
+   |          ^^^^^^^^ the evaluated program panicked at 'The tags for the variants `None` and `Some` of enum `OptI32` are equal', $DIR/tests/fail/duplicated_tag_enum.rs:10:10
+   |
+   = note: this error originates in the macro `$crate::panic::panic_2021` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/bee-common/bee-packable-derive/tests/fail/overlapping_discriminant.rs
+++ b/bee-common/bee-packable-derive/tests/fail/overlapping_discriminant.rs
@@ -1,7 +1,7 @@
 // Copyright 2021 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
-#![allow(unused_imports)]
+#![allow(unused_imports, unreachable_patterns)]
 
 use bee_packable::Packable;
 

--- a/bee-common/bee-packable-derive/tests/fail/overlapping_discriminant.stderr
+++ b/bee-common/bee-packable-derive/tests/fail/overlapping_discriminant.stderr
@@ -1,12 +1,7 @@
-error: unreachable pattern
-  --> $DIR/overlapping_discriminant.rs:13:22
-   |
-13 |     #[packable(tag = 0)]
-   |                      ^
-   |
-note: the lint level is defined here
-  --> $DIR/overlapping_discriminant.rs:8:10
-   |
-8  | #[derive(Packable)]
-   |          ^^^^^^^^
-   = note: this error originates in the derive macro `Packable` (in Nightly builds, run with -Z macro-backtrace for more info)
+error[E0080]: evaluation of constant value failed
+ --> tests/fail/overlapping_discriminant.rs:8:10
+  |
+8 | #[derive(Packable)]
+  |          ^^^^^^^^ the evaluated program panicked at 'The tags for the variants `B` and `C` of enum `A` are equal', $DIR/tests/fail/overlapping_discriminant.rs:8:10
+  |
+  = note: this error originates in the macro `$crate::panic::panic_2021` (in Nightly builds, run with -Z macro-backtrace for more info)


### PR DESCRIPTION
# Description of change

This PR uses the new `const-panic` feature of rust 1.57 to display more helpful errors when tags overlap while deriving `Packable`. Error messages like:

```
error: unreachable pattern
  --> $DIR/overlapping_discriminant.rs:13:22
   |
13 |     #[packable(tag = 0)]
   |                      ^
   |
note: the lint level is defined here
  --> $DIR/overlapping_discriminant.rs:8:10
   |
8  | #[derive(Packable)]
   |          ^^^^^^^^
   = note: this error originates in the derive macro `Packable` (in Nightly builds, run with -Z macro-backtrace for more info)
```
Have been replaced by
```
error[E0080]: evaluation of constant value failed
 --> tests/fail/overlapping_discriminant.rs:8:10
  |
8 | #[derive(Packable)]
  |          ^^^^^^^^ the evaluated program panicked at 'The tags for the variants `B` and `C` of enum `A` are equal', $DIR/tests/fail/overlappingdiscriminant.rs:8:10
  |
  = note: this error originates in the macro `$crate::panic::panic_2021` (in Nightly builds, run with -Z macro-backtrace for more info)
```

## Type of change

- Enhancement (a non-breaking change which adds functionality)

## How the change has been tested

Tests were updated with the new error messages

## Change checklist

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that new and existing unit tests pass locally with my changes
- [x] I have updated the CHANGELOG.md, if my changes are significant enough
