### PR TITLE
Remove `MIN` and `MAX` const from `Bounded` trait

### DIFF
--- a/bee-common/bee-packable/src/packable/bounded.rs
+++ b/bee-common/bee-packable/src/packable/bounded.rs
@@ -16,11 +16,6 @@ use core::fmt::{self, Display};
 pub trait Bounded: TryFrom<usize> + Into<Self::Bounds> {
     /// The type used to define the bounds.
     type Bounds: PartialOrd + TryInto<Self> + TryInto<usize> + Default + Copy;
-
-    /// Minimum bounded value.
-    const MIN: Self::Bounds;
-    /// Maximum bounded value.
-    const MAX: Self::Bounds;
 }
 
 macro_rules! bounded {
@@ -72,12 +67,14 @@ macro_rules! bounded {
 
         impl<const MIN: $ty, const MAX: $ty> Bounded for $wrapper<MIN, MAX> {
             type Bounds = $ty;
-
-            const MIN: $ty = MIN;
-            const MAX: $ty = MAX;
         }
 
         impl<const MIN: $ty, const MAX: $ty> $wrapper<MIN, MAX> {
+            /// Minimum bounded value.
+            pub const MIN: $ty = MIN;
+            /// Maximum bounded value.
+            pub const MAX: $ty = MAX;
+
             /// Creates a bounded integer without checking whether the value is in-bounds.
             ///
             /// # Safety
@@ -165,28 +162,16 @@ bounded!(BoundedU64, InvalidBoundedU64, TryIntoBoundedU64Error, u64);
 
 impl Bounded for u8 {
     type Bounds = Self;
-
-    const MIN: Self::Bounds = u8::MIN;
-    const MAX: Self::Bounds = u8::MAX;
 }
 
 impl Bounded for u16 {
     type Bounds = Self;
-
-    const MIN: Self::Bounds = u16::MIN;
-    const MAX: Self::Bounds = u16::MAX;
 }
 
 impl Bounded for u32 {
     type Bounds = Self;
-
-    const MIN: Self::Bounds = u32::MIN;
-    const MAX: Self::Bounds = u32::MAX;
 }
 
 impl Bounded for u64 {
     type Bounds = Self;
-
-    const MIN: Self::Bounds = u64::MIN;
-    const MAX: Self::Bounds = u64::MAX;
 }

--- a/bee-common/bee-packable/tests/bounded.rs
+++ b/bee-common/bee-packable/tests/bounded.rs
@@ -5,8 +5,8 @@ mod common;
 
 use bee_packable::{
     bounded::{
-        Bounded, BoundedU16, BoundedU32, BoundedU64, BoundedU8, InvalidBoundedU16, InvalidBoundedU32,
-        InvalidBoundedU64, InvalidBoundedU8,
+        BoundedU16, BoundedU32, BoundedU64, BoundedU8, InvalidBoundedU16, InvalidBoundedU32, InvalidBoundedU64,
+        InvalidBoundedU8,
     },
     error::UnpackError,
     PackableExt,

--- a/bee-message/src/payload/indexation/mod.rs
+++ b/bee-message/src/payload/indexation/mod.rs
@@ -10,7 +10,7 @@ use crate::{payload::MessagePayload, MessageUnpackError, ValidationError, MESSAG
 pub use padded::PaddedIndex;
 
 use bee_packable::{
-    bounded::{Bounded, BoundedU32},
+    bounded::BoundedU32,
     prefix::{UnpackPrefixError, VecPrefix},
     Packable,
 };


### PR DESCRIPTION
Some types in the stardust layout consist of sequences with an integer length prefix `p` with constraints like `p == 0 || p > MIN_P`. At first glance those sequences could be represented as `VecPrefix<T, P>` where `P` is `struct P(u32);`. However that would require `P` to implement `Bounded`. 

Currently the `Bounded` trait requires two constant `MIN` and `MAX` assuming that the valid bound for values of types implementing this trait is exactly `MIN..=MAX`. However, the constraint shown above cannot be represented as such.

This PR removes those constants from the `Bounded` trait and moves them as associated constants of the `BoundedUXX` types directly.