### PR TITLE
Enable rand features 'std' and 'std_rng' in bee-autopeering

### DIFF
--- a/bee-network/bee-autopeering/Cargo.toml
+++ b/bee-network/bee-autopeering/Cargo.toml
@@ -26,7 +26,7 @@ num-derive = { version = "0.3.3", default-features = false  }
 num-traits = { version = "0.2.14" , default-features = false }
 priority-queue = { version = "1.2.0" , default-features = false }
 prost = { version = "0.8", default-features = false, features = [ "std" ] }
-rand = { version = "0.8.4" , default-features = false }
+rand = { version = "0.8.4" , default-features = false, features = [ "std", "std_rng" ] }
 ring = { version = "0.16.20" , default-features = false }
 rocksdb = { version = "0.17.0", default-features = false, optional = true }
 serde = { version = "1.0", default-features = false , features = [ "derive" ] }


### PR DESCRIPTION
# Description of change

`bee-autopeering` relies on the `rand` features: `std` and `std_rng`, which weren't enabled in the crate's `Cargo.toml` itself. This went unnoticed due to another crate in the workspace having this features already enabled. (Shouldn't Cargo better ensure, that each crate also compiles on its own, i.e. has a consistent `Cargo.toml`? :thinking: )

## Links to any relevant issues

Fixes #1077 

## Type of change

- Bug fix (a non-breaking change which fixes an issue)

## How the change has been tested

`cargo b -p bee-autopeering`

## Change checklist

Tick the boxes that are relevant to your changes, and delete any items that are not.

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that new and existing unit tests pass locally with my changes
- [x] I have updated the CHANGELOG.md, if my changes are significant enough
