### PR TITLE
Add Deserialize to SuccessBody

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -299,7 +299,7 @@ dependencies = [
 
 [[package]]
 name = "bee-rest-api"
-version = "0.1.3"
+version = "0.1.4"
 dependencies = [
  "bee-ledger",
  "bee-message",

--- a/bee-api/bee-rest-api/CHANGELOG.md
+++ b/bee-api/bee-rest-api/CHANGELOG.md
@@ -19,6 +19,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Security -->
 
+## 0.1.4 - 2021-12-3
+
+### Added
+
+- `Deserialize` to `SuccessBody`;
+
 ## 0.1.3 - 2021-11-03
 
 ### Removed

--- a/bee-api/bee-rest-api/CHANGELOG.md
+++ b/bee-api/bee-rest-api/CHANGELOG.md
@@ -19,7 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Security -->
 
-## 0.1.4 - 2021-12-3
+## 0.1.4 - 2021-12-03
 
 ### Added
 

--- a/bee-api/bee-rest-api/Cargo.toml
+++ b/bee-api/bee-rest-api/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bee-rest-api"
-version = "0.1.3"
+version = "0.1.4"
 authors = [ "IOTA Stiftung" ]
 edition = "2021"
 description = "The default REST API implementation for the IOTA Bee node software."

--- a/bee-api/bee-rest-api/src/types/body.rs
+++ b/bee-api/bee-rest-api/src/types/body.rs
@@ -1,13 +1,13 @@
 // Copyright 2020-2021 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
 
 /// A marker trait to represent the data that can be included into `SuccessBody` and `ErrorBody`.
 pub trait BodyInner {}
 
 /// Describes the response body of a successful HTTP request.
-#[derive(Clone, Debug, Serialize)]
+#[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct SuccessBody<T: BodyInner> {
     pub data: T,
 }


### PR DESCRIPTION
# Description of change

Add Deserialize to SuccessBody so we can use it in the client to deserialize responses.

## Links to any relevant issues

Related to https://github.com/iotaledger/iota.rs/issues/763

## Type of change

- Enhancement (a non-breaking change which adds functionality)

## How the change has been tested

Compiles

## Change checklist

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have checked that new and existing unit tests pass locally with my changes
- [x] I have updated the CHANGELOG.md, if my changes are significant enough
