### PR TITLE
Properly handle responses while downloading snapshots

### DIFF
--- a/bee-ledger/src/workers/snapshot/download.rs
+++ b/bee-ledger/src/workers/snapshot/download.rs
@@ -24,24 +24,27 @@ async fn download_snapshot_header(download_url: &str) -> Result<SnapshotHeader, 
             if res.status().is_success() {
                 let mut stream = res.bytes_stream();
                 let mut bytes = Vec::<u8>::with_capacity(SnapshotHeader::LENGTH);
-    
+
                 while let Some(chunk) = stream.next().await {
                     let mut chunk_reader = chunk.map_err(|_| Error::DownloadingFailed)?.reader();
-    
+
                     let mut buf = Vec::new();
                     chunk_reader.read_to_end(&mut buf)?;
                     bytes.extend_from_slice(&buf);
-    
+
                     if bytes.len() >= SnapshotHeader::LENGTH {
                         debug!("Downloaded snapshot header from {}.", download_url);
-    
+
                         let mut slice: &[u8] = &bytes[..SnapshotHeader::LENGTH];
-    
+
                         return Ok(SnapshotHeader::unpack(&mut slice)?);
                     }
                 }
             } else {
-                debug!("Downloading snapshot header failed with status code {:?}.", res.status());
+                debug!(
+                    "Downloading snapshot header failed with status code {:?}.",
+                    res.status()
+                );
             }
         }
         Err(e) => debug!("Downloading snapshot header failed: {:?}.", e.to_string()),

--- a/bee-ledger/src/workers/snapshot/download.rs
+++ b/bee-ledger/src/workers/snapshot/download.rs
@@ -171,7 +171,7 @@ async fn download_snapshot_file(path: &Path, download_url: &str) -> Result<(), E
                 warn!("Downloading snapshot file failed with status code {:?}.", res.status());
             }
         }
-        Err(e) => debug!("Downloading snapshot failed: {:?}.", e.to_string()),
+        Err(e) => warn!("Downloading snapshot failed: {:?}.", e.to_string()),
     }
 
     Ok(())


### PR DESCRIPTION
# Description of change

When downloading snapshot files (or their headers), we used to only check if the server responded and not what the actual status code was. This should be fixed by this PR.

## Links to any relevant issues

* #948 

## Type of change

- Bug fix (a non-breaking change which fixes an issue)

## How the change has been tested

Checked against Tanglebay, which does not provide a delta snapshot.

## Change checklist

Tick the boxes that are relevant to your changes, and delete any items that are not.

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that new and existing unit tests pass locally with my changes
- [x] I have updated the CHANGELOG.md, if my changes are significant enough
