### PR TITLE
Raise autopeering discovery query log level to 'info'

### DIFF
--- a/bee-network/bee-autopeering/src/discovery/query.rs
+++ b/bee-network/bee-autopeering/src/discovery/query.rs
@@ -74,9 +74,9 @@ pub(crate) fn query_fn() -> Repeat<QueryContext> {
     Box::new(|ctx| {
         let peers = select_peers_to_query(&ctx.active_peers);
         if peers.is_empty() {
-            log::debug!("No peers to query.");
+            log::info!("No peers to query.");
         } else {
-            log::debug!("Querying {} peer/s...", peers.len());
+            log::info!("Querying {} peer/s...", peers.len());
 
             for peer_id in peers.into_iter() {
                 let ctx_ = ctx.clone();


### PR DESCRIPTION
# Description of change

Now logs discovery queries in `bee-autopeering` as `info` instead of `debug`.

Example:
```bash
2022-02-04 13:34:49 (UTC) bee_autopeering::discovery::query          INFO  No peers to query.
```

Since a query happens in a predefined interval, the info log will keep the user updated about what is going on behind the scenes.

## Type of change

Choose a type of change, and delete any options that are not relevant.

- Enhancement (a non-breaking change which adds functionality)

## How the change has been tested

Investigated output of a running node.

## Change checklist

Tick the boxes that are relevant to your changes, and delete any items that are not.

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that new and existing unit tests pass locally with my changes
- [x] I have updated the CHANGELOG.md, if my changes are significant enough
