### PR TITLE
Fix peer manager deadlock

### DIFF
--- a/bee-protocol/src/workers/peer/manager_res.rs
+++ b/bee-protocol/src/workers/peer/manager_res.rs
@@ -48,12 +48,10 @@ type PeerTuple = (Arc<Peer>, Option<(GossipSender, oneshot::Sender<()>)>);
 pub struct PeerManagerInner {
     peers: HashMap<PeerId, PeerTuple>,
     // This is needed to ensure message distribution fairness as iterating over a HashMap is random.
-    // TODO private
-    pub(crate) keys: Vec<PeerId>,
+    keys: Vec<PeerId>,
 }
 
 #[derive(Default)]
-// TODO private
 pub struct PeerManager(RwLock<PeerManagerInner>);
 
 impl PeerManager {

--- a/bee-protocol/src/workers/peer/manager_res.rs
+++ b/bee-protocol/src/workers/peer/manager_res.rs
@@ -13,7 +13,14 @@ use futures::channel::oneshot;
 use log::debug;
 use parking_lot::{RwLock, RwLockReadGuard, RwLockWriteGuard};
 
-use std::{collections::HashMap, convert::Infallible, sync::Arc};
+use std::{
+    collections::HashMap,
+    convert::Infallible,
+    sync::{
+        atomic::{AtomicUsize, Ordering},
+        Arc,
+    },
+};
 
 pub struct PeerManagerResWorker {}
 
@@ -30,7 +37,7 @@ impl<N: Node> Worker<N> for PeerManagerResWorker {
 
     async fn stop(self, node: &mut N) -> Result<(), Self::Error> {
         if let Some(peer_manager) = node.remove_resource::<PeerManager>() {
-            for (_, (_, sender)) in peer_manager.0.into_inner().peers {
+            for (_, (_, sender)) in peer_manager.inner.into_inner().peers {
                 if let Some(sender) = sender {
                     // TODO: Should we handle this error?
                     let _ = sender.1.send(());
@@ -52,7 +59,10 @@ pub struct PeerManagerInner {
 }
 
 #[derive(Default)]
-pub struct PeerManager(RwLock<PeerManagerInner>);
+pub struct PeerManager {
+    inner: RwLock<PeerManagerInner>,
+    counter: AtomicUsize,
+}
 
 impl PeerManager {
     pub(crate) fn new() -> Self {
@@ -60,47 +70,52 @@ impl PeerManager {
     }
 
     pub fn is_empty(&self) -> bool {
-        self.0.read().peers.is_empty()
+        self.inner.read().peers.is_empty()
     }
 
     // TODO find a way to only return a ref to the peer.
     pub fn get(&self, id: &PeerId) -> Option<impl std::ops::Deref<Target = PeerTuple> + '_> {
-        RwLockReadGuard::try_map(self.0.read(), |map| map.peers.get(id)).ok()
+        RwLockReadGuard::try_map(self.inner.read(), |map| map.peers.get(id)).ok()
     }
 
     pub fn get_mut(&self, id: &PeerId) -> Option<impl std::ops::DerefMut<Target = PeerTuple> + '_> {
-        RwLockWriteGuard::try_map(self.0.write(), |map| map.peers.get_mut(id)).ok()
+        RwLockWriteGuard::try_map(self.inner.write(), |map| map.peers.get_mut(id)).ok()
     }
 
     pub fn get_all(&self) -> Vec<Arc<Peer>> {
-        self.0.read().peers.iter().map(|(_, (peer, _))| peer).cloned().collect()
+        self.inner
+            .read()
+            .peers
+            .iter()
+            .map(|(_, (peer, _))| peer)
+            .cloned()
+            .collect()
     }
 
     pub(crate) fn add(&self, peer: Arc<Peer>) {
         debug!("Added peer {}.", peer.id());
-        let mut lock = self.0.write();
+        let mut lock = self.inner.write();
         lock.keys.push(*peer.id());
         lock.peers.insert(*peer.id(), (peer, None));
     }
 
     pub(crate) fn remove(&self, id: &PeerId) -> Option<PeerTuple> {
         debug!("Removed peer {}.", id);
-        let mut lock = self.0.write();
+        let mut lock = self.inner.write();
         lock.keys.retain(|peer_id| peer_id != id);
         lock.peers.remove(id)
     }
 
     pub(crate) fn for_each<F: Fn(&PeerId, &Peer)>(&self, f: F) {
-        self.0.read().peers.iter().for_each(|(id, (peer, _))| f(id, peer));
+        self.inner.read().peers.iter().for_each(|(id, (peer, _))| f(id, peer));
     }
 
-    pub(crate) fn find_first_fairly(&self, counter: &mut usize, f: impl Fn(&Peer) -> bool) -> Option<PeerId> {
-        let guard = self.0.read();
+    pub(crate) fn fair_find(&self, f: impl Fn(&Peer) -> bool) -> Option<PeerId> {
+        let guard = self.inner.read();
 
         for _ in 0..guard.keys.len() {
-            let peer_id = &guard.keys[*counter % guard.keys.len()];
-
-            *counter += 1;
+            let counter = self.counter.fetch_add(1, Ordering::Relaxed);
+            let peer_id = &guard.keys[counter % guard.keys.len()];
 
             if let Some((peer, _)) = guard.peers.get(peer_id) {
                 if f(peer.as_ref()) {
@@ -115,15 +130,20 @@ impl PeerManager {
     }
 
     pub fn is_connected(&self, id: &PeerId) -> bool {
-        self.0.read().peers.get(id).map_or(false, |p| p.1.is_some())
+        self.inner.read().peers.get(id).map_or(false, |p| p.1.is_some())
     }
 
     pub fn connected_peers(&self) -> u8 {
-        self.0.read().peers.iter().filter(|(_, (_, ctx))| ctx.is_some()).count() as u8
+        self.inner
+            .read()
+            .peers
+            .iter()
+            .filter(|(_, (_, ctx))| ctx.is_some())
+            .count() as u8
     }
 
     pub fn synced_peers(&self) -> u8 {
-        self.0
+        self.inner
             .read()
             .peers
             .iter()

--- a/bee-protocol/src/workers/peer/manager_res.rs
+++ b/bee-protocol/src/workers/peer/manager_res.rs
@@ -104,7 +104,7 @@ impl PeerManager {
 
             if let Some((peer, _)) = guard.peers.get(peer_id) {
                 if f(peer.as_ref()) {
-                    return Some(peer_id.clone());
+                    return Some(*peer_id);
                 }
             }
         }

--- a/bee-protocol/src/workers/peer/manager_res.rs
+++ b/bee-protocol/src/workers/peer/manager_res.rs
@@ -14,7 +14,6 @@ use log::debug;
 use parking_lot::{RwLock, RwLockReadGuard, RwLockWriteGuard};
 
 use std::{
-    collections::HashMap,
     convert::Infallible,
     sync::{
         atomic::{AtomicUsize, Ordering},

--- a/bee-protocol/src/workers/peer/manager_res.rs
+++ b/bee-protocol/src/workers/peer/manager_res.rs
@@ -96,7 +96,7 @@ impl PeerManager {
         self.0.read().peers.iter().for_each(|(id, (peer, _))| f(id, peer));
     }
 
-    pub(crate) fn foo(&self, counter: &mut usize, f: impl Fn(&PeerId, &Peer) -> bool) -> Option<PeerId> {
+    pub(crate) fn find_first_fairly(&self, counter: &mut usize, f: impl Fn(&Peer) -> bool) -> Option<PeerId> {
         let guard = self.0.read();
 
         for _ in 0..guard.keys.len() {
@@ -105,7 +105,7 @@ impl PeerManager {
             *counter += 1;
 
             if let Some((peer, _)) = guard.peers.get(peer_id) {
-                if f(peer_id, peer.as_ref()) {
+                if f(peer.as_ref()) {
                     return Some(peer_id.clone());
                 }
             }

--- a/bee-protocol/src/workers/requester/message.rs
+++ b/bee-protocol/src/workers/requester/message.rs
@@ -132,8 +132,8 @@ fn process_request_unchecked(
     let message_request = MessageRequestPacket::new(message_id);
 
     if let Some(peer_id) = peer_manager
-        .foo(counter, |_, peer| peer.has_data(index))
-        .or_else(|| peer_manager.foo(counter, |_, peer| peer.maybe_has_data(index)))
+        .find_first_fairly(counter, |peer| peer.has_data(index))
+        .or_else(|| peer_manager.find_first_fairly(counter, |peer| peer.maybe_has_data(index)))
     {
         Sender::<MessageRequestPacket>::send(&message_request, &peer_id, peer_manager, metrics)
     }

--- a/bee-protocol/src/workers/requester/message.rs
+++ b/bee-protocol/src/workers/requester/message.rs
@@ -107,7 +107,6 @@ fn process_request(
     peer_manager: &PeerManager,
     metrics: &NodeMetrics,
     requested_messages: &RequestedMessages,
-    counter: &mut usize,
 ) {
     if requested_messages.contains(&message_id) {
         return;
@@ -119,7 +118,7 @@ fn process_request(
 
     requested_messages.insert(message_id, index);
 
-    process_request_unchecked(message_id, index, peer_manager, metrics, counter);
+    process_request_unchecked(message_id, index, peer_manager, metrics);
 }
 
 fn process_request_unchecked(
@@ -127,13 +126,12 @@ fn process_request_unchecked(
     index: MilestoneIndex,
     peer_manager: &PeerManager,
     metrics: &NodeMetrics,
-    counter: &mut usize,
 ) {
     let message_request = MessageRequestPacket::new(message_id);
 
     if let Some(peer_id) = peer_manager
-        .find_first_fairly(counter, |peer| peer.has_data(index))
-        .or_else(|| peer_manager.find_first_fairly(counter, |peer| peer.maybe_has_data(index)))
+        .fair_find(|peer| peer.has_data(index))
+        .or_else(|| peer_manager.fair_find(|peer| peer.maybe_has_data(index)))
     {
         Sender::<MessageRequestPacket>::send(&message_request, &peer_id, peer_manager, metrics)
     }
@@ -144,7 +142,6 @@ async fn retry_requests<B: StorageBackend>(
     peer_manager: &PeerManager,
     metrics: &NodeMetrics,
     tangle: &Tangle<B>,
-    counter: &mut usize,
 ) {
     if peer_manager.is_empty() {
         return;
@@ -169,7 +166,7 @@ async fn retry_requests<B: StorageBackend>(
         if tangle.contains(&message_id).await {
             requested_messages.remove(&message_id);
         } else {
-            process_request_unchecked(message_id, index, peer_manager, metrics, counter);
+            process_request_unchecked(message_id, index, peer_manager, metrics);
         }
     }
 
@@ -211,19 +208,11 @@ where
                 info!("Requester running.");
 
                 let mut receiver = ShutdownStream::new(shutdown, req_queue.incoming());
-                let mut counter: usize = 0;
 
                 while let Some(MessageRequesterWorkerEvent(message_id, index)) = receiver.next().await {
                     trace!("Requesting message {}.", message_id);
 
-                    process_request(
-                        message_id,
-                        index,
-                        &peer_manager,
-                        &metrics,
-                        &requested_messages,
-                        &mut counter,
-                    );
+                    process_request(message_id, index, &peer_manager, &metrics, &requested_messages);
                 }
 
                 info!("Requester stopped.");
@@ -239,10 +228,9 @@ where
             info!("Retryer running.");
 
             let mut ticker = ShutdownStream::new(shutdown, IntervalStream::new(interval(RETRY_INTERVAL)));
-            let mut counter: usize = 0;
 
             while ticker.next().await.is_some() {
-                retry_requests(&requested_messages, &peer_manager, &metrics, &tangle, &mut counter).await;
+                retry_requests(&requested_messages, &peer_manager, &metrics, &tangle).await;
             }
 
             info!("Retryer stopped.");

--- a/bee-protocol/src/workers/requester/milestone.rs
+++ b/bee-protocol/src/workers/requester/milestone.rs
@@ -124,20 +124,8 @@ fn process_request_unchecked(
             Sender::<MilestoneRequestPacket>::send(&milestone_request, &peer_id, peer_manager, metrics);
         }
         None => {
-            let guard = peer_manager.0.read();
-
-            for _ in 0..guard.keys.len() {
-                let peer_id = &guard.keys[*counter % guard.keys.len()];
-
-                *counter += 1;
-
-                if let Some(peer) = peer_manager.get(peer_id) {
-                    // TODO also request if has_data ?
-                    if (*peer).0.maybe_has_data(index) {
-                        Sender::<MilestoneRequestPacket>::send(&milestone_request, peer_id, peer_manager, metrics);
-                        return;
-                    }
-                }
+            if let Some(peer_id) = peer_manager.foo(counter, |_, peer| peer.maybe_has_data(index)) {
+                Sender::<MilestoneRequestPacket>::send(&milestone_request, &peer_id, peer_manager, metrics);
             }
         }
     }

--- a/bee-protocol/src/workers/requester/milestone.rs
+++ b/bee-protocol/src/workers/requester/milestone.rs
@@ -124,7 +124,7 @@ fn process_request_unchecked(
             Sender::<MilestoneRequestPacket>::send(&milestone_request, &peer_id, peer_manager, metrics);
         }
         None => {
-            if let Some(peer_id) = peer_manager.foo(counter, |_, peer| peer.maybe_has_data(index)) {
+            if let Some(peer_id) = peer_manager.find_first_fairly(counter, |peer| peer.maybe_has_data(index)) {
                 Sender::<MilestoneRequestPacket>::send(&milestone_request, &peer_id, peer_manager, metrics);
             }
         }

--- a/bee-protocol/src/workers/requester/milestone.rs
+++ b/bee-protocol/src/workers/requester/milestone.rs
@@ -93,7 +93,6 @@ async fn process_request(
     peer_manager: &PeerManager,
     metrics: &NodeMetrics,
     requested_milestones: &RequestedMilestones,
-    counter: &mut usize,
 ) {
     if requested_milestones.contains(&index) {
         return;
@@ -107,7 +106,7 @@ async fn process_request(
         requested_milestones.insert(index);
     }
 
-    process_request_unchecked(index, peer_id, peer_manager, metrics, counter);
+    process_request_unchecked(index, peer_id, peer_manager, metrics);
 }
 
 fn process_request_unchecked(
@@ -115,7 +114,6 @@ fn process_request_unchecked(
     peer_id: Option<PeerId>,
     peer_manager: &PeerManager,
     metrics: &NodeMetrics,
-    counter: &mut usize,
 ) {
     let milestone_request = MilestoneRequestPacket::new(*index);
 
@@ -124,7 +122,7 @@ fn process_request_unchecked(
             Sender::<MilestoneRequestPacket>::send(&milestone_request, &peer_id, peer_manager, metrics);
         }
         None => {
-            if let Some(peer_id) = peer_manager.find_first_fairly(counter, |peer| peer.maybe_has_data(index)) {
+            if let Some(peer_id) = peer_manager.fair_find(|peer| peer.maybe_has_data(index)) {
                 Sender::<MilestoneRequestPacket>::send(&milestone_request, &peer_id, peer_manager, metrics);
             }
         }
@@ -136,7 +134,6 @@ async fn retry_requests<B: StorageBackend>(
     peer_manager: &PeerManager,
     metrics: &NodeMetrics,
     tangle: &Tangle<B>,
-    counter: &mut usize,
 ) {
     if peer_manager.is_empty() {
         return;
@@ -161,7 +158,7 @@ async fn retry_requests<B: StorageBackend>(
         if tangle.contains_milestone(index).await {
             requested_milestones.remove(&index);
         } else {
-            process_request_unchecked(index, None, peer_manager, metrics, counter);
+            process_request_unchecked(index, None, peer_manager, metrics);
         }
     }
 
@@ -202,20 +199,11 @@ where
             info!("Requester running.");
 
             let mut receiver = ShutdownStream::new(shutdown, UnboundedReceiverStream::new(rx));
-            let mut counter: usize = 0;
 
             while let Some(MilestoneRequesterWorkerEvent(index, peer_id)) = receiver.next().await {
                 if !tangle.contains_milestone(index).await {
                     debug!("Requesting milestone {}.", *index);
-                    process_request(
-                        index,
-                        peer_id,
-                        &peer_manager,
-                        &metrics,
-                        &requested_milestones,
-                        &mut counter,
-                    )
-                    .await;
+                    process_request(index, peer_id, &peer_manager, &metrics, &requested_milestones).await;
                 }
             }
 
@@ -231,10 +219,9 @@ where
             info!("Retryer running.");
 
             let mut ticker = ShutdownStream::new(shutdown, IntervalStream::new(interval(RETRY_INTERVAL)));
-            let mut counter: usize = 0;
 
             while ticker.next().await.is_some() {
-                retry_requests(&requested_milestones, &peer_manager, &metrics, &tangle, &mut counter).await;
+                retry_requests(&requested_milestones, &peer_manager, &metrics, &tangle).await;
             }
 
             info!("Retryer stopped.");


### PR DESCRIPTION
# Description of change

Avoid nested read guard acquisition over the `PeerManager` lock in the same function which causes a deadlock. See https://docs.rs/parking_lot/latest/parking_lot/type.RwLock.html for more details. In particular:

> This lock uses a task-fair locking policy which avoids both reader and writer starvation. This means that readers trying to acquire the lock will block even if the lock is unlocked when there are writers waiting to acquire the lock. Because of this, attempts to recursively acquire a read lock within a single thread may result in a deadlock.

Also the `RwLock` field has been made private to keep all the ways of accessing this lock as methods of the struct that contains it.

## Links to any relevant issues

Fixes https://github.com/iotaledger/bee/issues/985 

## Type of change

Choose a type of change, and delete any options that are not relevant.

- Bug fix (a non-breaking change which fixes an issue)

## How the change has been tested

The node was run twice for 30 and 60 minutes and the deadlock did not happen

## Change checklist

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that new and existing unit tests pass locally with my changes
- [x] I have updated the CHANGELOG.md, if my changes are significant enough
