### PR TITLE
Add IPv6 support to `bee-autopeering`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -186,7 +186,7 @@ checksum = "cf9ff0bbfd639f15c74af777d81383cf53efb7c93613f6cab67c6c11e05bbf8b"
 
 [[package]]
 name = "bee-autopeering"
-version = "0.4.0-alpha1"
+version = "0.4.0"
 dependencies = [
  "async-trait",
  "base64 0.13.0",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -186,7 +186,7 @@ checksum = "cf9ff0bbfd639f15c74af777d81383cf53efb7c93613f6cab67c6c11e05bbf8b"
 
 [[package]]
 name = "bee-autopeering"
-version = "0.3.0"
+version = "0.4.0-alpha1"
 dependencies = [
  "async-trait",
  "base64 0.13.0",

--- a/bee-network/bee-autopeering/CHANGELOG.md
+++ b/bee-network/bee-autopeering/CHANGELOG.md
@@ -19,6 +19,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Security -->
 
+## 0.4.0 - 2022-xx-xx
+
+### Added
+
+- IPv6 support;
+
 ## 0.3.0 - 2022-01-20
 
 ### Added

--- a/bee-network/bee-autopeering/CHANGELOG.md
+++ b/bee-network/bee-autopeering/CHANGELOG.md
@@ -19,7 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Security -->
 
-## 0.4.0 - 2022-xx-xx
+## 0.4.0 - 2022-02-11
 
 ### Added
 

--- a/bee-network/bee-autopeering/Cargo.toml
+++ b/bee-network/bee-autopeering/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bee-autopeering"
-version = "0.4.0-alpha1"
+version = "0.4.0"
 authors = [ "IOTA Stiftung" ]
 edition = "2021"
 description = "Allows peers in the same IOTA network to automatically discover each other."

--- a/bee-network/bee-autopeering/Cargo.toml
+++ b/bee-network/bee-autopeering/Cargo.toml
@@ -46,6 +46,7 @@ prost-build = { version = "0.8", default-features = false }
 
 [[example]]
 name = "node"
+required-features = [ "in-memory" ]
 
 [features]
 default = [ "rocksdb" ]

--- a/bee-network/bee-autopeering/Cargo.toml
+++ b/bee-network/bee-autopeering/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bee-autopeering"
-version = "0.3.0"
+version = "0.4.0-alpha1"
 authors = [ "IOTA Stiftung" ]
 edition = "2021"
 description = "Allows peers in the same IOTA network to automatically discover each other."

--- a/bee-network/bee-autopeering/examples/node.rs
+++ b/bee-network/bee-autopeering/examples/node.rs
@@ -4,10 +4,8 @@
 #![allow(warnings)]
 
 use bee_autopeering::{
-    config::AutopeeringConfigBuilder,
-    init,
-    stores::InMemoryPeerStore,
-    AutopeeringConfig, Event, Local, NeighborValidator, Peer, ServiceProtocol, AUTOPEERING_SERVICE_NAME,
+    config::AutopeeringConfigBuilder, init, stores::InMemoryPeerStore, AutopeeringConfig, Event, Local,
+    NeighborValidator, Peer, ServiceProtocol, AUTOPEERING_SERVICE_NAME,
 };
 
 use libp2p_core::identity::ed25519::Keypair;

--- a/bee-network/bee-autopeering/examples/node.rs
+++ b/bee-network/bee-autopeering/examples/node.rs
@@ -64,7 +64,7 @@ async fn main() {
     local.add_service(
         AUTOPEERING_SERVICE_NAME,
         ServiceProtocol::Udp,
-        config.bind_addr().port(),
+        config.bind_addr_v4().unwrap().port(),
     );
     local.add_service(NETWORK_SERVICE_NAME, ServiceProtocol::Tcp, 15600);
 

--- a/bee-network/bee-autopeering/examples/node.rs
+++ b/bee-network/bee-autopeering/examples/node.rs
@@ -6,7 +6,7 @@
 use bee_autopeering::{
     config::AutopeeringConfigBuilder,
     init,
-    stores::{InMemoryPeerStore, SledPeerStore, SledPeerStoreConfig},
+    stores::InMemoryPeerStore,
     AutopeeringConfig, Event, Local, NeighborValidator, Peer, ServiceProtocol, AUTOPEERING_SERVICE_NAME,
 };
 
@@ -74,10 +74,10 @@ async fn main() {
 
     // Storage config.
     // No config is  necessary for the `InMemoryPeerStore`.
-    // let peer_store_config = ();
+    let peer_store_config = ();
 
     // Sled peer store:
-    let peer_store_config = SledPeerStoreConfig::new().path("./peerstore");
+    // let peer_store_config = SledPeerStoreConfig::new().path("./peerstore");
 
     // Neighbor validator.
     let neighbor_validator = GossipNeighborValidator {};
@@ -86,7 +86,7 @@ async fn main() {
     let term_signal = ctrl_c();
 
     // Initialize the Autopeering service.
-    let mut event_rx = bee_autopeering::init::<SledPeerStore, _, _, GossipNeighborValidator>(
+    let mut event_rx = bee_autopeering::init::<InMemoryPeerStore, _, _, GossipNeighborValidator>(
         config.clone(),
         version,
         network_name,

--- a/bee-network/bee-autopeering/src/config.rs
+++ b/bee-network/bee-autopeering/src/config.rs
@@ -230,7 +230,7 @@ mod tests {
         let toml_config_str = r#"
             enabled = true
             bind_address = "0.0.0.0:14626"
-            bind_address_v6 = "[::]:14626",
+            bind_address_v6 = "[::]:14626"
             entry_nodes = [
                 "/dns/entry-hornet-0.h.chrysalis-mainnet.iotaledger.net/udp/14626/autopeering/iotaPHdAn7eueBnXtikZMwhfPXaeGJGXDt4RBuLuGgb",
                 "/dns/entry-hornet-1.h.chrysalis-mainnet.iotaledger.net/udp/14626/autopeering/iotaJJqMd5CQvv1A61coSQCYW9PNT1QKPs7xh2Qg5K2",

--- a/bee-network/bee-autopeering/src/config.rs
+++ b/bee-network/bee-autopeering/src/config.rs
@@ -250,8 +250,8 @@ mod tests {
     fn create_config() -> AutopeeringConfig {
         AutopeeringConfig {
             enabled: true,
-            bind_addr_v4: "0.0.0.0:14626".parse().unwrap(),
-            bind_addr_v6: "[::]:14626".parse().unwrap(),
+            bind_addr_v4: Some("0.0.0.0:14626".parse().unwrap()),
+            bind_addr_v6: Some("[::]:14626".parse().unwrap()),
             entry_nodes: vec![
                 "/dns/entry-hornet-0.h.chrysalis-mainnet.iotaledger.net/udp/14626/autopeering/iotaPHdAn7eueBnXtikZMwhfPXaeGJGXDt4RBuLuGgb".parse().unwrap(),
                 "/dns/entry-hornet-1.h.chrysalis-mainnet.iotaledger.net/udp/14626/autopeering/iotaJJqMd5CQvv1A61coSQCYW9PNT1QKPs7xh2Qg5K2".parse().unwrap(),

--- a/bee-network/bee-autopeering/src/config.rs
+++ b/bee-network/bee-autopeering/src/config.rs
@@ -8,7 +8,7 @@
 //! ```json
 //! "autopeering": {
 //!     "enabled": true,
-//!     "bindAddressV4": "0.0.0.0:14626",
+//!     "bindAddress": "0.0.0.0:14626",
 //!     "entryNodes": [
 //!          "/dns/entry-hornet-0.h.chrysalis-mainnet.iotaledger.net/udp/14626/autopeering/iotaPHdAn7eueBnXtikZMwhfPXaeGJGXDt4RBuLuGgb",
 //!          "/dns/entry-hornet-1.h.chrysalis-mainnet.iotaledger.net/udp/14626/autopeering/iotaJJqMd5CQvv1A61coSQCYW9PNT1QKPs7xh2Qg5K2",
@@ -23,7 +23,7 @@
 //! ```toml
 //! [autopeering]
 //! enabled = true
-//! bind_address_v4 = "0.0.0.0:14626"
+//! bind_address = "0.0.0.0:14626"
 //! entry_nodes = [
 //!     "/dns/entry-hornet-0.h.chrysalis-mainnet.iotaledger.net/udp/14626/autopeering/iotaPHdAn7eueBnXtikZMwhfPXaeGJGXDt4RBuLuGgb",
 //!     "/dns/entry-hornet-1.h.chrysalis-mainnet.iotaledger.net/udp/14626/autopeering/iotaJJqMd5CQvv1A61coSQCYW9PNT1QKPs7xh2Qg5K2",

--- a/bee-network/bee-autopeering/src/config.rs
+++ b/bee-network/bee-autopeering/src/config.rs
@@ -200,13 +200,14 @@ fn ensure_ipv6(addr: Option<SocketAddr>) {
     if let Some(addr) = addr {
         if !addr.is_ipv6() {
             panic!("invalid config: bind address is not IPv6");
-            // TODO: Use `to_ipv4_mapped` once stable.
-            // See issue #27709 <https://github.com/rust-lang/rust/issues/27709> for more information
-        } else if let IpAddr::V6(ipv6_addr) = addr.ip() {
-            if ipv6_addr.to_ipv4().is_some() {
-                panic!("invalid config: IPv4-mapped IPv6 addresses not supported")
-            }
-        }
+        } 
+        // else if let IpAddr::V6(ipv6_addr) = addr.ip() {
+        //     // TODO: Use `to_ipv4_mapped` once stable.
+        //     // See issue #27709 <https://github.com/rust-lang/rust/issues/27709> for more information
+        //     if ipv6_addr.to_ipv4().is_some() {
+        //         panic!("invalid config: IPv4-mapped IPv6 addresses not allowed")
+        //     }
+        // }
     }
 }
 

--- a/bee-network/bee-autopeering/src/config.rs
+++ b/bee-network/bee-autopeering/src/config.rs
@@ -38,15 +38,11 @@ use serde::Deserialize;
 
 use std::{
     fmt::Debug,
-    net::{IpAddr, SocketAddr},
+    net::SocketAddr,
     path::{Path, PathBuf},
 };
 
 const ENABLED_DEFAULT: bool = false;
-// TODO: watch out for possible constification regarding `SocketAddr::new()`.
-// const BIND_ADDR_V4_DEFAULT: IpAddr = IpAddr::V4(Ipv4Addr::UNSPECIFIED);
-// const BIND_ADDR_V6_DEFAULT: IpAddr = IpAddr::V6(Ipv6Addr::UNSPECIFIED);
-// const BIND_PORT_DEFAULT: u16 = 14626;
 const ENTRYNODES_PREFER_IPV6_DEFAULT: bool = false;
 const RUN_AS_ENTRYNODE_DEFAULT: bool = false;
 const DROP_NEIGHBORS_ON_SALT_UPDATE_DEFAULT: bool = false;
@@ -201,13 +197,6 @@ fn ensure_ipv6(addr: Option<SocketAddr>) {
         if !addr.is_ipv6() {
             panic!("invalid config: bind address is not IPv6");
         } 
-        // else if let IpAddr::V6(ipv6_addr) = addr.ip() {
-        //     // TODO: Use `to_ipv4_mapped` once stable.
-        //     // See issue #27709 <https://github.com/rust-lang/rust/issues/27709> for more information
-        //     if ipv6_addr.to_ipv4().is_some() {
-        //         panic!("invalid config: IPv4-mapped IPv6 addresses not allowed")
-        //     }
-        // }
     }
 }
 

--- a/bee-network/bee-autopeering/src/config.rs
+++ b/bee-network/bee-autopeering/src/config.rs
@@ -8,7 +8,7 @@
 //! ```json
 //! "autopeering": {
 //!     "enabled": true,
-//!     "bindAddress": "0.0.0.0:14626",
+//!     "bindAddressV4": "0.0.0.0:14626",
 //!     "entryNodes": [
 //!          "/dns/entry-hornet-0.h.chrysalis-mainnet.iotaledger.net/udp/14626/autopeering/iotaPHdAn7eueBnXtikZMwhfPXaeGJGXDt4RBuLuGgb",
 //!          "/dns/entry-hornet-1.h.chrysalis-mainnet.iotaledger.net/udp/14626/autopeering/iotaJJqMd5CQvv1A61coSQCYW9PNT1QKPs7xh2Qg5K2",
@@ -23,7 +23,7 @@
 //! ```toml
 //! [autopeering]
 //! enabled = true
-//! bind_address = "0.0.0.0:14626"
+//! bind_address_v4 = "0.0.0.0:14626"
 //! entry_nodes = [
 //!     "/dns/entry-hornet-0.h.chrysalis-mainnet.iotaledger.net/udp/14626/autopeering/iotaPHdAn7eueBnXtikZMwhfPXaeGJGXDt4RBuLuGgb",
 //!     "/dns/entry-hornet-1.h.chrysalis-mainnet.iotaledger.net/udp/14626/autopeering/iotaJJqMd5CQvv1A61coSQCYW9PNT1QKPs7xh2Qg5K2",
@@ -38,14 +38,15 @@ use serde::Deserialize;
 
 use std::{
     fmt::Debug,
-    net::{IpAddr, Ipv4Addr, SocketAddr},
+    net::{IpAddr, SocketAddr},
     path::{Path, PathBuf},
 };
 
-const AUTOPEERING_ENABLED_DEFAULT: bool = false;
+const ENABLED_DEFAULT: bool = false;
 // TODO: watch out for possible constification regarding `SocketAddr::new()`.
-const AUTOPEERING_BIND_ADDR_DEFAULT: IpAddr = IpAddr::V4(Ipv4Addr::UNSPECIFIED);
-const AUTOPEERING_BIND_PORT_DEFAULT: u16 = 14626;
+// const BIND_ADDR_V4_DEFAULT: IpAddr = IpAddr::V4(Ipv4Addr::UNSPECIFIED);
+// const BIND_ADDR_V6_DEFAULT: IpAddr = IpAddr::V6(Ipv6Addr::UNSPECIFIED);
+// const BIND_PORT_DEFAULT: u16 = 14626;
 const ENTRYNODES_PREFER_IPV6_DEFAULT: bool = false;
 const RUN_AS_ENTRYNODE_DEFAULT: bool = false;
 const DROP_NEIGHBORS_ON_SALT_UPDATE_DEFAULT: bool = false;
@@ -56,7 +57,8 @@ const PEER_STORAGE_PATH_DEFAULT: &str = "./storage/mainnet/peers";
 #[derive(Clone, Debug)]
 pub struct AutopeeringConfig {
     enabled: bool,
-    bind_addr: SocketAddr,
+    bind_addr_v4: Option<SocketAddr>,
+    bind_addr_v6: Option<SocketAddr>,
     entry_nodes: Vec<AutopeeringMultiaddr>,
     entry_nodes_prefer_ipv6: bool,
     run_as_entry_node: bool,
@@ -70,9 +72,14 @@ impl AutopeeringConfig {
         self.enabled
     }
 
-    /// The bind address for the server.
-    pub fn bind_addr(&self) -> SocketAddr {
-        self.bind_addr
+    /// The IPv4 bind address for the server.
+    pub fn bind_addr_v4(&self) -> Option<SocketAddr> {
+        self.bind_addr_v4
+    }
+
+    /// The IPv6 bind address for the server.
+    pub fn bind_addr_v6(&self) -> Option<SocketAddr> {
+        self.bind_addr_v6
     }
 
     /// The entry nodes for bootstrapping.
@@ -116,9 +123,12 @@ impl AutopeeringConfig {
 pub struct AutopeeringConfigBuilder {
     /// Whether autopeering should be enabled.
     pub enabled: bool,
-    /// The bind address for the server.
+    /// The IPv4 bind address for the server.
     #[serde(alias = "bindAddress", alias = "bind_address")]
-    pub bind_addr: SocketAddr,
+    pub bind_addr_v4: Option<SocketAddr>,
+    /// The IPv6 bind address for the server.
+    #[serde(alias = "bindAddressV6", alias = "bind_address_v6")]
+    pub bind_addr_v6: Option<SocketAddr>,
     /// The entry nodes for bootstrapping.
     #[serde(alias = "entryNodes")]
     pub entry_nodes: Vec<AutopeeringMultiaddr>,
@@ -139,9 +149,17 @@ pub struct AutopeeringConfigBuilder {
 impl AutopeeringConfigBuilder {
     /// Builds the actual `AutopeeringConfig`.
     pub fn finish(self) -> AutopeeringConfig {
+        ensure_ipv4(self.bind_addr_v4);
+        ensure_ipv6(self.bind_addr_v6);
+
+        if self.bind_addr_v4.is_none() && self.bind_addr_v6.is_none() {
+            panic!("invalid config: no bind addresses");
+        }
+
         AutopeeringConfig {
             enabled: self.enabled,
-            bind_addr: self.bind_addr,
+            bind_addr_v4: self.bind_addr_v4,
+            bind_addr_v6: self.bind_addr_v6,
             entry_nodes: self.entry_nodes,
             entry_nodes_prefer_ipv6: self.entry_nodes_prefer_ipv6.unwrap_or(ENTRYNODES_PREFER_IPV6_DEFAULT),
             run_as_entry_node: self.run_as_entry_node.unwrap_or(RUN_AS_ENTRYNODE_DEFAULT),
@@ -158,13 +176,36 @@ impl AutopeeringConfigBuilder {
 impl Default for AutopeeringConfigBuilder {
     fn default() -> Self {
         Self {
-            enabled: AUTOPEERING_ENABLED_DEFAULT,
-            bind_addr: SocketAddr::new(AUTOPEERING_BIND_ADDR_DEFAULT, AUTOPEERING_BIND_PORT_DEFAULT),
+            enabled: ENABLED_DEFAULT,
+            bind_addr_v4: None,
+            bind_addr_v6: None,
             entry_nodes: Vec::default(),
             entry_nodes_prefer_ipv6: Some(ENTRYNODES_PREFER_IPV6_DEFAULT),
             run_as_entry_node: Some(RUN_AS_ENTRYNODE_DEFAULT),
             drop_neighbors_on_salt_update: Some(DROP_NEIGHBORS_ON_SALT_UPDATE_DEFAULT),
             peer_storage_path: Some(PEER_STORAGE_PATH_DEFAULT.into()),
+        }
+    }
+}
+
+fn ensure_ipv4(addr: Option<SocketAddr>) {
+    if let Some(addr) = addr {
+        if !addr.is_ipv4() {
+            panic!("invalid config: bind address is not IPv4");
+        }
+    }
+}
+
+fn ensure_ipv6(addr: Option<SocketAddr>) {
+    if let Some(addr) = addr {
+        if !addr.is_ipv6() {
+            panic!("invalid config: bind address is not IPv6");
+            // TODO: Use `to_ipv4_mapped` once stable.
+            // See issue #27709 <https://github.com/rust-lang/rust/issues/27709> for more information
+        } else if let IpAddr::V6(ipv6_addr) = addr.ip() {
+            if ipv6_addr.to_ipv4().is_some() {
+                panic!("invalid config: IPv4-mapped IPv6 addresses not supported")
+            }
         }
     }
 }
@@ -178,8 +219,8 @@ mod tests {
         {
             "enabled": true,
             "bindAddress": "0.0.0.0:14626",
+            "bindAddressV6": "[::]:14626",
             "entryNodes": [
-                "/dns/lucamoser.ch/udp/14826/autopeering/4H6WV54tB29u8xCcEaMGQMn37LFvM1ynNpp27TTXaqNM",
                 "/dns/entry-hornet-0.h.chrysalis-mainnet.iotaledger.net/udp/14626/autopeering/iotaPHdAn7eueBnXtikZMwhfPXaeGJGXDt4RBuLuGgb",
                 "/dns/entry-hornet-1.h.chrysalis-mainnet.iotaledger.net/udp/14626/autopeering/iotaJJqMd5CQvv1A61coSQCYW9PNT1QKPs7xh2Qg5K2",
                 "/dns/entry-mainnet.tanglebay.com/udp/14626/autopeering/iot4By1FD4pFLrGJ6AAe7YEeSu9RbW9xnPUmxMdQenC"
@@ -199,8 +240,8 @@ mod tests {
         let toml_config_str = r#"
             enabled = true
             bind_address = "0.0.0.0:14626"
+            bind_address_v6 = "[::]:14626",
             entry_nodes = [
-                "/dns/lucamoser.ch/udp/14826/autopeering/4H6WV54tB29u8xCcEaMGQMn37LFvM1ynNpp27TTXaqNM",
                 "/dns/entry-hornet-0.h.chrysalis-mainnet.iotaledger.net/udp/14626/autopeering/iotaPHdAn7eueBnXtikZMwhfPXaeGJGXDt4RBuLuGgb",
                 "/dns/entry-hornet-1.h.chrysalis-mainnet.iotaledger.net/udp/14626/autopeering/iotaJJqMd5CQvv1A61coSQCYW9PNT1QKPs7xh2Qg5K2",
                 "/dns/entry-mainnet.tanglebay.com/udp/14626/autopeering/iot4By1FD4pFLrGJ6AAe7YEeSu9RbW9xnPUmxMdQenC"
@@ -219,9 +260,9 @@ mod tests {
     fn create_config() -> AutopeeringConfig {
         AutopeeringConfig {
             enabled: true,
-            bind_addr: "0.0.0.0:14626".parse().unwrap(),
+            bind_addr_v4: "0.0.0.0:14626".parse().unwrap(),
+            bind_addr_v6: "[::]:14626".parse().unwrap(),
             entry_nodes: vec![
-                "/dns/lucamoser.ch/udp/14826/autopeering/4H6WV54tB29u8xCcEaMGQMn37LFvM1ynNpp27TTXaqNM".parse().unwrap(),
                 "/dns/entry-hornet-0.h.chrysalis-mainnet.iotaledger.net/udp/14626/autopeering/iotaPHdAn7eueBnXtikZMwhfPXaeGJGXDt4RBuLuGgb".parse().unwrap(),
                 "/dns/entry-hornet-1.h.chrysalis-mainnet.iotaledger.net/udp/14626/autopeering/iotaJJqMd5CQvv1A61coSQCYW9PNT1QKPs7xh2Qg5K2".parse().unwrap(),
                 "/dns/entry-mainnet.tanglebay.com/udp/14626/autopeering/iot4By1FD4pFLrGJ6AAe7YEeSu9RbW9xnPUmxMdQenC".parse().unwrap(),

--- a/bee-network/bee-autopeering/src/config.rs
+++ b/bee-network/bee-autopeering/src/config.rs
@@ -196,7 +196,7 @@ fn ensure_ipv6(addr: Option<SocketAddr>) {
     if let Some(addr) = addr {
         if !addr.is_ipv6() {
             panic!("invalid config: bind address is not IPv6");
-        } 
+        }
     }
 }
 

--- a/bee-network/bee-autopeering/src/lib.rs
+++ b/bee-network/bee-autopeering/src/lib.rs
@@ -61,7 +61,7 @@
 //!         l.add_service(
 //!             AUTOPEERING_SERVICE_NAME,
 //!             ServiceProtocol::Udp,
-//!             config.bind_addr().port(),
+//!             config.bind_addr_v4().unwrap().port(),
 //!         );
 //!         l.add_service(NETWORK, ServiceProtocol::Tcp, 15600);
 //!         l

--- a/bee-network/bee-autopeering/src/peer/stores/mod.rs
+++ b/bee-network/bee-autopeering/src/peer/stores/mod.rs
@@ -10,12 +10,12 @@ mod rocksdb;
 #[cfg(feature = "sled")]
 mod sled;
 
+#[cfg(feature = "in-memory")]
+pub use self::in_memory::*;
 #[cfg(feature = "rocksdb")]
 pub use self::rocksdb::*;
 #[cfg(feature = "sled")]
 pub use self::sled::*;
-#[cfg(feature = "in-memory")]
-pub use in_memory::*;
 
 use super::{
     lists::{ActivePeer, ActivePeersList, ReplacementPeersList},

--- a/bee-network/bee-autopeering/src/server.rs
+++ b/bee-network/bee-autopeering/src/server.rs
@@ -110,6 +110,8 @@ impl Server {
             .is_ok()
             {
                 socket_bound = true;
+            } else {
+                log::warn!("Binding to the configured IPv4 address {} failed.", bind_addr_v4)
             }
         }
 
@@ -120,12 +122,14 @@ impl Server {
                 .is_ok()
             {
                 socket_bound = true;
+            } else {
+                log::warn!("Binding to the configured IPv6 ({}) failed.", bind_addr_v6)
             }
         }
 
         // At least one socket must be successfully bound.
         if !socket_bound {
-            panic!("binding a socket failed");
+            panic!("failed binding a UDP socket to an address");
         }
     }
 }

--- a/bee-network/bee-autopeering/src/server.rs
+++ b/bee-network/bee-autopeering/src/server.rs
@@ -117,8 +117,8 @@ impl Server {
 
         // Bind a socket to the given IPv6 address.
         if let Some(bind_addr_v6) = config.bind_addr_v6 {
-            if let Ok(local_addr) = bind_socket::<_, IP_V6_FLAG>(bind_addr_v6, incoming_senders, local, outgoing_rx_v6, task_mngr)
-                .await
+            if let Ok(local_addr) =
+                bind_socket::<_, IP_V6_FLAG>(bind_addr_v6, incoming_senders, local, outgoing_rx_v6, task_mngr).await
             {
                 log::debug!("Bound IPv6 socket to {}.", local_addr);
                 socket_bound = true;

--- a/bee-network/bee-autopeering/src/server.rs
+++ b/bee-network/bee-autopeering/src/server.rs
@@ -94,9 +94,6 @@ impl Server {
 
         let mut socket_bound = false;
 
-        // Note: the config validation guarantees that at least one of the bind addresses
-        // is set, and that `bind_addr_v6` is a true (not v4-mapped) v6 address.
-
         // Bind a socket to the given IPv4 address.
         if let Some(bind_addr_v4) = config.bind_addr_v4 {
             if let Ok(local_addr) = bind_socket::<_, IP_V4_FLAG>(
@@ -111,7 +108,7 @@ impl Server {
                 log::debug!("Bound IPv4 socket to {}.", local_addr);
                 socket_bound = true;
             } else {
-                log::warn!("Binding to the configured IPv4 address {} failed.", bind_addr_v4)
+                log::warn!("Binding to the configured IPv4 address ({}) failed.", bind_addr_v4)
             }
         }
 
@@ -123,7 +120,7 @@ impl Server {
                 log::debug!("Bound IPv6 socket to {}.", local_addr);
                 socket_bound = true;
             } else {
-                log::warn!("Binding to the configured IPv6 ({}) failed.", bind_addr_v6)
+                log::warn!("Binding to the configured IPv6 address ({}) failed.", bind_addr_v6)
             }
         }
 

--- a/bee-network/bee-autopeering/src/task.rs
+++ b/bee-network/bee-autopeering/src/task.rs
@@ -34,7 +34,7 @@ pub(crate) trait Runnable {
     async fn run(self, shutdown_rx: Self::ShutdownSignal);
 }
 
-pub(crate) struct TaskManager<S: PeerStore, const N: usize> {
+pub(crate) struct TaskManager<S: PeerStore> {
     shutdown_handles: HashMap<String, JoinHandle<()>>,
     shutdown_senders: HashMap<String, ShutdownTx>,
     shutdown_order: PriorityQueue<String, u8>,
@@ -43,12 +43,12 @@ pub(crate) struct TaskManager<S: PeerStore, const N: usize> {
     replacements: ReplacementPeersList,
 }
 
-impl<S: PeerStore, const N: usize> TaskManager<S, N> {
+impl<S: PeerStore> TaskManager<S> {
     pub(crate) fn new(peer_store: S, active_peers: ActivePeersList, replacements: ReplacementPeersList) -> Self {
         Self {
-            shutdown_handles: HashMap::with_capacity(N),
-            shutdown_senders: HashMap::with_capacity(N),
-            shutdown_order: PriorityQueue::with_capacity(N),
+            shutdown_handles: HashMap::default(),
+            shutdown_senders: HashMap::default(),
+            shutdown_order: PriorityQueue::default(),
             peer_store,
             active_peers,
             replacements,

--- a/bee-node/Cargo.toml
+++ b/bee-node/Cargo.toml
@@ -11,7 +11,7 @@ keywords = [ "iota", "tangle", "bee", "framework", "node" ]
 homepage = "https://www.iota.org"
 
 [dependencies]
-bee-autopeering = { version = "0.3.0", path = "../bee-network/bee-autopeering", default-features = false, features = [ "rocksdb" ] }
+bee-autopeering = { version = "0.4.0-alpha1", path = "../bee-network/bee-autopeering", default-features = false, features = [ "rocksdb" ] }
 bee-common = { version = "0.6.0", path = "../bee-common/bee-common", default-features = false }
 bee-gossip = { version = "0.4.0", path = "../bee-network/bee-gossip", default-features = false, features = [ "full" ] }
 bee-ledger = { version = "0.6.1", path = "../bee-ledger", default-features = false, features = [ "workers" ] }

--- a/bee-node/Cargo.toml
+++ b/bee-node/Cargo.toml
@@ -11,7 +11,7 @@ keywords = [ "iota", "tangle", "bee", "framework", "node" ]
 homepage = "https://www.iota.org"
 
 [dependencies]
-bee-autopeering = { version = "0.4.0-alpha1", path = "../bee-network/bee-autopeering", default-features = false, features = [ "rocksdb" ] }
+bee-autopeering = { version = "0.4.0", path = "../bee-network/bee-autopeering", default-features = false, features = [ "rocksdb" ] }
 bee-common = { version = "0.6.0", path = "../bee-common/bee-common", default-features = false }
 bee-gossip = { version = "0.4.0", path = "../bee-network/bee-gossip", default-features = false, features = [ "full" ] }
 bee-ledger = { version = "0.6.1", path = "../bee-ledger", default-features = false, features = [ "workers" ] }

--- a/bee-node/config.chrysalis-comnet.toml
+++ b/bee-node/config.chrysalis-comnet.toml
@@ -29,15 +29,15 @@ max_discovered_peers    = 8
 #alias    = ""
 
 [autopeering]
-enabled = false
-bind_address = "0.0.0.0:14626"
-entry_nodes = [
+enabled                       = false
+bind_address                  = "0.0.0.0:14626"
+entry_nodes                   = [
     "/dns/entry.comnet.tanglebay.com/udp/14636/autopeering/iot4By1FD4pFLrGJ6AAe7YEeSu9RbW9xnPUmxMdQenC",
 ]
-entry_nodes_prefer_ipv6 = false
-run_as_entry_node = false
+entry_nodes_prefer_ipv6       = false
+run_as_entry_node             = false
 drop_neighbors_on_salt_update = false
-peer_storage_path = "./storage/comnet/peers"
+peer_storage_path             = "./storage/comnet/peers"
 
 [protocol]
 minimum_pow_score = 2000

--- a/bee-node/config.chrysalis-devnet.toml
+++ b/bee-node/config.chrysalis-devnet.toml
@@ -29,13 +29,13 @@ max_discovered_peers    = 8
 #alias    = ""
 
 [autopeering]
-enabled = false
-bind_address = "0.0.0.0:14626"
-entry_nodes = []
-entry_nodes_prefer_ipv6 = false
-run_as_entry_node = false
+enabled                       = false
+bind_address                  = "0.0.0.0:14626"
+entry_nodes                   = []
+entry_nodes_prefer_ipv6       = false
+run_as_entry_node             = false
 drop_neighbors_on_salt_update = false
-peer_storage_path = "./storage/devnet/peers"
+peer_storage_path             = "./storage/devnet/peers"
 
 [protocol]
 minimum_pow_score = 2000

--- a/bee-node/config.chrysalis-mainnet.toml
+++ b/bee-node/config.chrysalis-mainnet.toml
@@ -31,7 +31,6 @@ max_discovered_peers    = 8
 [autopeering]
 enabled         = false
 bind_address    = "0.0.0.0:14626"
-bind_address_v6 = "[::]:14626"
 entry_nodes     = [
     "/dns/entry-hornet-0.h.chrysalis-mainnet.iotaledger.net/udp/14626/autopeering/iotaPHdAn7eueBnXtikZMwhfPXaeGJGXDt4RBuLuGgb",
     "/dns/entry-hornet-1.h.chrysalis-mainnet.iotaledger.net/udp/14626/autopeering/iotaJJqMd5CQvv1A61coSQCYW9PNT1QKPs7xh2Qg5K2",

--- a/bee-node/config.chrysalis-mainnet.toml
+++ b/bee-node/config.chrysalis-mainnet.toml
@@ -29,10 +29,10 @@ max_discovered_peers    = 8
 #alias    = ""
 
 [autopeering]
-enabled = false
-bind_address = "0.0.0.0:14626"
-entry_nodes = [
-    "/dns/lucamoser.ch/udp/14826/autopeering/4H6WV54tB29u8xCcEaMGQMn37LFvM1ynNpp27TTXaqNM",
+enabled         = false
+bind_address    = "0.0.0.0:14626"
+bind_address_v6 = "[::]:14626"
+entry_nodes     = [
     "/dns/entry-hornet-0.h.chrysalis-mainnet.iotaledger.net/udp/14626/autopeering/iotaPHdAn7eueBnXtikZMwhfPXaeGJGXDt4RBuLuGgb",
     "/dns/entry-hornet-1.h.chrysalis-mainnet.iotaledger.net/udp/14626/autopeering/iotaJJqMd5CQvv1A61coSQCYW9PNT1QKPs7xh2Qg5K2",
     "/dns/entry-0.mainnet.tanglebay.com/udp/14626/autopeering/iot4By1FD4pFLrGJ6AAe7YEeSu9RbW9xnPUmxMdQenC",

--- a/bee-node/config.chrysalis-mainnet.toml
+++ b/bee-node/config.chrysalis-mainnet.toml
@@ -29,18 +29,18 @@ max_discovered_peers    = 8
 #alias    = ""
 
 [autopeering]
-enabled         = false
-bind_address    = "0.0.0.0:14626"
-entry_nodes     = [
+enabled                       = false
+bind_address                  = "0.0.0.0:14626"
+entry_nodes                   = [
     "/dns/entry-hornet-0.h.chrysalis-mainnet.iotaledger.net/udp/14626/autopeering/iotaPHdAn7eueBnXtikZMwhfPXaeGJGXDt4RBuLuGgb",
     "/dns/entry-hornet-1.h.chrysalis-mainnet.iotaledger.net/udp/14626/autopeering/iotaJJqMd5CQvv1A61coSQCYW9PNT1QKPs7xh2Qg5K2",
     "/dns/entry-0.mainnet.tanglebay.com/udp/14626/autopeering/iot4By1FD4pFLrGJ6AAe7YEeSu9RbW9xnPUmxMdQenC",
     "/dns/entry-1.mainnet.tanglebay.com/udp/14636/autopeering/CATsx21mFVvQQPXeDineGs9DDeKvoBBQdzcmR6ffCkVA",
 ]
-entry_nodes_prefer_ipv6 = false
-run_as_entry_node = false
+entry_nodes_prefer_ipv6       = false
+run_as_entry_node             = false
 drop_neighbors_on_salt_update = false
-peer_storage_path = "./storage/mainnet/peers"
+peer_storage_path             = "./storage/mainnet/peers"
 
 [protocol]
 minimum_pow_score = 4000

--- a/bee-node/src/entrynode/builder.rs
+++ b/bee-node/src/entrynode/builder.rs
@@ -253,9 +253,9 @@ async fn initialize_autopeering(
 fn create_local_autopeering_entity(keypair: Keypair, config: &EntryNodeConfig) -> bee_autopeering::Local {
     let local = bee_autopeering::Local::from_keypair(keypair).expect("failed to create local entity");
 
-    let port = if let Some(bind_addr) = config.autopeering_config.bind_addr_v4() {
+    let port = if let Some(bind_addr) = config.autopeering.bind_addr_v4() {
         bind_addr.port()
-    } else if let Some(bind_addr) = config.autopeering_config.bind_addr_v6() {
+    } else if let Some(bind_addr) = config.autopeering.bind_addr_v6() {
         bind_addr.port()
     } else {
         unreachable!("config validation ensures, that one bind address is available.");

--- a/bee-node/src/entrynode/builder.rs
+++ b/bee-node/src/entrynode/builder.rs
@@ -253,12 +253,16 @@ async fn initialize_autopeering(
 fn create_local_autopeering_entity(keypair: Keypair, config: &EntryNodeConfig) -> bee_autopeering::Local {
     let local = bee_autopeering::Local::from_keypair(keypair).expect("failed to create local entity");
 
+    let port = if let Some(bind_addr) = config.autopeering_config.bind_addr_v4() {
+        bind_addr.port()
+    } else if let Some(bind_addr) = config.autopeering_config.bind_addr_v6() {
+        bind_addr.port()
+    } else {
+        unreachable!("config validation ensures, that one bind address is available.");
+    };
+
     // Announce the autopeering service.
-    local.add_service(
-        AUTOPEERING_SERVICE_NAME,
-        ServiceProtocol::Udp,
-        config.autopeering.bind_addr().port(),
-    );
+    local.add_service(AUTOPEERING_SERVICE_NAME, ServiceProtocol::Udp, port);
 
     local
 }

--- a/bee-node/src/fullnode/builder.rs
+++ b/bee-node/src/fullnode/builder.rs
@@ -360,12 +360,16 @@ fn create_local_autopeering_entity<S: NodeStorageBackend>(
 ) -> bee_autopeering::Local {
     let local = bee_autopeering::Local::from_keypair(keypair).expect("failed to create local entity");
 
+    let port = if let Some(bind_addr) = config.autopeering_config.bind_addr_v4() {
+        bind_addr.port()
+    } else if let Some(bind_addr) = config.autopeering_config.bind_addr_v6() {
+        bind_addr.port()
+    } else {
+        unreachable!("config validation ensures, that one bind address is available.");
+    };
+
     // Announce the autopeering service.
-    local.add_service(
-        AUTOPEERING_SERVICE_NAME,
-        ServiceProtocol::Udp,
-        config.autopeering.bind_addr().port(),
-    );
+    local.add_service(AUTOPEERING_SERVICE_NAME, ServiceProtocol::Udp, port);
 
     // Announce the gossip service.
     // TODO: Make the bind address a SocketAddr instead of a Multiaddr

--- a/bee-node/src/fullnode/builder.rs
+++ b/bee-node/src/fullnode/builder.rs
@@ -360,9 +360,9 @@ fn create_local_autopeering_entity<S: NodeStorageBackend>(
 ) -> bee_autopeering::Local {
     let local = bee_autopeering::Local::from_keypair(keypair).expect("failed to create local entity");
 
-    let port = if let Some(bind_addr) = config.autopeering_config.bind_addr_v4() {
+    let port = if let Some(bind_addr) = config.autopeering.bind_addr_v4() {
         bind_addr.port()
-    } else if let Some(bind_addr) = config.autopeering_config.bind_addr_v6() {
+    } else if let Some(bind_addr) = config.autopeering.bind_addr_v6() {
         bind_addr.port()
     } else {
         unreachable!("config validation ensures, that one bind address is available.");

--- a/bee-protocol/Cargo.toml
+++ b/bee-protocol/Cargo.toml
@@ -11,7 +11,7 @@ keywords = [ "iota", "tangle", "bee", "framework", "protocol" ]
 homepage = "https://www.iota.org"
 
 [dependencies]
-bee-autopeering = { version = "0.4.0-alpha1", path = "../bee-network/bee-autopeering", default-features = false }
+bee-autopeering = { version = "0.4.0", path = "../bee-network/bee-autopeering", default-features = false }
 bee-common = { version = "0.6.0", path = "../bee-common/bee-common", default-features = false, optional = true }
 bee-gossip = { version = "0.4.0", path = "../bee-network/bee-gossip", default-features = false }
 bee-ledger = { version = "0.6.0", path = "../bee-ledger", default-features = false, features = [ "workers" ], optional = true }

--- a/bee-protocol/Cargo.toml
+++ b/bee-protocol/Cargo.toml
@@ -11,7 +11,7 @@ keywords = [ "iota", "tangle", "bee", "framework", "protocol" ]
 homepage = "https://www.iota.org"
 
 [dependencies]
-bee-autopeering = { version = "0.3.0", path = "../bee-network/bee-autopeering", default-features = false }
+bee-autopeering = { version = "0.4.0-alpha1", path = "../bee-network/bee-autopeering", default-features = false }
 bee-common = { version = "0.6.0", path = "../bee-common/bee-common", default-features = false, optional = true }
 bee-gossip = { version = "0.4.0", path = "../bee-network/bee-gossip", default-features = false }
 bee-ledger = { version = "0.6.0", path = "../bee-ledger", default-features = false, features = [ "workers" ], optional = true }


### PR DESCRIPTION
# Description of change

Adds IPv6 support to `bee-autopeering`.

## Links to any relevant issues

Closes #990 

## Type of change


- Enhancement (a non-breaking change which adds functionality)

## How the change has been tested

VPS.

## Change checklist

Tick the boxes that are relevant to your changes, and delete any items that are not.

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that new and existing unit tests pass locally with my changes
- [x] I have updated the CHANGELOG.md, if my changes are significant enough
