### PR TITLE
Add Deserialize to SubmitMessageResponse

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -299,7 +299,7 @@ dependencies = [
 
 [[package]]
 name = "bee-rest-api"
-version = "0.1.4"
+version = "0.1.5"
 dependencies = [
  "bee-ledger",
  "bee-message",

--- a/bee-api/bee-rest-api/CHANGELOG.md
+++ b/bee-api/bee-rest-api/CHANGELOG.md
@@ -19,6 +19,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Security -->
 
+## 0.1.4 - 2021-12-06
+
+### Added
+
+- `Deserialize` to `SubmitMessageResponse`;
+
 ## 0.1.4 - 2021-12-03
 
 ### Added

--- a/bee-api/bee-rest-api/CHANGELOG.md
+++ b/bee-api/bee-rest-api/CHANGELOG.md
@@ -19,7 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Security -->
 
-## 0.1.4 - 2021-12-06
+## 0.1.5 - 2021-12-06
 
 ### Added
 

--- a/bee-api/bee-rest-api/Cargo.toml
+++ b/bee-api/bee-rest-api/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bee-rest-api"
-version = "0.1.4"
+version = "0.1.5"
 authors = [ "IOTA Stiftung" ]
 edition = "2021"
 description = "The default REST API implementation for the IOTA Bee node software."

--- a/bee-api/bee-rest-api/src/types/responses.rs
+++ b/bee-api/bee-rest-api/src/types/responses.rs
@@ -53,7 +53,7 @@ impl BodyInner for TipsResponse {}
 
 /// Response of POST /api/v1/messages.
 /// Returns the message identifier of the submitted message.
-#[derive(Clone, Debug, Serialize)]
+#[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct SubmitMessageResponse {
     #[serde(rename = "messageId")]
     pub message_id: String,


### PR DESCRIPTION
# Description of change

Add Deserialize to SubmitMessageResponse so we can use it in the client to deserialize it.

## Links to any relevant issues

Related to https://github.com/iotaledger/iota.rs/issues/763

## Type of change

- Enhancement (a non-breaking change which adds functionality)

## How the change has been tested

Compiles

## Change checklist

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have checked that new and existing unit tests pass locally with my changes
- [x] I have updated the CHANGELOG.md, if my changes are significant enough
