### PR TITLE
Reduce warning logs in bee-autopeering

### DIFF
--- a/bee-network/bee-autopeering/CHANGELOG.md
+++ b/bee-network/bee-autopeering/CHANGELOG.md
@@ -25,7 +25,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Server panics when sending to an IPv6 address;
 - Spams port mismatch warnings;
-- filters out valid incoming peering requests;
+- Filters out valid incoming peering requests;
 
 ## 0.1.0 - 2021-12-03
 

--- a/bee-network/bee-autopeering/src/discovery/manager.rs
+++ b/bee-network/bee-autopeering/src/discovery/manager.rs
@@ -220,12 +220,12 @@ impl Runnable for DiscoveryRecvHandler {
                                 let verif_req = if let Ok(verif_req) = VerificationRequest::from_protobuf(&msg_bytes) {
                                     verif_req
                                 } else {
-                                    log::warn!("Error decoding verification request from {}.", &peer_id);
+                                    log::debug!("Error decoding verification request from {}.", &peer_id);
                                     continue 'recv;
                                 };
 
                                 if let Err(e) = validate_verification_request(&verif_req, version, network_id) {
-                                    log::warn!("Received invalid verification request from {}. Reason: {}", &peer_id, e);
+                                    log::debug!("Received invalid verification request from {}. Reason: {}", &peer_id, e);
                                     continue 'recv;
                                 } else {
                                     log::trace!("Received valid verification request from {}.", &peer_id);
@@ -237,7 +237,7 @@ impl Runnable for DiscoveryRecvHandler {
                                 let verif_res = if let Ok(verif_res) = VerificationResponse::from_protobuf(&msg_bytes) {
                                     verif_res
                                 } else {
-                                    log::warn!("Error decoding verification response from {}.", &peer_id);
+                                    log::debug!("Error decoding verification response from {}.", &peer_id);
                                     continue 'recv;
                                 };
 
@@ -248,7 +248,7 @@ impl Runnable for DiscoveryRecvHandler {
                                         handle_verification_response(verif_res, verif_reqval, ctx);
                                     }
                                     Err(e) => {
-                                        log::warn!("Received invalid verification response from {}. Reason: {:?}", &peer_id, e);
+                                        log::debug!("Received invalid verification response from {}. Reason: {:?}", &peer_id, e);
                                         continue 'recv;
                                     }
                                 }
@@ -257,12 +257,12 @@ impl Runnable for DiscoveryRecvHandler {
                                 let disc_req = if let Ok(disc_req) = DiscoveryRequest::from_protobuf(&msg_bytes) {
                                     disc_req
                                 } else {
-                                    log::warn!("Error decoding discovery request from {}.", &peer_id);
+                                    log::debug!("Error decoding discovery request from {}.", &peer_id);
                                     continue 'recv;
                                 };
 
                                 if let Err(e) = validate_discovery_request(&disc_req) {
-                                    log::warn!("Received invalid discovery request from {}. Reason: {:?}", &peer_id, e);
+                                    log::debug!("Received invalid discovery request from {}. Reason: {:?}", &peer_id, e);
                                     continue 'recv;
                                 } else {
                                     log::trace!("Received valid discovery request from {}.", &peer_id);
@@ -274,7 +274,7 @@ impl Runnable for DiscoveryRecvHandler {
                                 let disc_res = if let Ok(disc_res) = DiscoveryResponse::from_protobuf(&msg_bytes) {
                                     disc_res
                                 } else {
-                                    log::warn!("Error decoding discovery response from {}.", &peer_id);
+                                    log::debug!("Error decoding discovery response from {}.", &peer_id);
                                     continue 'recv;
                                 };
 
@@ -285,12 +285,12 @@ impl Runnable for DiscoveryRecvHandler {
                                         handle_discovery_response(disc_res, disc_reqval, ctx);
                                     }
                                     Err(e) => {
-                                        log::warn!("Received invalid discovery response from {}. Reason: {:?}", &peer_id, e);
+                                        log::debug!("Received invalid discovery response from {}. Reason: {:?}", &peer_id, e);
                                         continue 'recv;
                                     }
                                 }
                             }
-                            _ => log::warn!("Received unsupported discovery message type"),
+                            _ => log::debug!("Received unsupported discovery message type"),
                         }
                     }
                 }

--- a/bee-network/bee-autopeering/src/discovery/query.rs
+++ b/bee-network/bee-autopeering/src/discovery/query.rs
@@ -74,7 +74,7 @@ pub(crate) fn query_fn() -> Repeat<QueryContext> {
     Box::new(|ctx| {
         let peers = select_peers_to_query(&ctx.active_peers);
         if peers.is_empty() {
-            log::warn!("No peers to query.");
+            log::debug!("No peers to query.");
         } else {
             log::debug!("Querying {} peer/s...", peers.len());
 

--- a/bee-network/bee-autopeering/src/peering/manager.rs
+++ b/bee-network/bee-autopeering/src/peering/manager.rs
@@ -137,12 +137,12 @@ impl<V: NeighborValidator> Runnable for PeeringManager<V> {
                                 let peer_req = if let Ok(peer_req) = PeeringRequest::from_protobuf(&msg_bytes) {
                                     peer_req
                                 } else {
-                                    log::warn!("Error decoding peering request from {}.", &peer_id);
+                                    log::debug!("Error decoding peering request from {}.", &peer_id);
                                     continue 'recv;
                                 };
 
                                 if let Err(e) = validate_peering_request(&peer_req, &ctx) {
-                                    log::warn!("Received invalid peering request from {}. Reason: {:?}", &peer_id, e);
+                                    log::debug!("Received invalid peering request from {}. Reason: {:?}", &peer_id, e);
                                     continue 'recv;
                                 } else {
                                     log::trace!("Received valid peering request from {}.", &peer_id);
@@ -154,7 +154,7 @@ impl<V: NeighborValidator> Runnable for PeeringManager<V> {
                                 let peer_res = if let Ok(peer_res) = PeeringResponse::from_protobuf(&msg_bytes) {
                                     peer_res
                                 } else {
-                                    log::warn!("Error decoding peering response from {}.", &peer_id);
+                                    log::debug!("Error decoding peering response from {}.", &peer_id);
                                     continue 'recv;
                                 };
 
@@ -165,7 +165,7 @@ impl<V: NeighborValidator> Runnable for PeeringManager<V> {
                                         handle_peering_response(peer_res, peer_reqval, ctx, &nb_filter);
                                     }
                                     Err(e) => {
-                                        log::warn!("Received invalid peering response from {}. Reason: {:?}", &peer_id, e);
+                                        log::debug!("Received invalid peering response from {}. Reason: {:?}", &peer_id, e);
                                         continue 'recv;
                                     }
                                 }
@@ -174,12 +174,12 @@ impl<V: NeighborValidator> Runnable for PeeringManager<V> {
                                 let drop_req = if let Ok(drop_req) = DropPeeringRequest::from_protobuf(&msg_bytes) {
                                     drop_req
                                 } else {
-                                    log::warn!("Error decoding drop request from {}.", &peer_id);
+                                    log::debug!("Error decoding drop request from {}.", &peer_id);
                                     continue 'recv;
                                 };
 
                                 if let Err(e) = validate_drop_request(&drop_req, &ctx) {
-                                    log::warn!("Received invalid drop request from {}. Reason: {:?}", &peer_id, e);
+                                    log::debug!("Received invalid drop request from {}. Reason: {:?}", &peer_id, e);
                                     continue 'recv;
                                 } else {
                                     log::trace!("Received valid drop request from {}.", &peer_id);
@@ -187,7 +187,7 @@ impl<V: NeighborValidator> Runnable for PeeringManager<V> {
                                     handle_drop_request(drop_req, ctx, &nb_filter);
                                 }
                             }
-                            _ => log::warn!("Received unsupported peering message type"),
+                            _ => log::debug!("Received unsupported peering message type"),
                         }
                     }
                 }


### PR DESCRIPTION
# Description of change

Doesn't log warnings for received messages, that are invalid in some way.

## Type of change

- Bug fix (a non-breaking change which fixes an issue)

## How the change has been tested

All unit tests passed. 

## Change checklist

Tick the boxes that are relevant to your changes, and delete any items that are not.

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have checked that new and existing unit tests pass locally with my changes

