### PR TITLE
Strip symbols from production binary (rust >= 1.59)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,3 @@
-# cargo-features = [ "strip" ]
-
 [workspace]
 members = [
 	"bee-api/bee-rest-api",
@@ -37,4 +35,4 @@ codegen-units = 1
 inherits = "release"
 lto = true
 panic = "abort"
-# strip = "symbols"
+strip = "symbols"


### PR DESCRIPTION
# Description of change

This should produce even smaller binaries, but requires Rust >= 1.59.

## Change checklist

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that new and existing unit tests pass locally with my changes
- [x] I have updated the CHANGELOG.md, if my changes are significant enough
