### PR TITLE
Fix MessageDto

### DIFF
--- a/bee-api/bee-rest-api/src/types/dtos.rs
+++ b/bee-api/bee-rest-api/src/types/dtos.rs
@@ -50,7 +50,7 @@ use serde_json::Value;
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct MessageDto {
     #[serde(rename = "protocolVersion")]
-    pub protocol_version: String,
+    pub protocol_version: u8,
     #[serde(rename = "parentMessageIds")]
     pub parents: Vec<String>,
     pub payload: Option<PayloadDto>,
@@ -60,7 +60,7 @@ pub struct MessageDto {
 impl From<&Message> for MessageDto {
     fn from(value: &Message) -> Self {
         MessageDto {
-            protocol_version: value.protocol_version().to_string(),
+            protocol_version: value.protocol_version(),
             parents: value.parents().iter().map(|p| p.to_string()).collect(),
             payload: value.payload().map(Into::into),
             nonce: value.nonce().to_string(),
@@ -73,12 +73,7 @@ impl TryFrom<&MessageDto> for Message {
 
     fn try_from(value: &MessageDto) -> Result<Self, Self::Error> {
         let mut builder = MessageBuilder::new()
-            .with_protocol_version(
-                value
-                    .protocol_version
-                    .parse::<u8>()
-                    .map_err(|_| Error::InvalidField("protocolVersion"))?,
-            )
+            .with_protocol_version(value.protocol_version)
             .with_parents(Parents::new(
                 value
                     .parents


### PR DESCRIPTION
# Description of change

Fixed MessageDto, because it should be a number instead of a String according to https://github.com/iotaledger/tips/blob/1798870330130cb95158390fd5e6f5294ca0ab37/tips/TIP-0025/core-rest-api.yaml#L1424

## Type of change

- Bug fix (a non-breaking change which fixes an issue)

## Change checklist

- [ ] I have followed the contribution guidelines for this project
- [ ] I have performed a self-review of my own code
- [ ] I have checked that new and existing unit tests pass locally with my changes
