### PR TITLE
Bump version of `bee-rest-api`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -262,7 +262,7 @@ dependencies = [
 
 [[package]]
 name = "bee-rest-api"
-version = "0.1.6"
+version = "0.1.7"
 dependencies = [
  "bee-ledger",
  "bee-message",

--- a/bee-api/bee-rest-api/CHANGELOG.md
+++ b/bee-api/bee-rest-api/CHANGELOG.md
@@ -19,6 +19,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Security -->
 
+## 0.1.7 - 2021-12-08
+
+### Changed
+
+- Update `bee-ledger` dependency;
+
 ## 0.1.6 - 2021-12-06
 
 ### Fixed

--- a/bee-api/bee-rest-api/Cargo.toml
+++ b/bee-api/bee-rest-api/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bee-rest-api"
-version = "0.1.6"
+version = "0.1.7"
 authors = [ "IOTA Stiftung" ]
 edition = "2021"
 description = "The default REST API implementation for the IOTA Bee node software."


### PR DESCRIPTION
# Description of change

Bumps the version of `bee-rest-api` to `0.1.7`.

## Links to any relevant issues

This should fix issue #869.

## Type of change

- Bug fix (a non-breaking change which fixes an issue)

## Change checklist

Tick the boxes that are relevant to your changes, and delete any items that are not.

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that new and existing unit tests pass locally with my changes
- [x] I have updated the CHANGELOG.md, if my changes are significant enough
