### PR TITLE
Re-export `SecretKey`

### DIFF
--- a/bee-network/bee-gossip/src/lib.rs
+++ b/bee-network/bee-gossip/src/lib.rs
@@ -28,10 +28,7 @@ pub use libp2p_core::{
 // Exported only with "full" feature flag.
 #[cfg(feature = "full")]
 #[doc(inline)]
-pub use libp2p::core::identity::{
-    ed25519::{Keypair, SecretKey},
-    PublicKey,
-};
+pub use libp2p::core::identity::ed25519::{Keypair, PublicKey, SecretKey};
 
 #[cfg(feature = "full")]
 pub use crate::{

--- a/bee-network/bee-gossip/src/lib.rs
+++ b/bee-network/bee-gossip/src/lib.rs
@@ -28,7 +28,10 @@ pub use libp2p_core::{
 // Exported only with "full" feature flag.
 #[cfg(feature = "full")]
 #[doc(inline)]
-pub use libp2p::core::identity::{ed25519::Keypair, PublicKey};
+pub use libp2p::core::identity::{
+    ed25519::{Keypair, SecretKey},
+    PublicKey,
+};
 
 #[cfg(feature = "full")]
 pub use crate::{


### PR DESCRIPTION
# Description of change

Re-exports the `SecretKey` symbol from `libp2p` to be used with the identity file.

## Change checklist

Tick the boxes that are relevant to your changes, and delete any items that are not.

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that new and existing unit tests pass locally with my changes
- [x] I have updated the CHANGELOG.md, if my changes are significant enough
