### PR TITLE
Allow enabling autopeering service in CLI

### DIFF
--- a/bee-node/src/cli.rs
+++ b/bee-node/src/cli.rs
@@ -8,11 +8,6 @@ use structopt::StructOpt;
 
 use std::path::{Path, PathBuf};
 
-/// Holds the command line arguments that were passed to the binary.
-pub struct ClArgs {
-    cli: Cli,
-}
-
 // The command-line interface.
 // BEWARE: `structopt` puts any doc comment for this struct into the output of `--help`. We don't want that.
 #[derive(Clone, Debug, StructOpt)]
@@ -45,7 +40,16 @@ struct Cli {
     commit_version: bool,
     // Whether the node should run as an (autopeering) entry node.
     #[structopt(long = "entry_node", help = "Runs as autopeering entry node")]
-    entry_node: bool,
+    run_as_entry_node: bool,
+    // Whether the node should run with enabled autopeering service.
+    #[structopt(long = "autopeering", help = "Enables the autopeering service")]
+    enable_autopeering_service: bool,
+
+}
+
+/// Holds the command line arguments that were passed to the binary.
+pub struct ClArgs {
+    cli: Cli,
 }
 
 impl Default for ClArgs {
@@ -90,7 +94,12 @@ impl ClArgs {
 
     /// Returns whether the node should run as an (autopeering) entry node.
     pub fn run_as_entry_node(&self) -> bool {
-        self.cli.entry_node
+        self.cli.run_as_entry_node
+    }
+
+    /// Returns whether the node should run with enabled autopeering service.
+    pub fn enable_autopeering_service(&self) -> bool {
+        self.cli.enable_autopeering_service
     }
 }
 

--- a/bee-node/src/cli.rs
+++ b/bee-node/src/cli.rs
@@ -39,7 +39,7 @@ struct Cli {
     #[structopt(short = "v", long = "commit_version", help = "Prints exact commit version")]
     commit_version: bool,
     // Whether the node should run as an (autopeering) entry node.
-    #[structopt(long = "entry_node", help = "Runs as autopeering entry node")]
+    #[structopt(long = "entry-node", help = "Runs as autopeering entry node")]
     run_as_entry_node: bool,
     // Whether the node should run with enabled autopeering service.
     #[structopt(long = "autopeering", help = "Enables the autopeering service")]

--- a/bee-node/src/cli.rs
+++ b/bee-node/src/cli.rs
@@ -43,8 +43,7 @@ struct Cli {
     run_as_entry_node: bool,
     // Whether the node should run with enabled autopeering service.
     #[structopt(long = "autopeering", help = "Enables the autopeering service")]
-    enable_autopeering_service: bool,
-
+    enable_autopeering: bool,
 }
 
 /// Holds the command line arguments that were passed to the binary.
@@ -98,8 +97,8 @@ impl ClArgs {
     }
 
     /// Returns whether the node should run with enabled autopeering service.
-    pub fn enable_autopeering_service(&self) -> bool {
-        self.cli.enable_autopeering_service
+    pub fn enable_autopeering(&self) -> bool {
+        self.cli.enable_autopeering
     }
 }
 

--- a/bee-node/src/config.rs
+++ b/bee-node/src/config.rs
@@ -199,6 +199,11 @@ where
 
             autopeering.enabled = true;
             autopeering.run_as_entry_node = Some(true);
+        } else if args.enable_autopeering_service() {
+            // TODO: use 'option_get_or_insert_default' once stable (see issue #82901)
+            let autopeering = self.autopeering.get_or_insert(AutopeeringConfigBuilder::default());
+
+            autopeering.enabled = true;
         }
 
         self

--- a/bee-node/src/config.rs
+++ b/bee-node/src/config.rs
@@ -192,17 +192,14 @@ where
             logger.level(LOGGER_STDOUT_NAME, log_level);
         }
 
+        // TODO: use 'option_get_or_insert_default' once stable (see issue #82901)
+        let autopeering = self.autopeering.get_or_insert(AutopeeringConfigBuilder::default());
+
         // Override the entry node mode.
         if args.run_as_entry_node() {
-            // TODO: use 'option_get_or_insert_default' once stable (see issue #82901)
-            let autopeering = self.autopeering.get_or_insert(AutopeeringConfigBuilder::default());
-
             autopeering.enabled = true;
             autopeering.run_as_entry_node = Some(true);
-        } else if args.enable_autopeering_service() {
-            // TODO: use 'option_get_or_insert_default' once stable (see issue #82901)
-            let autopeering = self.autopeering.get_or_insert(AutopeeringConfigBuilder::default());
-
+        } else if args.enable_autopeering() {
             autopeering.enabled = true;
         }
 


### PR DESCRIPTION
# Description of change

Allows node operators to enable the autopeering service via CLI.

## Links to any relevant issues

Fixes #1121 

## Type of change

<!-- Choose a type of change, and delete any options that are not relevant. -->

- Bug fix (a non-breaking change which fixes an issue)
- Enhancement (a non-breaking change which adds functionality)

## How the change has been tested

<!-- Describe the tests that you ran to verify your changes. -->

- Checked the correctness of the CLI via `cargo r -- --help`;
- Started the node, and checked whether autopeering service starts along with it;

<!-- Make sure to provide instructions for the maintainer as well as any relevant configurations. -->

## Change checklist

<!-- Tick the boxes that are relevant to your changes, and delete any items that are not. -->

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that new and existing unit tests pass locally with my changes
- [x] I have updated the CHANGELOG.md, if my changes are significant enough
