### PR TITLE
Extend range of milestone key 5

### DIFF
--- a/bee-node/config.chrysalis-mainnet.toml
+++ b/bee-node/config.chrysalis-mainnet.toml
@@ -50,7 +50,7 @@ start       = 1333460
 end         = 2888660
 [[protocol.coordinator.public_key_ranges]]
 public_key  = "7bac2209b576ea2235539358c7df8ca4d2f2fc35a663c760449e65eba9f8a6e7"
-start       = 2111060
+start       = 2108160
 end         = 3666260
 [[protocol.coordinator.public_key_ranges]]
 public_key  = "edd9c639a719325e465346b84133bf94740b7d476dd87fc949c0e8df516f9954"


### PR DESCRIPTION
# Description of change

Extends the range of milestone key 5 to fix the coordinator signing.

Hornet PR description:
> This PR extends the range of key 5 so that it starts at the end of key 3. It was originally scheduled to start on Jan 3.

## Links to any relevant issues

Here is the corresponding change in Hornet: https://github.com/gohornet/hornet/pull/1256

## Type of change

Choose a type of change, and delete any options that are not relevant.

- Bug fix (a non-breaking change which fixes an issue)

## How the change has been tested

Double checked with the config from Hornet. **All reviewers should do that too. :warning:**

## Change checklist

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that new and existing unit tests pass locally with my changes
- [x] I have updated the CHANGELOG.md, if my changes are significant enough
