### PR TITLE
Make it easier to copy & paste p2p-identity and password into config

### DIFF
--- a/bee-node/src/tools/p2p_identity.rs
+++ b/bee-node/src/tools/p2p_identity.rs
@@ -12,7 +12,7 @@ pub fn exec(_tool: &P2pIdentityTool) {
     let keypair = Keypair::generate();
     let public_key = keypair.public();
 
-    println!("Your node identity:\t\t{}", hex::encode(keypair.encode()));
+    println!("identity = \"{}\"", hex::encode(keypair.encode()));
     println!("Your node public key:\t\t{}", hex::encode(public_key.encode()));
     println!(
         "Your libp2p peer identity:\t{}",

--- a/bee-node/src/tools/password.rs
+++ b/bee-node/src/tools/password.rs
@@ -44,8 +44,8 @@ pub fn exec(_tool: &PasswordTool) -> Result<(), PasswordError> {
         return Err(PasswordError::VerificationFailed);
     }
 
-    println!("Password salt: {}", hex::encode(salt));
-    println!("Password hash: {}", hex::encode(hash));
+    println!("password_salt = \"{}\"", hex::encode(salt));
+    println!("password_hash = \"{}\"", hex::encode(hash));
 
     Ok(())
 }


### PR DESCRIPTION
# Description of change

Change the output of the `p2p-identity` and `password` tool commands to match the format of the .toml config file, for easier copy&pasting.

## Type of change

Choose a type of change, and delete any options that are not relevant.

- Enhancement (a non-breaking change which adds functionality)

## How the change has been tested

Local test run.

## Change checklist

Tick the boxes that are relevant to your changes, and delete any items that are not.

- [ X I have followed the contribution guidelines for this project
- [X] I have performed a self-review of my own code