### PR TITLE
Use bee-ternary from crates.io

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -167,7 +167,7 @@ dependencies = [
 name = "bee-crypto"
 version = "0.3.0"
 dependencies = [
- "bee-ternary",
+ "bee-ternary 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "byteorder",
  "criterion",
  "iota-crypto",
@@ -209,7 +209,7 @@ dependencies = [
  "bech32",
  "bee-common",
  "bee-pow",
- "bee-ternary",
+ "bee-ternary 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "bee-test",
  "bytemuck",
  "digest",
@@ -246,7 +246,7 @@ dependencies = [
 name = "bee-pow"
 version = "0.2.0"
 dependencies = [
- "bee-ternary",
+ "bee-ternary 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "bee-test",
  "iota-crypto",
  "thiserror",
@@ -291,7 +291,7 @@ version = "0.2.0"
 dependencies = [
  "bee-common-derive",
  "bee-crypto",
- "bee-ternary",
+ "bee-ternary 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.8.4",
  "sha3",
  "thiserror",
@@ -409,13 +409,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "bee-ternary"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e8479555c8e9bf3cad36daf16e6a2f77771774e977276a08df4d8ac5f1dda66"
+dependencies = [
+ "autocfg",
+ "num-traits",
+ "serde",
+]
+
+[[package]]
 name = "bee-test"
 version = "0.1.0"
 dependencies = [
  "bee-ledger",
  "bee-message",
  "bee-tangle",
- "bee-ternary",
+ "bee-ternary 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "bytemuck",
  "hex",
  "rand 0.8.4",
@@ -1371,7 +1382,7 @@ version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8c98a3248cde6b42cb479a52089fe4fc20d12de51b8edd923294cd5240ec89b0"
 dependencies = [
- "bee-ternary",
+ "bee-ternary 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "blake2",
  "digest",
  "ed25519-zebra",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,6 +28,3 @@ panic = "abort"
 [profile.release]
 panic = "abort"
 
-# `iota-crypto` uses bee-ternary. We patch it to use our local version to avoid importing it twice.
-[patch.crates-io]
-bee-ternary = { path = "bee-ternary" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,4 +27,3 @@ panic = "abort"
 
 [profile.release]
 panic = "abort"
-

--- a/bee-crypto/Cargo.toml
+++ b/bee-crypto/Cargo.toml
@@ -11,7 +11,7 @@ keywords = [ "iota", "tangle", "bee", "framework", "crypto" ]
 homepage = "https://www.iota.org"
 
 [dependencies]
-bee-ternary = { version = "0.5.2", path = "../bee-ternary", default-features = false }
+bee-ternary = { version = "0.5.2", default-features = false }
 
 byteorder = {version = "1.4.3", default-features = false }
 iota-crypto = { version = "0.9.1", default-features = false, features = [ "curl-p" ] }

--- a/bee-message/Cargo.toml
+++ b/bee-message/Cargo.toml
@@ -13,7 +13,7 @@ homepage = "https://www.iota.org"
 [dependencies]
 bee-common = { version = "0.5.0", path = "../bee-common/bee-common", default-features = false }
 bee-pow = { version = "0.2.0", path = "../bee-pow", default-features = false }
-bee-ternary = { version = "0.5.2", path = "../bee-ternary", default-features = false, features = [ "serde1" ] }
+bee-ternary = { version = "0.5.2", default-features = false, features = [ "serde1" ] }
 
 bech32 = { version = "0.8.1", default-features = false }
 bytemuck = { version = "1.7.2", default-features = false }

--- a/bee-pow/Cargo.toml
+++ b/bee-pow/Cargo.toml
@@ -11,7 +11,7 @@ keywords = [ "iota", "tangle", "bee", "framework", "pow" ]
 homepage = "https://www.iota.org"
 
 [dependencies]
-bee-ternary = { version = "0.5.2", path = "../bee-ternary", default-features = false }
+bee-ternary = { version = "0.5.2", default-features = false }
 
 iota-crypto = { version = "0.9.1", default-features = false, features = [ "blake2b", "digest", "curl-p" ] }
 thiserror = { version = "1.0.30", default-features = false }

--- a/bee-signing/Cargo.toml
+++ b/bee-signing/Cargo.toml
@@ -13,7 +13,7 @@ homepage = "https://www.iota.org"
 [dependencies]
 bee-common-derive = { version = "0.1.1-alpha", path = "../bee-common/bee-common-derive", default-features = false }
 bee-crypto = { version = "0.3.0", path = "../bee-crypto", default-features = false }
-bee-ternary = { version = "0.5.2", path = "../bee-ternary", default-features = false }
+bee-ternary = { version = "0.5.2", default-features = false }
 
 rand = { version = "0.8.4", default-features = false, features = [ "std", "std_rng" ] }
 sha3 = { version = "0.9.1", default-features = false }

--- a/bee-test/Cargo.toml
+++ b/bee-test/Cargo.toml
@@ -14,7 +14,7 @@ homepage = "https://www.iota.org"
 bee-ledger = { version = "0.6.0", path = "../bee-ledger", default-features = false }
 bee-message = { version = "0.1.6", path = "../bee-message", default-features = false }
 bee-tangle = { version = "0.2.0", path = "../bee-tangle", default-features = false }
-bee-ternary = { version = "0.5.2", path = "../bee-ternary", default-features = false, features = [ "serde1" ] }
+bee-ternary = { version = "0.5.2", default-features = false, features = [ "serde1" ] }
 
 bytemuck = { version = "1.7.2", default-features = false }
 rand = { version = "0.8.4", default-features = false }


### PR DESCRIPTION
# Description of change

Use bee-ternary from crates.io, because otherwise I get a conflicting version if I use the crates from git.


## Type of change

- Bug fix (a non-breaking change which fixes an issue)


## How the change has been tested

Specified the bee crates locally in iota.rs and it compiled

## Change checklist

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have checked that new and existing unit tests pass locally with my changes
