### PR TITLE
Update logger docs and set set color_enabled default to false

### DIFF
--- a/bee-common/bee-common/src/logger/config.rs
+++ b/bee-common/bee-common/src/logger/config.rs
@@ -17,7 +17,7 @@ const DEFAULT_OUTPUT_NAME: &str = LOGGER_STDOUT_NAME;
 /// Default log level for an output.
 const DEFAULT_OUTPUT_LEVEL_FILTER: LevelFilter = LevelFilter::Info;
 /// Default value for the color flag.
-const DEFAULT_COLOR_ENABLED: bool = true;
+const DEFAULT_COLOR_ENABLED: bool = false;
 
 /// Builder for a logger output configuration.
 #[derive(Default, Deserialize)]

--- a/documentation/docs/configuration.md
+++ b/documentation/docs/configuration.md
@@ -34,33 +34,35 @@ bee -c config_example.toml
 
 | Name                | Description                          | Type           |
 | :------------------ | :----------------------------------- | :------------- |
-| color_enabled       | stdout is colored if enabled         | bool           |
 | target_width        | width of the target section of a log | integer[usize] |
 | level_width         | width of the level section of a log  | integer[usize] |
 | [outputs](#outputs) | config for different log filters     | array          |
 
 ### Outputs
 
-| Name          | Description                     | Type             |
-| :------------ | :------------------------------ | :--------------- |
-| name          | standard stream or file         | string           |
-| level_filter  | log level filter of an output   | string           |
-| target_filter | log target filters of an output | array of strings |
+| Name              | Description                        | Type             |
+| :---------------- | :--------------------------------- | :--------------- |
+| name              | standard stream or file            | string           |
+| level_filter      | log level filter of an output      | string           |
+| target_filter     | log target filters of an output    | array of strings |
+| target_exclusions | log target exclusions of an output | array of strings |
+| color_enabled     | output is colored if enabled       | bool             |
 
 Example:
 
 ```toml
 [logger]
-color_enabled = true
 target_width = 42
 level_width = 5
 [[logger.outputs]]
+color_enabled  = true
 name           = "stdout"
 level_filter   = "info" # other possible values are: "error", "warn", "info", "debug", "trace"
 target_filters = ["bee_network"] 
 [[logger.outputs]]
-name           = "error.log"
-level_filter   = "error"
+name              = "error.log"
+level_filter      = "error"
+target_exclusions = ["bee_network"] 
 ```
 
 ## Network


### PR DESCRIPTION
# Description of change

Updated the logger docs to include `target_exclusions ` and `color_enabled` and set it's default to false.

## Links to any relevant issues

#930 

## Type of change

- Enhancement (a non-breaking change which adds functionality)
- Documentation Fix

## Change checklist

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that new and existing unit tests pass locally with my changes
- [ ] I have updated the CHANGELOG.md, if my changes are significant enough
