### PR TITLE
Use `bitflags` to represent allowed `FeatureBlocks`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -271,6 +271,7 @@ dependencies = [
  "bee-pow",
  "bee-ternary 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "bee-test",
+ "bitflags",
  "bytemuck",
  "derive_more",
  "digest",

--- a/bee-message/Cargo.toml
+++ b/bee-message/Cargo.toml
@@ -16,6 +16,7 @@ bee-pow = { version = "0.2.0", path = "../bee-pow", default-features = false }
 bee-ternary = { version = "0.5.2", default-features = false, features = [ "serde1" ] }
 
 bech32 = { version = "0.8.1", default-features = false }
+bitflags = { version = "1.3.2", default-features = false }
 bytemuck = { version = "1.7.2", default-features = false }
 derive_more = { version = "0.99.16", default-features = false, features = [ "from", "as_ref", "deref" ] }
 digest = { version = "0.9.0", default-features = false }

--- a/bee-message/src/error.rs
+++ b/bee-message/src/error.rs
@@ -89,7 +89,7 @@ impl fmt::Display for Error {
         match self {
             Error::CryptoError(e) => write!(f, "cryptographic error: {}.", e),
             Error::DuplicateFeatureBlock { index, kind } => {
-                write!(f, "duplicated feature block at index {} with kind {}.", index, kind)
+                write!(f, "duplicate feature block at index {} with kind {}.", index, kind)
             }
             Error::DuplicateSignatureUnlockBlock(index) => {
                 write!(f, "duplicate signature unlock block at index: {0}", index)

--- a/bee-message/src/error.rs
+++ b/bee-message/src/error.rs
@@ -16,7 +16,6 @@ use core::fmt;
 #[allow(missing_docs)]
 pub enum Error {
     CryptoError(CryptoError),
-    DuplicateFeatureBlock { index: usize, kind: u8 },
     DuplicateSignatureUnlockBlock(u16),
     DuplicateUtxo(UtxoInput),
     FeatureBlocksNotUniqueSorted,
@@ -88,9 +87,6 @@ impl fmt::Display for Error {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             Error::CryptoError(e) => write!(f, "cryptographic error: {}.", e),
-            Error::DuplicateFeatureBlock { index, kind } => {
-                write!(f, "duplicate feature block at index {} with kind {}.", index, kind)
-            }
             Error::DuplicateSignatureUnlockBlock(index) => {
                 write!(f, "duplicate signature unlock block at index: {0}", index)
             }

--- a/bee-message/src/error.rs
+++ b/bee-message/src/error.rs
@@ -16,6 +16,7 @@ use core::fmt;
 #[allow(missing_docs)]
 pub enum Error {
     CryptoError(CryptoError),
+    DuplicateFeatureBlock { index: usize, kind: u8 },
     DuplicateSignatureUnlockBlock(u16),
     DuplicateUtxo(UtxoInput),
     FeatureBlocksNotUniqueSorted,
@@ -79,7 +80,6 @@ pub enum Error {
     SignaturePublicKeyMismatch { expected: String, actual: String },
     TailTransactionHashNotUnique { previous: usize, current: usize },
     UnallowedFeatureBlock { index: usize, kind: u8 },
-    TooManyFeatureBlocks { max: usize, actual: usize },
 }
 
 impl std::error::Error for Error {}
@@ -88,7 +88,9 @@ impl fmt::Display for Error {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             Error::CryptoError(e) => write!(f, "cryptographic error: {}.", e),
-
+            Error::DuplicateFeatureBlock { index, kind } => {
+                write!(f, "duplicated feature block at index {} with kind {}.", index, kind)
+            }
             Error::DuplicateSignatureUnlockBlock(index) => {
                 write!(f, "duplicate signature unlock block at index: {0}", index)
             }
@@ -230,9 +232,6 @@ impl fmt::Display for Error {
             }
             Error::UnallowedFeatureBlock { index, kind } => {
                 write!(f, "unallowed feature block at index {} with kind {}.", index, kind)
-            }
-            Error::TooManyFeatureBlocks { max, actual } => {
-                write!(f, "too many feature blocks, max {}, got {}.", max, actual)
             }
         }
     }

--- a/bee-message/src/output/alias.rs
+++ b/bee-message/src/output/alias.rs
@@ -156,7 +156,7 @@ impl AliasOutput {
 
     /// Returns the set of allowed [`FeatureBlock`]s for an [`AliasOutput`].
     #[inline(always)]
-    pub fn allowed_feature_blocks() -> FeatureBlockUsages {
+    fn allowed_feature_blocks() -> FeatureBlockUsages {
         FeatureBlockUsages::empty()
             | FeatureBlockUsages::SENDER
             | FeatureBlockUsages::ISSUER

--- a/bee-message/src/output/extended.rs
+++ b/bee-message/src/output/extended.rs
@@ -11,6 +11,7 @@ use crate::{
 };
 
 use bee_common::packable::{Packable, Read, Write};
+
 ///
 pub struct ExtendedOutputBuilder {
     address: Address,
@@ -93,7 +94,7 @@ impl ExtendedOutput {
 
     /// Returns the set of allowed [`FeatureBlock`]s for an [`ExtendedOutput`].
     #[inline(always)]
-    pub fn allowed_feature_blocks() -> FeatureBlockUsages {
+    fn allowed_feature_blocks() -> FeatureBlockUsages {
         FeatureBlockUsages::empty()
             | FeatureBlockUsages::SENDER
             | FeatureBlockUsages::DUST_DEPOSIT_RETURN

--- a/bee-message/src/output/feature_block/mod.rs
+++ b/bee-message/src/output/feature_block/mod.rs
@@ -28,6 +28,7 @@ use bee_common::{
     packable::{Packable, Read, Write},
 };
 
+use bitflags::bitflags;
 use derive_more::{Deref, From};
 
 ///
@@ -74,8 +75,8 @@ impl FeatureBlock {
         }
     }
 
-    /// Returns the [`FeatureBlockUsages`] for the given [`FeatureBlock`].
-    pub(crate) fn usage(&self) -> FeatureBlockFlags {
+    /// Returns the [`FeatureBlockFlags`] for the given [`FeatureBlock`].
+    pub(crate) fn flag(&self) -> FeatureBlockFlags {
         match self {
             Self::Sender(_) => FeatureBlockFlags::SENDER,
             Self::Issuer(_) => FeatureBlockFlags::ISSUER,
@@ -311,7 +312,7 @@ pub(crate) fn validate_allowed_feature_blocks(
     allowed_feature_blocks: FeatureBlockFlags,
 ) -> Result<(), Error> {
     for (index, feature_block) in feature_blocks.iter().enumerate() {
-        if !allowed_feature_blocks.contains(feature_block.usage()) {
+        if !allowed_feature_blocks.contains(feature_block.flag()) {
             return Err(Error::UnallowedFeatureBlock {
                 index,
                 kind: feature_block.kind(),
@@ -320,8 +321,6 @@ pub(crate) fn validate_allowed_feature_blocks(
     }
     Ok(())
 }
-
-use bitflags::bitflags;
 
 bitflags! {
     /// A bitflags-based representation of the set of active feature blocks.

--- a/bee-message/src/output/feature_block/mod.rs
+++ b/bee-message/src/output/feature_block/mod.rs
@@ -75,7 +75,7 @@ impl FeatureBlock {
     }
 
     /// Returns the [`FeatureBlockUsages`] for the given [`FeatureBlock`].
-    pub fn usage(&self) -> FeatureBlockUsages {
+    pub(crate) fn usage(&self) -> FeatureBlockUsages {
         match self {
             Self::Sender(_) => FeatureBlockUsages::SENDER,
             Self::Issuer(_) => FeatureBlockUsages::ISSUER,
@@ -334,9 +334,11 @@ use bitflags::bitflags;
 
 bitflags! {
     /// A bitflags-based representation of the set of active feature blocks.
-    pub struct FeatureBlockUsages: u16 {
+    pub(crate) struct FeatureBlockUsages: u16 {
         /// Signals the presence of a [`SenderFeatureBlock`].
         const SENDER = 1 << SenderFeatureBlock::KIND;
+        /// Signals the presence of a [`IssuerFeatureBlock`].
+        const ISSUER = 1 << IssuerFeatureBlock::KIND;
         /// Signals the presence of a [`DustDepositReturnFeatureBlock`].
         const DUST_DEPOSIT_RETURN = 1 << DustDepositReturnFeatureBlock::KIND;
         /// Signals the presence of a [`TimelockMilestoneIndexFeatureBlock`].
@@ -351,7 +353,5 @@ bitflags! {
         const METADATA = 1 << MetadataFeatureBlock::KIND;
         /// Signals the presence of a [`IndexationFeatureBlock`].
         const INDEXATION = 1 << IndexationFeatureBlock::KIND;
-        /// Signals the presence of a [`IssuerFeatureBlock`].
-        const ISSUER = 1 << IssuerFeatureBlock::KIND;
     }
 }

--- a/bee-message/src/output/feature_block/mod.rs
+++ b/bee-message/src/output/feature_block/mod.rs
@@ -310,21 +310,12 @@ pub(crate) fn validate_allowed_feature_blocks(
     feature_blocks: &FeatureBlocks,
     allowed_feature_blocks: FeatureBlockUsages,
 ) -> Result<(), Error> {
-    let mut blocks = FeatureBlockUsages::empty();
     for (index, feature_block) in feature_blocks.iter().enumerate() {
-        let usage = feature_block.usage();
-        if blocks.contains(usage) {
-            return Err(Error::DuplicateFeatureBlock {
-                index,
-                kind: feature_block.kind(),
-            });
-        } else if !allowed_feature_blocks.contains(usage) {
+        if !allowed_feature_blocks.contains(feature_block.usage()) {
             return Err(Error::UnallowedFeatureBlock {
                 index,
                 kind: feature_block.kind(),
             });
-        } else {
-            blocks.insert(usage);
         }
     }
     Ok(())

--- a/bee-message/src/output/feature_block/mod.rs
+++ b/bee-message/src/output/feature_block/mod.rs
@@ -75,17 +75,17 @@ impl FeatureBlock {
     }
 
     /// Returns the [`FeatureBlockUsages`] for the given [`FeatureBlock`].
-    pub(crate) fn usage(&self) -> FeatureBlockUsages {
+    pub(crate) fn usage(&self) -> FeatureBlockFlags {
         match self {
-            Self::Sender(_) => FeatureBlockUsages::SENDER,
-            Self::Issuer(_) => FeatureBlockUsages::ISSUER,
-            Self::DustDepositReturn(_) => FeatureBlockUsages::DUST_DEPOSIT_RETURN,
-            Self::TimelockMilestoneIndex(_) => FeatureBlockUsages::TIMELOCK_MILESTONE_INDEX,
-            Self::TimelockUnix(_) => FeatureBlockUsages::TIMELOCK_UNIX,
-            Self::ExpirationMilestoneIndex(_) => FeatureBlockUsages::EXPIRATION_MILESTONE_INDEX,
-            Self::ExpirationUnix(_) => FeatureBlockUsages::EXPIRATION_UNIX,
-            Self::Indexation(_) => FeatureBlockUsages::INDEXATION,
-            Self::Metadata(_) => FeatureBlockUsages::METADATA,
+            Self::Sender(_) => FeatureBlockFlags::SENDER,
+            Self::Issuer(_) => FeatureBlockFlags::ISSUER,
+            Self::DustDepositReturn(_) => FeatureBlockFlags::DUST_DEPOSIT_RETURN,
+            Self::TimelockMilestoneIndex(_) => FeatureBlockFlags::TIMELOCK_MILESTONE_INDEX,
+            Self::TimelockUnix(_) => FeatureBlockFlags::TIMELOCK_UNIX,
+            Self::ExpirationMilestoneIndex(_) => FeatureBlockFlags::EXPIRATION_MILESTONE_INDEX,
+            Self::ExpirationUnix(_) => FeatureBlockFlags::EXPIRATION_UNIX,
+            Self::Indexation(_) => FeatureBlockFlags::INDEXATION,
+            Self::Metadata(_) => FeatureBlockFlags::METADATA,
         }
     }
 }
@@ -308,7 +308,7 @@ fn validate_dependencies(feature_blocks: &[FeatureBlock]) -> Result<(), Error> {
 
 pub(crate) fn validate_allowed_feature_blocks(
     feature_blocks: &FeatureBlocks,
-    allowed_feature_blocks: FeatureBlockUsages,
+    allowed_feature_blocks: FeatureBlockFlags,
 ) -> Result<(), Error> {
     for (index, feature_block) in feature_blocks.iter().enumerate() {
         if !allowed_feature_blocks.contains(feature_block.usage()) {
@@ -325,7 +325,7 @@ use bitflags::bitflags;
 
 bitflags! {
     /// A bitflags-based representation of the set of active feature blocks.
-    pub(crate) struct FeatureBlockUsages: u16 {
+    pub(crate) struct FeatureBlockFlags: u16 {
         /// Signals the presence of a [`SenderFeatureBlock`].
         const SENDER = 1 << SenderFeatureBlock::KIND;
         /// Signals the presence of a [`IssuerFeatureBlock`].

--- a/bee-message/src/output/foundry.rs
+++ b/bee-message/src/output/foundry.rs
@@ -4,7 +4,7 @@
 use crate::{
     address::Address,
     output::{
-        feature_block::{validate_allowed_feature_blocks, FeatureBlock, FeatureBlockUsages, FeatureBlocks},
+        feature_block::{validate_allowed_feature_blocks, FeatureBlock, FeatureBlockFlags, FeatureBlocks},
         NativeToken, NativeTokens,
     },
     Error,
@@ -116,7 +116,7 @@ impl FoundryOutputBuilder {
     pub fn finish(self) -> Result<FoundryOutput, Error> {
         let feature_blocks = FeatureBlocks::new(self.feature_blocks)?;
 
-        validate_allowed_feature_blocks(&feature_blocks, FoundryOutput::allowed_feature_blocks())?;
+        validate_allowed_feature_blocks(&feature_blocks, FoundryOutput::ALLOWED_FEATURE_BLOCKS)?;
 
         Ok(FoundryOutput {
             address: self.address,
@@ -158,11 +158,8 @@ impl FoundryOutput {
     /// The [`Output`](crate::output::Output) kind of a [`FoundryOutput`].
     pub const KIND: u8 = 5;
 
-    /// Returns the set of allowed [`FeatureBlock`]s for an [`FoundryOutput`].
-    #[inline(always)]
-    fn allowed_feature_blocks() -> FeatureBlockUsages {
-        FeatureBlockUsages::METADATA
-    }
+    /// The set of allowed [`FeatureBlock`]s for an [`FoundryOutput`].
+    const ALLOWED_FEATURE_BLOCKS: FeatureBlockFlags = FeatureBlockFlags::METADATA;
 
     /// Creates a new [`FoundryOutput`].
     #[inline(always)]
@@ -317,7 +314,7 @@ impl Packable for FoundryOutput {
         let feature_blocks = FeatureBlocks::unpack_inner::<R, CHECK>(reader)?;
 
         if CHECK {
-            validate_allowed_feature_blocks(&feature_blocks, FoundryOutput::allowed_feature_blocks())?;
+            validate_allowed_feature_blocks(&feature_blocks, FoundryOutput::ALLOWED_FEATURE_BLOCKS)?;
         }
 
         Ok(Self {

--- a/bee-message/src/output/foundry.rs
+++ b/bee-message/src/output/foundry.rs
@@ -4,7 +4,7 @@
 use crate::{
     address::Address,
     output::{
-        feature_block::{validate_allowed_feature_blocks, FeatureBlock, FeatureBlocks, MetadataFeatureBlock},
+        feature_block::{validate_allowed_feature_blocks, FeatureBlock, FeatureBlockUsages, FeatureBlocks},
         NativeToken, NativeTokens,
     },
     Error,
@@ -116,7 +116,7 @@ impl FoundryOutputBuilder {
     pub fn finish(self) -> Result<FoundryOutput, Error> {
         let feature_blocks = FeatureBlocks::new(self.feature_blocks)?;
 
-        validate_allowed_feature_blocks(&feature_blocks, &FoundryOutput::ALLOWED_FEATURE_BLOCKS)?;
+        validate_allowed_feature_blocks(&feature_blocks, FoundryOutput::allowed_feature_blocks())?;
 
         Ok(FoundryOutput {
             address: self.address,
@@ -157,8 +157,12 @@ pub struct FoundryOutput {
 impl FoundryOutput {
     /// The [`Output`](crate::output::Output) kind of a [`FoundryOutput`].
     pub const KIND: u8 = 5;
-    ///
-    const ALLOWED_FEATURE_BLOCKS: [u8; 1] = [MetadataFeatureBlock::KIND];
+
+    /// Returns the set of allowed [`FeatureBlock`]s for an [`FoundryOutput`].
+    #[inline(always)]
+    fn allowed_feature_blocks() -> FeatureBlockUsages {
+        FeatureBlockUsages::METADATA
+    }
 
     /// Creates a new [`FoundryOutput`].
     #[inline(always)]
@@ -313,7 +317,7 @@ impl Packable for FoundryOutput {
         let feature_blocks = FeatureBlocks::unpack_inner::<R, CHECK>(reader)?;
 
         if CHECK {
-            validate_allowed_feature_blocks(&feature_blocks, &FoundryOutput::ALLOWED_FEATURE_BLOCKS)?;
+            validate_allowed_feature_blocks(&feature_blocks, FoundryOutput::allowed_feature_blocks())?;
         }
 
         Ok(Self {


### PR DESCRIPTION
# Description of change

Changes `ALLOWED_FEATURE_BLOCKS` to a `bitflags`-based representation and adapts the errors for a malformed list of `FeatureBlocks`.  

## Type of change

- Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Change checklist

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that new and existing unit tests pass locally with my changes
- [x] I have updated the CHANGELOG.md, if my changes are significant enough
