### PR TITLE
Impl hash() for OutputId

### DIFF
--- a/bee-message/src/output/output_id.rs
+++ b/bee-message/src/output/output_id.rs
@@ -3,7 +3,8 @@
 
 use crate::{output::OUTPUT_INDEX_RANGE, payload::transaction::TransactionId, util::hex_decode, Error};
 
-use packable::bounded::BoundedU16;
+use crypto::hashes::{blake2b::Blake2b160, Digest};
+use packable::{bounded::BoundedU16, PackableExt};
 
 use core::str::FromStr;
 
@@ -46,6 +47,12 @@ impl OutputId {
     #[inline(always)]
     pub fn split(self) -> (TransactionId, u16) {
         (self.transaction_id, self.index())
+    }
+
+    /// Hash the `OutputId` with BLAKE2b-160 for `AliasId` or `NftId`.
+    #[inline(always)]
+    pub fn hash(self) -> [u8; 20] {
+        Blake2b160::digest(&self.pack_to_vec()).into()
     }
 }
 


### PR DESCRIPTION
# Description of change

Impl hash() for OutputId because it's used for Alias/NftIds.

## Type of change

- Enhancement (a non-breaking change which adds functionality)

## Change checklist

- [ ] I have followed the contribution guidelines for this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
