### PR TITLE
Fix removal of disconnected peers in the peer manager

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -406,7 +406,7 @@ dependencies = [
 
 [[package]]
 name = "bee-rest-api"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "async-trait",
  "bech32",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -186,7 +186,7 @@ checksum = "cf9ff0bbfd639f15c74af777d81383cf53efb7c93613f6cab67c6c11e05bbf8b"
 
 [[package]]
 name = "bee-autopeering"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "async-trait",
  "base64 0.13.0",
@@ -247,7 +247,7 @@ dependencies = [
 
 [[package]]
 name = "bee-gossip"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "async-trait",
  "bee-runtime",
@@ -374,7 +374,7 @@ dependencies = [
 
 [[package]]
 name = "bee-protocol"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "async-channel",
  "async-priority-queue",

--- a/bee-api/bee-rest-api/CHANGELOG.md
+++ b/bee-api/bee-rest-api/CHANGELOG.md
@@ -19,7 +19,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Security -->
 
-## 0.2.0 - 2022-XX-XX
+## 0.2.1 - 2022-02-28
+
+- Update `bee-gossip` dependency to 0.5.0;
+
+## 0.2.0 - 2022-01-28
 
 ### Added
 

--- a/bee-api/bee-rest-api/Cargo.toml
+++ b/bee-api/bee-rest-api/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bee-rest-api"
-version = "0.2.0"
+version = "0.2.1"
 authors = [ "IOTA Stiftung" ]
 edition = "2021"
 description = "The default REST API implementation for the IOTA Bee node software."

--- a/bee-api/bee-rest-api/Cargo.toml
+++ b/bee-api/bee-rest-api/Cargo.toml
@@ -12,7 +12,7 @@ homepage = "https://www.iota.org"
 
 [dependencies]
 bee-common = { version = "0.6.0", path = "../../bee-common/bee-common", default-features = false, optional = true }
-bee-gossip = { version = "0.4.0", path = "../../bee-network/bee-gossip", default-features = false, optional = true }
+bee-gossip = { version = "0.5.0", path = "../../bee-network/bee-gossip", default-features = false, optional = true }
 bee-ledger = { version = "0.6.1", path = "../../bee-ledger", default-features = false }
 bee-message = { version = "0.1.6", path = "../../bee-message", default-features = false }
 bee-pow = { version = "0.2.0", path = "../../bee-pow", default-features = false }

--- a/bee-network/bee-autopeering/CHANGELOG.md
+++ b/bee-network/bee-autopeering/CHANGELOG.md
@@ -19,6 +19,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Security -->
 
+## 0.5.0 - 2022-02-28
+
+### Changed
+
+- Moved `PeerId` display format to start of significant part;
+
 ## 0.4.0 - 2022-02-11
 
 ### Added

--- a/bee-network/bee-autopeering/CHANGELOG.md
+++ b/bee-network/bee-autopeering/CHANGELOG.md
@@ -19,11 +19,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Security -->
 
-## 0.5.0 - 2022-02-28
+## 0.4.1 - 2022-02-28
 
 ### Changed
 
-- Moved `PeerId` display format to start of significant part;
+- Displayed representation of `PeerId`s to start at the beginning of its significant part;
 
 ## 0.4.0 - 2022-02-11
 

--- a/bee-network/bee-autopeering/Cargo.toml
+++ b/bee-network/bee-autopeering/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bee-autopeering"
-version = "0.4.0"
+version = "0.4.1"
 authors = [ "IOTA Stiftung" ]
 edition = "2021"
 description = "Allows peers in the same IOTA network to automatically discover each other."

--- a/bee-network/bee-autopeering/src/peer/peer_id.rs
+++ b/bee-network/bee-autopeering/src/peer/peer_id.rs
@@ -98,7 +98,7 @@ impl fmt::Debug for PeerId {
 
 impl fmt::Display for PeerId {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        self.libp2p_peer_id().to_base58()[..DISPLAY_LENGTH].fmt(f)
+        self.libp2p_peer_id().to_base58()[8..8+DISPLAY_LENGTH].fmt(f)
     }
 }
 

--- a/bee-network/bee-autopeering/src/peer/peer_id.rs
+++ b/bee-network/bee-autopeering/src/peer/peer_id.rs
@@ -18,6 +18,7 @@ use std::{
 };
 
 const DISPLAY_LENGTH: usize = 16;
+const DISPLAY_OFFSET: usize = 8;
 
 /// Represents the unique identity of a peer in the network.
 #[derive(Copy, Clone)]
@@ -98,7 +99,7 @@ impl fmt::Debug for PeerId {
 
 impl fmt::Display for PeerId {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        self.libp2p_peer_id().to_base58()[8..8+DISPLAY_LENGTH].fmt(f)
+        self.libp2p_peer_id().to_base58()[DISPLAY_OFFSET..DISPLAY_OFFSET + DISPLAY_LENGTH].fmt(f)
     }
 }
 

--- a/bee-network/bee-autopeering/src/task.rs
+++ b/bee-network/bee-autopeering/src/task.rs
@@ -117,7 +117,10 @@ impl<S: PeerStore> TaskManager<S> {
             let shutdown_tx = shutdown_senders.remove(&task_name).unwrap();
 
             log::trace!("Shutting down: {}", task_name);
-            shutdown_tx.send(()).expect("error sending shutdown signal");
+
+            if shutdown_tx.send(()).is_err() {
+                log::error!("Error sending shutdown signal to task {task_name}. This is a bug.");
+            }
         }
 
         // Wait for all tasks to shutdown down in a certain order and maximum amount of time.

--- a/bee-network/bee-autopeering/src/task.rs
+++ b/bee-network/bee-autopeering/src/task.rs
@@ -119,7 +119,7 @@ impl<S: PeerStore> TaskManager<S> {
             log::trace!("Shutting down: {}", task_name);
 
             if shutdown_tx.send(()).is_err() {
-                log::error!("Error sending shutdown signal to task {task_name}. This is a bug.");
+                log::error!("Error sending shutdown signal to task {task_name}.");
             }
         }
 

--- a/bee-network/bee-gossip/CHANGELOG.md
+++ b/bee-network/bee-gossip/CHANGELOG.md
@@ -19,6 +19,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Security -->
 
+## 0.5.0 - 2022-02-28
+
+### Added
+
+- `PeerMetrics` type, that keeps a count of dial attempts and idenfication timestamp;
+- `PeerUnreachable` event: fired after a certain number of unsuccessful dial attempts;
+
+### Changed
+
+- `PeerList` type keeps metrics for each peer;
+
+### Fixed
+
+- Missing `PeerRemoved` event for disconnected unknown peers;
+
 ## 0.4.0 - 2022-01-20
 
 ### Fixed

--- a/bee-network/bee-gossip/CHANGELOG.md
+++ b/bee-network/bee-gossip/CHANGELOG.md
@@ -23,8 +23,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- `PeerMetrics` type, that keeps a count of dial attempts and idenfication timestamp;
-- `PeerUnreachable` event: fired after a certain number of unsuccessful dial attempts;
+- `PeerMetrics` type that keeps a count of dial attempts and identification timestamp;
+- `PeerUnreachable` event that is fired after a certain number of unsuccessful dial attempts;
 
 ### Changed
 

--- a/bee-network/bee-gossip/Cargo.toml
+++ b/bee-network/bee-gossip/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bee-gossip"
-version = "0.4.0"
+version = "0.5.0"
 authors = [ "IOTA Stiftung" ]
 edition = "2021"
 description = "Allows peers in the same IOTA network to exchange gossip messages with each other."

--- a/bee-network/bee-gossip/src/alias.rs
+++ b/bee-network/bee-gossip/src/alias.rs
@@ -10,6 +10,6 @@ macro_rules! alias {
         &$peer_id.to_base58()[7..23]
     };
     ($peer_id:expr, $len:expr) => {
-        &$peer_id.to_base58()[7..7+$len]
+        &$peer_id.to_base58()[7..7 + $len]
     };
 }

--- a/bee-network/bee-gossip/src/alias.rs
+++ b/bee-network/bee-gossip/src/alias.rs
@@ -7,9 +7,9 @@
 #[macro_export]
 macro_rules! alias {
     ($peer_id:expr) => {
-        &$peer_id.to_base58()[..16]
+        &$peer_id.to_base58()[7..23]
     };
     ($peer_id:expr, $len:expr) => {
-        &$peer_id.to_base58()[..$len]
+        &$peer_id.to_base58()[7..7+$len]
     };
 }

--- a/bee-network/bee-gossip/src/alias.rs
+++ b/bee-network/bee-gossip/src/alias.rs
@@ -7,9 +7,9 @@
 #[macro_export]
 macro_rules! alias {
     ($peer_id:expr) => {
-        &$peer_id.to_base58()[46..]
+        &$peer_id.to_base58()[..16]
     };
     ($peer_id:expr, $len:expr) => {
-        &$peer_id.to_base58()[(52 - $len)..]
+        &$peer_id.to_base58()[..$len]
     };
 }

--- a/bee-network/bee-gossip/src/alias.rs
+++ b/bee-network/bee-gossip/src/alias.rs
@@ -7,9 +7,9 @@
 #[macro_export]
 macro_rules! alias {
     ($peer_id:expr) => {
-        &$peer_id.to_base58()[7..23]
+        &$peer_id.to_base58()[8..24]
     };
     ($peer_id:expr, $len:expr) => {
-        &$peer_id.to_base58()[7..7 + $len]
+        &$peer_id.to_base58()[8..8 + $len]
     };
 }

--- a/bee-network/bee-gossip/src/network/host.rs
+++ b/bee-network/bee-gossip/src/network/host.rs
@@ -143,12 +143,12 @@ async fn process_swarm_event(
                 })
                 .expect("send error");
 
-            peerlist
+            // Note: We don't care if the inserted address is a duplicate.
+            let _ = peerlist
                 .0
                 .write()
                 .await
-                .add_local_addr(address)
-                .expect("insert_local_addr");
+                .add_local_addr(address);
         }
         SwarmEvent::ConnectionEstablished { peer_id, .. } => {
             debug!("Swarm event: connection established with {}.", alias!(peer_id));

--- a/bee-network/bee-gossip/src/network/host.rs
+++ b/bee-network/bee-gossip/src/network/host.rs
@@ -144,11 +144,7 @@ async fn process_swarm_event(
                 .expect("send error");
 
             // Note: We don't care if the inserted address is a duplicate.
-            let _ = peerlist
-                .0
-                .write()
-                .await
-                .add_local_addr(address);
+            let _ = peerlist.0.write().await.add_local_addr(address);
         }
         SwarmEvent::ConnectionEstablished { peer_id, .. } => {
             debug!("Swarm event: connection established with {}.", alias!(peer_id));

--- a/bee-network/bee-gossip/src/network/host.rs
+++ b/bee-network/bee-gossip/src/network/host.rs
@@ -212,13 +212,17 @@ async fn dial_peer(swarm: &mut Swarm<SwarmBehaviour>, peer_id: PeerId, peerlist:
         address: addr, alias, ..
     } = peerlist.0.read().await.info(&peer_id).expect("peer must exist");
 
-    let dial_attempt = peerlist
+    let mut dial_attempt = 0;
+    
+    peerlist
         .0
         .write()
         .await
-        .log_dial_attempt(&peer_id)
-        .expect("peer must exist")
-        .expect("peer must not be connected");
+        .update_metrics(&peer_id, |m| {
+            m.num_dials += 1;
+            dial_attempt = m.num_dials;
+        })
+        .expect("peer must exist");
 
     debug!(
         "Dialing peer: {} ({}) attempt: #{}.",

--- a/bee-network/bee-gossip/src/network/host.rs
+++ b/bee-network/bee-gossip/src/network/host.rs
@@ -182,6 +182,9 @@ async fn process_internal_command(internal_command: Command, swarm: &mut Swarm<S
                 warn!("Dialing peer {} failed. Cause: {}", alias!(peer_id), e);
             }
         }
+        Command::DisconnectPeer { peer_id } => {
+            hang_up(swarm, peer_id).await
+        }
         _ => {}
     }
 }
@@ -218,4 +221,10 @@ async fn dial_peer(swarm: &mut Swarm<SwarmBehaviour>, peer_id: PeerId, peerlist:
     Swarm::dial_addr(swarm, addr).map_err(|e| Error::DialingPeerFailed(peer_id, e))?;
 
     Ok(())
+}
+
+async fn hang_up(swarm: &mut Swarm<SwarmBehaviour>, peer_id: PeerId) {
+    debug!("Hanging up on: {}.", alias!(peer_id));
+
+    let _ = Swarm::disconnect_peer_id(swarm, peer_id);
 }

--- a/bee-network/bee-gossip/src/network/host.rs
+++ b/bee-network/bee-gossip/src/network/host.rs
@@ -147,7 +147,7 @@ async fn process_swarm_event(
                 .0
                 .write()
                 .await
-                .insert_local_addr(address)
+                .add_local_addr(address)
                 .expect("insert_local_addr");
         }
         SwarmEvent::ConnectionEstablished { peer_id, .. } => {
@@ -213,7 +213,7 @@ async fn dial_peer(swarm: &mut Swarm<SwarmBehaviour>, peer_id: PeerId, peerlist:
     } = peerlist.0.read().await.info(&peer_id).expect("peer must exist");
 
     let mut dial_attempt = 0;
-    
+
     peerlist
         .0
         .write()

--- a/bee-network/bee-gossip/src/peer/list.rs
+++ b/bee-network/bee-gossip/src/peer/list.rs
@@ -499,7 +499,7 @@ pub enum PeerState {
 #[derive(Clone, Debug, Default)]
 pub struct PeerMetrics {
     pub(crate) num_dials: usize,
-    pub(crate) identified: Option<u64>,
+    pub(crate) identified_at: Option<u64>,
 }
 
 impl Default for PeerState {

--- a/bee-network/bee-gossip/src/peer/list.rs
+++ b/bee-network/bee-gossip/src/peer/list.rs
@@ -119,6 +119,7 @@ impl PeerList {
         self.peers.len()
     }
 
+    /// Note: Returns an error if the address trying to be added is a duplicate.
     pub fn add_local_addr(&mut self, addr: Multiaddr) -> Result<(), (Multiaddr, Error)> {
         if self.local_addrs.contains(&addr) {
             return Err((addr.clone(), Error::AddressIsDuplicate(addr)));

--- a/bee-network/bee-gossip/src/peer/list.rs
+++ b/bee-network/bee-gossip/src/peer/list.rs
@@ -121,13 +121,11 @@ impl PeerList {
 
     /// Note: Returns an error if the address trying to be added is a duplicate.
     pub fn add_local_addr(&mut self, addr: Multiaddr) -> Result<(), (Multiaddr, Error)> {
-        if self.local_addrs.contains(&addr) {
-            return Err((addr.clone(), Error::AddressIsDuplicate(addr)));
+        if self.local_addrs.insert(addr.clone()) {
+            Ok(())
+        } else {
+            Err((addr.clone(), Error::AddressIsDuplicate(addr)))
         }
-
-        let _ = self.local_addrs.insert(addr);
-
-        Ok(())
     }
 
     pub fn update_info<U>(&mut self, peer_id: &PeerId, mut update: U) -> Result<(), Error>

--- a/bee-network/bee-gossip/src/service/event.rs
+++ b/bee-network/bee-gossip/src/service/event.rs
@@ -100,6 +100,13 @@ pub enum Event {
         /// The peer's id.
         peer_id: PeerId,
     },
+    /// A peer didn't answer our repeated calls.
+    PeerUnreachable {
+        /// The peer's id.
+        peer_id: PeerId,
+        /// The relation we have with that peer.
+        peer_info: PeerInfo,
+    },
 }
 
 /// Describes the internal events.

--- a/bee-network/bee-gossip/src/service/event.rs
+++ b/bee-network/bee-gossip/src/service/event.rs
@@ -100,11 +100,12 @@ pub enum Event {
         /// The peer's id.
         peer_id: PeerId,
     },
+
     /// A peer didn't answer our repeated calls.
     PeerUnreachable {
         /// The peer's id.
         peer_id: PeerId,
-        /// The relation we have with that peer.
+        /// The peer's info.
         peer_info: PeerInfo,
     },
 }

--- a/bee-network/bee-gossip/src/service/event.rs
+++ b/bee-network/bee-gossip/src/service/event.rs
@@ -132,9 +132,9 @@ pub enum InternalEvent {
     },
 
     /// The gossip protocol with a peer was stopped.
-    ProtocolStopped { 
+    ProtocolStopped {
         /// The peer's id.
-        peer_id: PeerId
+        peer_id: PeerId,
     },
 
     /// A peer didn't answer our repeated calls.

--- a/bee-network/bee-gossip/src/service/event.rs
+++ b/bee-network/bee-gossip/src/service/event.rs
@@ -123,8 +123,8 @@ pub enum InternalEvent {
         substream: Box<NegotiatedSubstream>,
     },
 
-    /// The gossip protocol has been dropped with a peer.
-    ProtocolDropped { peer_id: PeerId },
+    /// The gossip protocol with a peer was stopped.
+    ProtocolStopped { peer_id: PeerId },
 }
 
 /// Allows the user to receive [`Event`]s published by the network layer.

--- a/bee-network/bee-gossip/src/service/event.rs
+++ b/bee-network/bee-gossip/src/service/event.rs
@@ -132,6 +132,12 @@ pub enum InternalEvent {
 
     /// The gossip protocol with a peer was stopped.
     ProtocolStopped { peer_id: PeerId },
+
+    /// A peer didn't answer our repeated calls.
+    PeerUnreachable {
+        /// The peer's id.
+        peer_id: PeerId,
+    },
 }
 
 /// Allows the user to receive [`Event`]s published by the network layer.

--- a/bee-network/bee-gossip/src/service/event.rs
+++ b/bee-network/bee-gossip/src/service/event.rs
@@ -138,6 +138,12 @@ pub enum InternalEvent {
         /// The peer's id.
         peer_id: PeerId,
     },
+
+    /// A peer has identified itself via the `libp2p` Identify protocol.
+    PeerIdentified {
+        /// The peer's id.
+        peer_id: PeerId,
+    },
 }
 
 /// Allows the user to receive [`Event`]s published by the network layer.

--- a/bee-network/bee-gossip/src/service/event.rs
+++ b/bee-network/bee-gossip/src/service/event.rs
@@ -132,7 +132,10 @@ pub enum InternalEvent {
     },
 
     /// The gossip protocol with a peer was stopped.
-    ProtocolStopped { peer_id: PeerId },
+    ProtocolStopped { 
+        /// The peer's id.
+        peer_id: PeerId
+    },
 
     /// A peer didn't answer our repeated calls.
     PeerUnreachable {

--- a/bee-network/bee-gossip/src/service/host.rs
+++ b/bee-network/bee-gossip/src/service/host.rs
@@ -248,7 +248,10 @@ async fn peerstate_checker(shutdown: Shutdown, senders: Senders, peerlist: PeerL
         for (peer_id, peer_info) in peerlist_reader.filter_info(|info, state| {
             (info.relation.is_known() || info.relation.is_discovered()) && state.is_disconnected()
         }) {
-            let dial_attempts = peerlist_reader.dial_attempts(&peer_id).expect("peer does exist").expect("peer is not connected");
+            let dial_attempts = peerlist_reader
+                .dial_attempts(&peer_id)
+                .expect("peer does exist")
+                .expect("peer is not connected");
 
             if dial_attempts >= MAX_DIAL_ATTEMPTS {
                 log::debug!("Peer {} is unreachable.", peer_id);

--- a/bee-network/bee-gossip/src/service/host.rs
+++ b/bee-network/bee-gossip/src/service/host.rs
@@ -354,7 +354,7 @@ async fn process_internal_event(
                 .map_err(|_| Error::SendingEventFailed)?;
         }
 
-        InternalEvent::ProtocolDropped { peer_id } => {
+        InternalEvent::ProtocolStopped { peer_id } => {
             let mut peerlist = peerlist.0.write().await;
 
             // Try to disconnect, but ignore errors in-case the peer was disconnected already.

--- a/bee-network/bee-gossip/src/service/host.rs
+++ b/bee-network/bee-gossip/src/service/host.rs
@@ -216,6 +216,9 @@ async fn peerstate_checker(shutdown: Shutdown, senders: Senders, peerlist: PeerL
     while interval.next().await.is_some() {
         let peerlist_reader = peerlist.0.read().await;
 
+        // How many peers we know about.
+        let num_all = peerlist_reader.len();
+
         // To how many known peers are we currently connected.
         let num_known = peerlist_reader.filter_count(|info, _| info.relation.is_known());
         let num_connected_known =
@@ -230,13 +233,14 @@ async fn peerstate_checker(shutdown: Shutdown, senders: Senders, peerlist: PeerL
             peerlist_reader.filter_count(|info, state| info.relation.is_discovered() && state.is_connected());
 
         info!(
-            "Connected peers: known {}/{} unknown {}/{} discovered {}/{}.",
+            "Connected peers: known {}/{} unknown {}/{} discovered {}/{}, All peers: {}.",
             num_connected_known,
             num_known,
             num_connected_unknown,
             global::max_unknown_peers(),
             num_connected_discovered,
-            global::max_discovered_peers()
+            global::max_discovered_peers(),
+            num_all,
         );
 
         // Automatically try to reconnect known **and** discovered peers. The removal of discovered peers is a decision

--- a/bee-network/bee-gossip/src/service/host.rs
+++ b/bee-network/bee-gossip/src/service/host.rs
@@ -511,7 +511,7 @@ async fn process_internal_event(
                 // Reset dial count.
                 m.num_dials = 0;
                 // Update Identify timestamp.
-                m.identified = Some(
+                m.identified_at = Some(
                     SystemTime::now()
                         .duration_since(UNIX_EPOCH)
                         .expect("system time")

--- a/bee-network/bee-gossip/src/service/host.rs
+++ b/bee-network/bee-gossip/src/service/host.rs
@@ -393,7 +393,8 @@ async fn process_internal_event(
                 .map_err(|_| Error::SendingEventFailed)?;
 
             if was_removed {
-                log::warn!("Removed unknown {peer_id}");
+                log::trace!("Removed unknown peer: {peer_id}");
+
                 senders
                     .events
                     .send(Event::PeerRemoved { peer_id })

--- a/bee-network/bee-gossip/src/service/host.rs
+++ b/bee-network/bee-gossip/src/service/host.rs
@@ -367,6 +367,12 @@ async fn process_internal_event(
             // We no longer need to hold the lock.
             drop(peerlist);
 
+            // Make sure to end the underlying connection.
+            senders
+                .internal_commands
+                .send(Command::DisconnectPeer { peer_id })
+                .map_err(|_| Error::SendingEventFailed)?;
+
             senders
                 .events
                 .send(Event::PeerDisconnected { peer_id })

--- a/bee-network/bee-gossip/src/swarm/behaviour.rs
+++ b/bee-network/bee-gossip/src/swarm/behaviour.rs
@@ -45,8 +45,8 @@ impl NetworkBehaviourEventProcess<IdentifyEvent> for SwarmBehaviour {
             IdentifyEvent::Received { peer_id, info } => {
                 trace!("Received Identify response from {}: {:?}.", alias!(peer_id), info,);
 
-                // Panic: we made sure that the sender (network host) is always dropped before the receiver (service host)
-                // through the worker dependencies, hence this can never panic.
+                // Panic: we made sure that the sender (network host) is always dropped before the receiver (service
+                // host) through the worker dependencies, hence this can never panic.
                 self.internal_sender
                     .send(InternalEvent::PeerIdentified { peer_id })
                     .expect("send internal event");
@@ -60,8 +60,8 @@ impl NetworkBehaviourEventProcess<IdentifyEvent> for SwarmBehaviour {
             IdentifyEvent::Error { peer_id, error } => {
                 debug!("Identification error with {}: Cause: {:?}.", alias!(peer_id), error);
 
-                // Panic: we made sure that the sender (network host) is always dropped before the receiver (service host)
-                // through the worker dependencies, hence this can never panic.
+                // Panic: we made sure that the sender (network host) is always dropped before the receiver (service
+                // host) through the worker dependencies, hence this can never panic.
                 self.internal_sender
                     .send(InternalEvent::PeerUnreachable { peer_id })
                     .expect("send internal event");

--- a/bee-network/bee-gossip/src/swarm/behaviour.rs
+++ b/bee-network/bee-gossip/src/swarm/behaviour.rs
@@ -91,12 +91,14 @@ impl NetworkBehaviourEventProcess<IotaGossipEvent> for SwarmBehaviour {
             } => {
                 trace!("Successfully negotiated IOTA gossip protocol with {}.", alias!(peer_id));
 
-                self.internal_sender.send(InternalEvent::ProtocolEstablished {
-                    peer_id,
-                    peer_addr,
-                    origin,
-                    substream,
-                }).expect("send internal event");
+                self.internal_sender
+                    .send(InternalEvent::ProtocolEstablished {
+                        peer_id,
+                        peer_addr,
+                        origin,
+                        substream,
+                    })
+                    .expect("send internal event");
             }
             IotaGossipEvent::UpgradeError { peer_id, error } => {
                 debug!(

--- a/bee-network/bee-gossip/src/swarm/behaviour.rs
+++ b/bee-network/bee-gossip/src/swarm/behaviour.rs
@@ -44,9 +44,9 @@ impl NetworkBehaviourEventProcess<IdentifyEvent> for SwarmBehaviour {
         match event {
             IdentifyEvent::Received { peer_id, info } => {
                 trace!(
-                    "Received Identify response from {}. Observed address: {:?}.",
+                    "Received Identify response from {}: {:?}.",
                     alias!(peer_id),
-                    info.observed_addr,
+                    info,
                 );
 
                 // Panic:

--- a/bee-network/bee-gossip/src/swarm/behaviour.rs
+++ b/bee-network/bee-gossip/src/swarm/behaviour.rs
@@ -58,7 +58,11 @@ impl NetworkBehaviourEventProcess<IdentifyEvent> for SwarmBehaviour {
                 trace!("Pushed Identify request to {}.", alias!(peer_id));
             }
             IdentifyEvent::Error { peer_id, error } => {
-                warn!("Identification error with {}: Cause: {:?}.", alias!(peer_id), error);
+                trace!("Identification error with {}: Cause: {:?}.", alias!(peer_id), error);
+
+                // Panic:
+                // Sending must not fail.
+                self.internal_sender.send(InternalEvent::PeerUnreachable { peer_id }).expect("send internal event");
             }
         }
     }

--- a/bee-network/bee-gossip/src/swarm/behaviour.rs
+++ b/bee-network/bee-gossip/src/swarm/behaviour.rs
@@ -45,8 +45,8 @@ impl NetworkBehaviourEventProcess<IdentifyEvent> for SwarmBehaviour {
             IdentifyEvent::Received { peer_id, info } => {
                 trace!("Received Identify response from {}: {:?}.", alias!(peer_id), info,);
 
-                // Panic:
-                // Sending must not fail.
+                // Panic: we made sure that the sender (network host) is always dropped before the receiver (service host)
+                // through the worker dependencies, hence this can never panic.
                 self.internal_sender
                     .send(InternalEvent::PeerIdentified { peer_id })
                     .expect("send internal event");
@@ -60,8 +60,8 @@ impl NetworkBehaviourEventProcess<IdentifyEvent> for SwarmBehaviour {
             IdentifyEvent::Error { peer_id, error } => {
                 debug!("Identification error with {}: Cause: {:?}.", alias!(peer_id), error);
 
-                // Panic:
-                // Sending must not fail.
+                // Panic: we made sure that the sender (network host) is always dropped before the receiver (service host)
+                // through the worker dependencies, hence this can never panic.
                 self.internal_sender
                     .send(InternalEvent::PeerUnreachable { peer_id })
                     .expect("send internal event");

--- a/bee-network/bee-gossip/src/swarm/behaviour.rs
+++ b/bee-network/bee-gossip/src/swarm/behaviour.rs
@@ -62,7 +62,7 @@ impl NetworkBehaviourEventProcess<IdentifyEvent> for SwarmBehaviour {
                 trace!("Pushed Identify request to {}.", alias!(peer_id));
             }
             IdentifyEvent::Error { peer_id, error } => {
-                trace!("Identification error with {}: Cause: {:?}.", alias!(peer_id), error);
+                debug!("Identification error with {}: Cause: {:?}.", alias!(peer_id), error);
 
                 // Panic:
                 // Sending must not fail.
@@ -78,10 +78,10 @@ impl NetworkBehaviourEventProcess<IotaGossipEvent> for SwarmBehaviour {
     fn inject_event(&mut self, event: IotaGossipEvent) {
         match event {
             IotaGossipEvent::ReceivedUpgradeRequest { from } => {
-                debug!("Received IOTA gossip request from {}.", alias!(from));
+                trace!("Received IOTA gossip request from {}.", alias!(from));
             }
             IotaGossipEvent::SentUpgradeRequest { to } => {
-                debug!("Sent IOTA gossip request to {}.", alias!(to));
+                trace!("Sent IOTA gossip request to {}.", alias!(to));
             }
             IotaGossipEvent::UpgradeCompleted {
                 peer_id,
@@ -89,24 +89,17 @@ impl NetworkBehaviourEventProcess<IotaGossipEvent> for SwarmBehaviour {
                 origin,
                 substream,
             } => {
-                debug!("Successfully negotiated IOTA gossip protocol with {}.", alias!(peer_id));
+                trace!("Successfully negotiated IOTA gossip protocol with {}.", alias!(peer_id));
 
-                if let Err(e) = self.internal_sender.send(InternalEvent::ProtocolEstablished {
+                self.internal_sender.send(InternalEvent::ProtocolEstablished {
                     peer_id,
                     peer_addr,
                     origin,
                     substream,
-                }) {
-                    warn!(
-                        "Send event error for {} after successfully established IOTA gossip protocol. Cause: {}",
-                        peer_id, e
-                    );
-
-                    // TODO: stop processors in that case.
-                }
+                }).expect("send internal event");
             }
             IotaGossipEvent::UpgradeError { peer_id, error } => {
-                warn!(
+                debug!(
                     "IOTA gossip upgrade error with {}: Cause: {:?}.",
                     alias!(peer_id),
                     error

--- a/bee-network/bee-gossip/src/swarm/behaviour.rs
+++ b/bee-network/bee-gossip/src/swarm/behaviour.rs
@@ -44,12 +44,16 @@ impl NetworkBehaviourEventProcess<IdentifyEvent> for SwarmBehaviour {
         match event {
             IdentifyEvent::Received { peer_id, info } => {
                 trace!(
-                    "Received Identify request from {}. Observed address: {:?}.",
+                    "Received Identify response from {}. Observed address: {:?}.",
                     alias!(peer_id),
                     info.observed_addr,
                 );
 
-                // TODO: log supported protocols by the peer (info.protocols)
+                // Panic:
+                // Sending must not fail.
+                self.internal_sender
+                    .send(InternalEvent::PeerIdentified { peer_id })
+                    .expect("send internal event");
             }
             IdentifyEvent::Sent { peer_id } => {
                 trace!("Sent Identify request to {}.", alias!(peer_id));
@@ -62,7 +66,9 @@ impl NetworkBehaviourEventProcess<IdentifyEvent> for SwarmBehaviour {
 
                 // Panic:
                 // Sending must not fail.
-                self.internal_sender.send(InternalEvent::PeerUnreachable { peer_id }).expect("send internal event");
+                self.internal_sender
+                    .send(InternalEvent::PeerUnreachable { peer_id })
+                    .expect("send internal event");
             }
         }
     }

--- a/bee-network/bee-gossip/src/swarm/behaviour.rs
+++ b/bee-network/bee-gossip/src/swarm/behaviour.rs
@@ -43,11 +43,7 @@ impl NetworkBehaviourEventProcess<IdentifyEvent> for SwarmBehaviour {
     fn inject_event(&mut self, event: IdentifyEvent) {
         match event {
             IdentifyEvent::Received { peer_id, info } => {
-                trace!(
-                    "Received Identify response from {}: {:?}.",
-                    alias!(peer_id),
-                    info,
-                );
+                trace!("Received Identify response from {}: {:?}.", alias!(peer_id), info,);
 
                 // Panic:
                 // Sending must not fail.

--- a/bee-network/bee-gossip/src/swarm/protocols/iota_gossip/io.rs
+++ b/bee-network/bee-gossip/src/swarm/protocols/iota_gossip/io.rs
@@ -53,14 +53,12 @@ pub fn start_incoming_processor(
                 // from all once connected peers, hence if the following send fails, then it
                 // must be considered a bug.
 
-                // The remote peer dropped the connection.
-                internal_event_sender
-                    .send(InternalEvent::ProtocolDropped { peer_id })
-                    .expect("The service must not shutdown as long as there are gossip tasks running.");
-
                 break;
             }
         }
+
+        // Ignore send errors.
+        let _ = internal_event_sender.send(InternalEvent::ProtocolStopped { peer_id });
 
         // Reasons why this task might end:
         // (1) The remote dropped the TCP connection.
@@ -91,11 +89,6 @@ pub fn start_outgoing_processor(
                 // NB: The network service will not shut down before it has received the `ConnectionDropped` event
                 // from all once connected peers, hence if the following send fails, then it
                 // must be considered a bug.
-
-                internal_event_sender
-                    .send(InternalEvent::ProtocolDropped { peer_id })
-                    .expect("The service must not shutdown as long as there are gossip tasks running.");
-
                 break;
             }
 
@@ -106,6 +99,9 @@ pub fn start_outgoing_processor(
                 break;
             }
         }
+
+        // Ignore send errors.
+        let _ = internal_event_sender.send(InternalEvent::ProtocolStopped { peer_id });
 
         // Reasons why this task might end:
         // (1) The local send the shutdown message (len = 0)

--- a/bee-network/bee-gossip/src/swarm/protocols/iota_gossip/io.rs
+++ b/bee-network/bee-gossip/src/swarm/protocols/iota_gossip/io.rs
@@ -28,85 +28,80 @@ pub fn channel() -> (GossipSender, GossipReceiver) {
     (sender, UnboundedReceiverStream::new(receiver))
 }
 
-pub fn start_incoming_processor(
+pub fn start_inbound_gossip_handler(
     peer_id: PeerId,
-    mut reader: BufReader<ReadHalf<Box<NegotiatedSubstream>>>,
-    incoming_tx: GossipSender,
-    internal_event_sender: InternalEventSender,
+    mut inbound_gossip_rx: BufReader<ReadHalf<Box<NegotiatedSubstream>>>,
+    inbound_gossip_tx: GossipSender,
+    internal_event_tx: InternalEventSender,
 ) {
     tokio::spawn(async move {
-        let mut msg_buf = vec![0u8; MSG_BUFFER_LEN];
+        let mut buf = vec![0u8; MSG_BUFFER_LEN];
 
         loop {
-            if let Some(len) = (&mut reader).read(&mut msg_buf).await.ok().filter(|len| *len > 0) {
-                if incoming_tx.send(msg_buf[..len].to_vec()).is_err() {
-                    debug!("gossip-in: receiver dropped locally.");
+            if let Some(len) = (&mut inbound_gossip_rx)
+                .read(&mut buf)
+                .await
+                .ok()
+                .filter(|len| *len > 0)
+            {
+                if inbound_gossip_tx.send(buf[..len].to_vec()).is_err() {
+                    debug!("Terminating gossip protocol with {}.", alias!(peer_id));
 
-                    // The receiver of this channel was dropped, maybe due to a shutdown. There is nothing we can do
-                    // to salvage this situation, hence we drop the connection.
                     break;
                 }
             } else {
-                debug!("gossip-in: stream closed remotely.");
+                debug!("Peer {} terminated gossip protocol.", alias!(peer_id));
 
-                // NB: The network service will not shut down before it has received the `ProtocolDropped` event
-                // from all once connected peers, hence if the following send fails, then it
-                // must be considered a bug.
+                // Panic: we made sure that the sender (network host) is always dropped before the receiver (service
+                // host) through the worker dependencies, hence this can never panic.
+                internal_event_tx
+                    .send(InternalEvent::ProtocolStopped { peer_id })
+                    .expect("send internal event");
 
                 break;
             }
         }
 
-        // Ignore send errors.
-        let _ = internal_event_sender.send(InternalEvent::ProtocolStopped { peer_id });
-
-        // Reasons why this task might end:
-        // (1) The remote dropped the TCP connection.
-        // (2) The local dropped the gossip_in receiver channel.
-
-        debug!("gossip-in: exiting gossip-in processor for {}.", alias!(peer_id));
+        trace!("Dropping gossip stream reader for {}.", alias!(peer_id));
     });
 }
 
-pub fn start_outgoing_processor(
+pub fn start_outbound_gossip_handler(
     peer_id: PeerId,
-    mut writer: BufWriter<WriteHalf<Box<NegotiatedSubstream>>>,
-    outgoing_rx: GossipReceiver,
-    internal_event_sender: InternalEventSender,
+    mut outbound_gossip_tx: BufWriter<WriteHalf<Box<NegotiatedSubstream>>>,
+    outbound_gossip_rx: GossipReceiver,
+    internal_event_tx: InternalEventSender,
 ) {
     tokio::spawn(async move {
-        let mut outgoing_gossip_receiver = outgoing_rx.fuse();
+        let mut outbound_gossip_rx = outbound_gossip_rx.fuse();
 
         // If the gossip sender dropped we end the connection.
-        while let Some(message) = outgoing_gossip_receiver.next().await {
-            // NB: Instead of polling another shutdown channel, we use an empty message
+        while let Some(message) = outbound_gossip_rx.next().await {
+            // Note: Instead of polling another shutdown channel, we use an empty message
             // to signal that we want to end the connection. We use this "trick" whenever the network
             // receives the `DisconnectPeer` command to enforce that the connection will be dropped.
-
             if message.is_empty() {
-                debug!("gossip-out: received shutdown message.");
+                debug!(
+                    "Terminating gossip protocol with {} (received shutdown signal).",
+                    alias!(peer_id)
+                );
 
-                // NB: The network service will not shut down before it has received the `ConnectionDropped` event
-                // from all once connected peers, hence if the following send fails, then it
-                // must be considered a bug.
+                // Panic: we made sure that the sender (network host) is always dropped before the receiver (service
+                // host) through the worker dependencies, hence this can never panic.
+                internal_event_tx
+                    .send(InternalEvent::ProtocolStopped { peer_id })
+                    .expect("send internal event");
+
                 break;
-            }
+            } else if (&mut outbound_gossip_tx).write_all(&message).await.is_err()
+                || (&mut outbound_gossip_tx).flush().await.is_err()
+            {
+                debug!("Peer {} terminated gossip protocol.", alias!(peer_id));
 
-            // If sending to the stream fails we end the connection.
-            // TODO: buffer for x milliseconds before flushing.
-            if (&mut writer).write_all(&message).await.is_err() || (&mut writer).flush().await.is_err() {
-                debug!("gossip-out: stream closed remotely");
                 break;
             }
         }
 
-        // Ignore send errors.
-        let _ = internal_event_sender.send(InternalEvent::ProtocolStopped { peer_id });
-
-        // Reasons why this task might end:
-        // (1) The local send the shutdown message (len = 0)
-        // (2) The remote dropped the TCP connection.
-
-        debug!("gossip-out: exiting gossip-out processor for {}.", alias!(peer_id));
+        trace!("Dropping gossip stream writer for {}.", alias!(peer_id));
     });
 }

--- a/bee-network/bee-gossip/src/tests/alias.rs
+++ b/bee-network/bee-gossip/src/tests/alias.rs
@@ -9,12 +9,12 @@ use crate::alias;
 fn alias_default() {
     let peer_id = gen_constant_peer_id();
     let alias = alias!(peer_id);
-    assert_eq!(alias, "WJWEKvSFbben74C7");
+    assert_eq!(alias, "JWEKvSFbben74C7H");
 }
 
 #[test]
 fn alias_custom() {
     let peer_id = gen_constant_peer_id();
     let alias = alias!(peer_id, 10);
-    assert_eq!(alias, "WJWEKvSFbb");
+    assert_eq!(alias, "JWEKvSFbbe");
 }

--- a/bee-network/bee-gossip/src/tests/alias.rs
+++ b/bee-network/bee-gossip/src/tests/alias.rs
@@ -9,12 +9,12 @@ use crate::alias;
 fn alias_default() {
     let peer_id = gen_constant_peer_id();
     let alias = alias!(peer_id);
-    assert_eq!(alias, "eF27st");
+    assert_eq!(alias, "WJWEKvSFbben74C7");
 }
 
 #[test]
 fn alias_custom() {
     let peer_id = gen_constant_peer_id();
     let alias = alias!(peer_id, 10);
-    assert_eq!(alias, "WSUEeF27st");
+    assert_eq!(alias, "WJWEKvSFbb");
 }

--- a/bee-node/Cargo.toml
+++ b/bee-node/Cargo.toml
@@ -13,7 +13,7 @@ homepage = "https://www.iota.org"
 [dependencies]
 bee-autopeering = { version = "0.4.0", path = "../bee-network/bee-autopeering", default-features = false, features = [ "rocksdb" ] }
 bee-common = { version = "0.6.0", path = "../bee-common/bee-common", default-features = false }
-bee-gossip = { version = "0.4.0", path = "../bee-network/bee-gossip", default-features = false, features = [ "full" ] }
+bee-gossip = { version = "0.5.0", path = "../bee-network/bee-gossip", default-features = false, features = [ "full" ] }
 bee-ledger = { version = "0.6.1", path = "../bee-ledger", default-features = false, features = [ "workers" ] }
 bee-message = { version = "0.1.6", path = "../bee-message", default-features = false }
 bee-protocol = { version = "0.2.0", path = "../bee-protocol", default-features = false, features = [ "workers" ] }

--- a/bee-protocol/CHANGELOG.md
+++ b/bee-protocol/CHANGELOG.md
@@ -19,7 +19,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Security -->
 
-## 0.2.0 - 2022-XX-XX
+## 0.2.1 - 2022-02-28
+
+### Changed
+
+- Peer manager handles new bee-gossip `PeerUnreachable` event;
+
+## 0.2.0 - 2022-01-27
 
 ### Added
 

--- a/bee-protocol/Cargo.toml
+++ b/bee-protocol/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bee-protocol"
-version = "0.2.0"
+version = "0.2.1"
 authors = [ "IOTA Stiftung" ]
 edition = "2021"
 description = "All types and workers enabling the IOTA protocol"
@@ -13,7 +13,7 @@ homepage = "https://www.iota.org"
 [dependencies]
 bee-autopeering = { version = "0.4.0", path = "../bee-network/bee-autopeering", default-features = false }
 bee-common = { version = "0.6.0", path = "../bee-common/bee-common", default-features = false, optional = true }
-bee-gossip = { version = "0.4.0", path = "../bee-network/bee-gossip", default-features = false }
+bee-gossip = { version = "0.5.0", path = "../bee-network/bee-gossip", default-features = false }
 bee-ledger = { version = "0.6.0", path = "../bee-ledger", default-features = false, features = [ "workers" ], optional = true }
 bee-message = { version = "0.1.6", path = "../bee-message", default-features = false, features = [ "serde" ] }
 bee-pow = { version = "0.2.0", path = "../bee-pow", default-features = false }

--- a/bee-protocol/src/workers/peer/manager.rs
+++ b/bee-protocol/src/workers/peer/manager.rs
@@ -190,7 +190,11 @@ where
                         .unwrap_or_default(),
                     NetworkEvent::PeerUnreachable { peer_id, peer_info } => {
                         if peer_info.relation.is_discovered() {
-                            // todo: tell the autopeering to remove that neighbor
+                            // Remove that discovered peer from the manager.
+                            if let Some(peer) = peer_manager.remove(&peer_id) {
+                                info!("Removed peer {}.", peer.0.alias());
+                            }
+                            // Todo: tell the autopeering to remove that neighbor.
                             log::error!("Tell autopeering to remove {}", alias!(peer_id));
                         }
                     }

--- a/bee-protocol/src/workers/peer/manager.rs
+++ b/bee-protocol/src/workers/peer/manager.rs
@@ -198,7 +198,10 @@ where
                                 .expect("send gossip command");
 
                             // Todo: tell the autopeering to remove that neighbor.
-                            log::warn!("TODO: tell autopeering to remove {} from neighborhood.", alias!(peer_id));
+                            log::warn!(
+                                "TODO: tell autopeering to remove {} from neighborhood.",
+                                alias!(peer_id)
+                            );
                         }
                     }
                     _ => (), // Ignore all other events for now
@@ -216,16 +219,16 @@ fn handle_new_peering(peer: bee_autopeering::Peer, network_name: &str, command_t
     if let Some(multiaddr) = peer.service_multiaddr(network_name) {
         let peer_id = peer.peer_id().libp2p_peer_id();
 
-    // Panic:
-    // Sending commands must not fail.
-    command_tx
-        .send(Command::AddPeer {
-            peer_id,
-            alias: Some(alias!(peer_id).to_string()),
-            multiaddr,
-            relation: PeerRelation::Discovered,
-        })
-        .expect("send command to gossip layer");
+        // Panic:
+        // Sending commands must not fail.
+        command_tx
+            .send(Command::AddPeer {
+                peer_id,
+                alias: Some(alias!(peer_id).to_string()),
+                multiaddr,
+                relation: PeerRelation::Discovered,
+            })
+            .expect("send command to gossip layer");
     }
 }
 

--- a/bee-protocol/src/workers/peer/manager.rs
+++ b/bee-protocol/src/workers/peer/manager.rs
@@ -198,7 +198,7 @@ where
                                 .expect("send gossip command");
 
                             // Todo: tell the autopeering to remove that neighbor.
-                            log::error!("Tell autopeering to remove {}", alias!(peer_id));
+                            log::warn!("TODO: tell autopeering to remove {} from neighborhood.", alias!(peer_id));
                         }
                     }
                     _ => (), // Ignore all other events for now
@@ -216,21 +216,25 @@ fn handle_new_peering(peer: bee_autopeering::Peer, network_name: &str, command_t
     if let Some(multiaddr) = peer.service_multiaddr(network_name) {
         let peer_id = peer.peer_id().libp2p_peer_id();
 
-        command_tx
-            .send(Command::AddPeer {
-                peer_id,
-                alias: Some(alias!(peer_id).to_string()),
-                multiaddr,
-                relation: PeerRelation::Discovered,
-            })
-            .expect("error sending network command");
+    // Panic:
+    // Sending commands must not fail.
+    command_tx
+        .send(Command::AddPeer {
+            peer_id,
+            alias: Some(alias!(peer_id).to_string()),
+            multiaddr,
+            relation: PeerRelation::Discovered,
+        })
+        .expect("send command to gossip layer");
     }
 }
 
 fn handle_peering_dropped(peer_id: bee_autopeering::PeerId, command_tx: &NetworkCommandSender) {
     let peer_id = peer_id.libp2p_peer_id();
 
+    // Panic:
+    // Sending commands must not fail.
     command_tx
         .send(Command::RemovePeer { peer_id })
-        .expect("error sending network command");
+        .expect("send command to gossip layer");
 }

--- a/bee-protocol/src/workers/peer/manager.rs
+++ b/bee-protocol/src/workers/peer/manager.rs
@@ -110,6 +110,7 @@ where
 
             while let Some(event) = receiver.next().await {
                 trace!("Received event {:?}.", event);
+                log::warn!{"peer_manager.len()={}", peer_manager.len()};
 
                 match event {
                     NetworkEvent::PeerAdded { peer_id, info } => {

--- a/bee-protocol/src/workers/peer/manager.rs
+++ b/bee-protocol/src/workers/peer/manager.rs
@@ -187,6 +187,12 @@ where
                             info!("Disconnected peer {}.", peer.0.alias());
                         })
                         .unwrap_or_default(),
+                    NetworkEvent::PeerUnreachable { peer_id, peer_info } => {
+                        if peer_info.relation.is_discovered() {
+                            // todo: tell the autopeering to remove that neighbor
+                            log::error!("Tell autopeering to remove {}", alias!(peer_id));
+                        }
+                    }
                     _ => (), // Ignore all other events for now
                 }
             }

--- a/bee-protocol/src/workers/peer/manager.rs
+++ b/bee-protocol/src/workers/peer/manager.rs
@@ -112,7 +112,6 @@ where
 
             while let Some(event) = receiver.next().await {
                 trace!("Received event {:?}.", event);
-                log::warn! {"peer_manager.len()={}", peer_manager.len()};
 
                 match event {
                     NetworkEvent::PeerAdded { peer_id, info } => {
@@ -197,11 +196,7 @@ where
                                 .send(Command::RemovePeer { peer_id })
                                 .expect("send gossip command");
 
-                            // Todo: tell the autopeering to remove that neighbor.
-                            log::warn!(
-                                "TODO: tell autopeering to remove {} from neighborhood.",
-                                alias!(peer_id)
-                            );
+                            // Todo: tell the autopeering to remove that peer from the neighborhood.
                         }
                     }
                     _ => (), // Ignore all other events for now

--- a/bee-protocol/src/workers/peer/manager_res.rs
+++ b/bee-protocol/src/workers/peer/manager_res.rs
@@ -181,4 +181,8 @@ impl PeerManager {
             .filter(|(_, (peer, ctx))| (ctx.is_some() && peer.is_synced()))
             .count() as u8
     }
+
+    pub fn len(&self) -> usize {
+        self.inner.read().peers.len()
+    }
 }


### PR DESCRIPTION
# Description of change

* Improves detection of a valid connection by making use of `libp2p` identify protocol;
* Fixes notification of removed peers in `bee-gossip` so that the peer manager in `bee-protocol` removes all disconnected peers appropriatedly;
* Improves logs;

## Links to any relevant issues

Fixes #1143 

## Type of change

<!-- Choose a type of change, and delete any options that are not relevant. -->

- Enhancement (a non-breaking change which adds functionality)
- Bug fix (a non-breaking change which fixes an issue)

## How the change has been tested

VPS

## Change checklist

<!-- Tick the boxes that are relevant to your changes, and delete any items that are not. -->

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that new and existing unit tests pass locally with my changes
- [x] I have updated the CHANGELOG.md, if my changes are significant enough
