### PR TITLE
Fetch dashboard release in `build.rs`

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,3 +1,1 @@
 target/
-
-bee-node/src/plugins/dashboard/frontend/node_modules/

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -93,14 +93,6 @@ jobs:
             ${{ matrix.os }}-${{ matrix.rust }}-
             ${{ matrix.os }}-
 
-      - name: Install dashboard frontend
-        run: |
-          git submodule init
-          git submodule update --recursive --remote
-          cd bee-node/src/plugins/dashboard/frontend/
-          npm install
-          npm run build-bee
-
       - name: Build
         uses: actions-rs/cargo@v1
         with:
@@ -227,14 +219,6 @@ jobs:
             ubuntu-latest-beta-
             ubuntu-latest-
 
-      - name: Install dashboard frontend
-        run: |
-          git submodule init
-          git submodule update --recursive --remote
-          cd bee-node/src/plugins/dashboard/frontend/
-          npm install
-          npm run build-bee
-
       - uses: actions-rs/clippy-check@v1
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
@@ -267,14 +251,6 @@ jobs:
             ubuntu-latest-nightly-${{ env.cache-name }}-
             ubuntu-latest-nightly-
             ubuntu-latest-
-
-      - name: Install dashboard frontend
-        run: |
-          git submodule init
-          git submodule update --recursive --remote
-          cd bee-node/src/plugins/dashboard/frontend/
-          npm install
-          npm run build-bee
 
       - uses: actions-rs/cargo@v1
         with:

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -36,14 +36,6 @@ jobs:
           crate: rustfilt
           version: 0.2.1
 
-      - name: Install dashboard frontend
-        run: |
-          git submodule init
-          git submodule update --recursive --remote
-          cd bee-node/src/plugins/dashboard/frontend/
-          npm install
-          npm run build-bee
-
       - name: Run test coverage
         run: bash .github/workflows/scripts/coverage.sh
 

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,5 +1,0 @@
-[submodule "bee-node/src/plugins/dashboard/frontend"]
-	path = bee-node/src/plugins/dashboard/frontend
-	url = https://github.com/iotaledger/node-dashboard
-	branch = main
-	ignore = dirty

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -55,6 +55,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "aho-corasick"
+version = "0.7.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e37cfd5e7657ada45f742d6e99ca5788580b5c529dc78faf11ece6dc702656f"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
+name = "ansi_term"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d52a9bb7ec0cf484c551830a7ce27bd20d67eac647e1befb56b0be4ee39a55d2"
+dependencies = [
+ "winapi",
+]
+
+[[package]]
 name = "anyhow"
 version = "1.0.53"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -79,6 +97,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "23b62fc65de8e4e7f52534fb52b0f3ed04746ae267519eef2a83941e8085068b"
 
 [[package]]
+name = "arrayvec"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8da52d66c7071e2e3fa2a1e5c6d088fec47b593032b254f5e980de8ea54454d6"
+
+[[package]]
 name = "asn1_der"
 version = "0.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -101,7 +125,7 @@ version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "327a05f4e4b447de629293f84baf0fd25616c2dfad963c9bf2cd8507c95b7852"
 dependencies = [
- "futures",
+ "futures 0.3.19",
 ]
 
 [[package]]
@@ -258,7 +282,7 @@ dependencies = [
  "async-trait",
  "bee-runtime",
  "fern",
- "futures",
+ "futures 0.3.19",
  "hashbrown",
  "hex",
  "libp2p",
@@ -284,8 +308,8 @@ dependencies = [
  "bee-storage",
  "bee-tangle",
  "bytes",
- "digest",
- "futures",
+ "digest 0.9.0",
+ "futures 0.3.19",
  "hashbrown",
  "hex",
  "iota-crypto",
@@ -310,7 +334,7 @@ dependencies = [
  "bee-ternary 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "bee-test",
  "bytemuck",
- "digest",
+ "digest 0.9.0",
  "hex",
  "iota-crypto",
  "iterator-sorted",
@@ -340,10 +364,11 @@ dependencies = [
  "bee-storage-sled",
  "bee-tangle",
  "cap",
+ "checksums",
  "chrono",
  "ed25519",
  "fern-logger",
- "futures",
+ "futures 0.3.19",
  "fxhash",
  "hex",
  "iota-crypto",
@@ -359,7 +384,6 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_repr",
- "sha2",
  "structopt",
  "tempfile",
  "thiserror",
@@ -398,7 +422,7 @@ dependencies = [
  "bee-runtime",
  "bee-storage",
  "bee-tangle",
- "futures",
+ "futures 0.3.19",
  "futures-util",
  "fxhash",
  "hex",
@@ -429,8 +453,8 @@ dependencies = [
  "bee-runtime",
  "bee-storage",
  "bee-tangle",
- "digest",
- "futures",
+ "digest 0.9.0",
+ "futures 0.3.19",
  "hex",
  "iota-crypto",
  "log",
@@ -450,7 +474,7 @@ dependencies = [
  "async-trait",
  "bee-storage",
  "dashmap",
- "futures",
+ "futures 0.3.19",
  "log",
  "tokio",
 ]
@@ -558,7 +582,7 @@ dependencies = [
  "bee-test",
  "bitflags",
  "criterion",
- "futures",
+ "futures 0.3.19",
  "hashbrown",
  "log",
  "rand 0.8.4",
@@ -639,13 +663,23 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
+name = "blake"
+version = "2.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee55e9ca33be1f257d8356cfb29b10b1c8f86dc38cf1344ca01525464356cd0c"
+dependencies = [
+ "cc",
+ "libc",
+]
+
+[[package]]
 name = "blake2"
 version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0a4e37d16930f5459780f5621038b6382b9bb37c19016f39fb6b5808d831f174"
 dependencies = [
  "crypto-mac",
- "digest",
+ "digest 0.9.0",
  "opaque-debug",
 ]
 
@@ -656,8 +690,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "afa748e348ad3be8263be728124b24a24f268266f6f5d58af9d75f6a40b5c587"
 dependencies = [
  "arrayref",
- "arrayvec",
+ "arrayvec 0.5.2",
  "constant_time_eq",
+]
+
+[[package]]
+name = "blake3"
+version = "1.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a08e53fc5a564bb15bfe6fae56bd71522205f1f91893f9c0116edad6496c183f"
+dependencies = [
+ "arrayref",
+ "arrayvec 0.7.2",
+ "cc",
+ "cfg-if",
+ "constant_time_eq",
+ "digest 0.10.3",
 ]
 
 [[package]]
@@ -667,6 +715,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4152116fd6e9dadb291ae18fc1ec3575ed6d84c29642d97890f4b4a3417297e4"
 dependencies = [
  "block-padding",
+ "generic-array",
+]
+
+[[package]]
+name = "block-buffer"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0bf7fe51849ea569fd452f37822f606a5cabb684dc918707a0193fd4664ff324"
+dependencies = [
  "generic-array",
 ]
 
@@ -703,6 +760,12 @@ dependencies = [
  "memchr",
  "safemem",
 ]
+
+[[package]]
+name = "build_const"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4ae4235e6dac0694637c763029ecea1a2ec9e4e06ec2729bd21ba4d9c863eb7"
 
 [[package]]
 name = "bumpalo"
@@ -820,6 +883,35 @@ dependencies = [
 ]
 
 [[package]]
+name = "checksums"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e7b400ece158d2e69b09054f6ce3a5773510e7cbde7effbc289c95041e19c3f5"
+dependencies = [
+ "blake",
+ "blake2",
+ "blake3",
+ "clap",
+ "crc",
+ "crc16",
+ "crc32c",
+ "crc8",
+ "futures 0.1.31",
+ "futures-cpupool",
+ "md-5",
+ "md6",
+ "num_cpus",
+ "once_cell",
+ "pbr",
+ "regex",
+ "shaman",
+ "tabwriter",
+ "tiny-keccak",
+ "walkdir",
+ "whirlpool",
+]
+
+[[package]]
 name = "chrono"
 version = "0.4.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -858,9 +950,13 @@ version = "2.34.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a0610544180c38b88101fecf2dd634b174a62eef6946f84dfc6a7127512b381c"
 dependencies = [
+ "ansi_term",
+ "atty",
  "bitflags",
+ "strsim",
  "textwrap",
  "unicode-width",
+ "vec_map",
 ]
 
 [[package]]
@@ -939,6 +1035,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "crc"
+version = "1.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d663548de7f5cca343f1e0a48d14dcfb0e9eb4e079ec58883b7251539fa10aeb"
+dependencies = [
+ "build_const",
+]
+
+[[package]]
+name = "crc16"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "338089f42c427b86394a5ee60ff321da23a5c89c9d89514c829687b26359fcff"
+
+[[package]]
+name = "crc32c"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee6b9c9389584bcba988bd0836086789b7f87ad91892d6a83d5291dbb24524b5"
+dependencies = [
+ "rustc_version 0.4.0",
+]
+
+[[package]]
 name = "crc32fast"
 version = "1.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -946,6 +1066,12 @@ checksum = "a2209c310e29876f7f0b2721e7e26b84aff178aa3da5d091f9bfbf47669e60e3"
 dependencies = [
  "cfg-if",
 ]
+
+[[package]]
+name = "crc8"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b31d2174830f395fd7e413c2f8a119252de36356982f805f495269331e97559e"
 
 [[package]]
 name = "criterion"
@@ -958,7 +1084,7 @@ dependencies = [
  "clap",
  "criterion-plot",
  "csv",
- "futures",
+ "futures 0.3.19",
  "itertools",
  "lazy_static",
  "num-traits",
@@ -1036,6 +1162,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a81dae078cea95a014a339291cec439d2f232ebe854a9d672b796c6afafa9b7"
 
 [[package]]
+name = "crypto-common"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57952ca27b5e3606ff4dd79b0020231aaf9d6aa76dc05fd30137538c50bd3ce8"
+dependencies = [
+ "generic-array",
+ "typenum",
+]
+
+[[package]]
 name = "crypto-mac"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1083,7 +1219,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b9fdf9972b2bd6af2d913799d9ebc165ea4d2e65878e329d9c6b372c4491b61"
 dependencies = [
  "byteorder",
- "digest",
+ "digest 0.9.0",
  "rand_core 0.5.1",
  "subtle",
  "zeroize",
@@ -1122,6 +1258,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3dd60d1080a57a05ab032377049e0591415d2b31afd7028356dbf3cc6dcb066"
 dependencies = [
  "generic-array",
+]
+
+[[package]]
+name = "digest"
+version = "0.10.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2fb860ca6fafa5552fb6d0e816a69c8e49f0908bf524e30a90d97c85892d506"
+dependencies = [
+ "block-buffer 0.10.2",
+ "crypto-common",
+ "subtle",
 ]
 
 [[package]]
@@ -1308,6 +1455,12 @@ dependencies = [
 
 [[package]]
 name = "futures"
+version = "0.1.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a471a38ef8ed83cd6e40aa59c1ffe17db6855c18e3604d9c4ed8c08ebc28678"
+
+[[package]]
+name = "futures"
 version = "0.3.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "28560757fe2bb34e79f907794bb6b22ae8b0e5c669b638a1132f2592b19035b4"
@@ -1336,6 +1489,16 @@ name = "futures-core"
 version = "0.3.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0c8ff0461b82559810cdccfde3215c3f373807f5e5232b71479bff7bb2583d7"
+
+[[package]]
+name = "futures-cpupool"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab90cde24b3319636588d0c35fe03b1333857621051837ed769faefb4c2162e4"
+dependencies = [
+ "futures 0.1.31",
+ "num_cpus",
+]
 
 [[package]]
 name = "futures-executor"
@@ -1560,7 +1723,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "126888268dcc288495a26bf004b38c5fdbb31682f992c84ceb046a1f0fe38840"
 dependencies = [
  "crypto-mac",
- "digest",
+ "digest 0.9.0",
 ]
 
 [[package]]
@@ -1569,7 +1732,7 @@ version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "17ea0a1394df5b6574da6e0c1ade9e78868c9fb0a4e5ef4428e32da4676b85b1"
 dependencies = [
- "digest",
+ "digest 0.9.0",
  "generic-array",
  "hmac",
 ]
@@ -1715,7 +1878,7 @@ checksum = "8c98a3248cde6b42cb479a52089fe4fc20d12de51b8edd923294cd5240ec89b0"
 dependencies = [
  "bee-ternary 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "blake2",
- "digest",
+ "digest 0.9.0",
  "ed25519-zebra",
  "getrandom 0.2.4",
  "lazy_static",
@@ -1844,7 +2007,7 @@ checksum = "9004c06878ef8f3b4b4067e69a140d87ed20bf777287f82223e49713b36ee433"
 dependencies = [
  "atomic",
  "bytes",
- "futures",
+ "futures 0.3.19",
  "lazy_static",
  "libp2p-core",
  "libp2p-dns",
@@ -1873,7 +2036,7 @@ dependencies = [
  "ed25519-dalek",
  "either",
  "fnv",
- "futures",
+ "futures 0.3.19",
  "futures-timer",
  "lazy_static",
  "libsecp256k1",
@@ -1902,7 +2065,7 @@ version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "58ff08b3196b85a17f202d80589e93b1660a574af67275706657fdc762e42c32"
 dependencies = [
- "futures",
+ "futures 0.3.19",
  "libp2p-core",
  "log",
  "smallvec",
@@ -1915,7 +2078,7 @@ version = "0.30.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a7b61f6cf07664fb97016c318c4d4512b3dd4cc07238607f3f0163245f99008e"
 dependencies = [
- "futures",
+ "futures 0.3.19",
  "libp2p-core",
  "libp2p-swarm",
  "log",
@@ -1933,7 +2096,7 @@ checksum = "313d9ea526c68df4425f580024e67a9d3ffd49f2c33de5154b1f5019816f7a99"
 dependencies = [
  "asynchronous-codec",
  "bytes",
- "futures",
+ "futures 0.3.19",
  "libp2p-core",
  "log",
  "nohash-hasher",
@@ -1951,7 +2114,7 @@ checksum = "3f1db7212f342b6ba7c981cc40e31f76e9e56cb48e65fa4c142ecaca5839523e"
 dependencies = [
  "bytes",
  "curve25519-dalek",
- "futures",
+ "futures 0.3.19",
  "lazy_static",
  "libp2p-core",
  "log",
@@ -1972,7 +2135,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7083861341e1555467863b4cd802bea1e8c4787c0f7b5110097d0f1f3248f9a9"
 dependencies = [
  "either",
- "futures",
+ "futures 0.3.19",
  "libp2p-core",
  "log",
  "rand 0.7.3",
@@ -1997,7 +2160,7 @@ version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "79edd26b6b4bb5feee210dcda562dca186940dfecb0024b979c3f50824b3bf28"
 dependencies = [
- "futures",
+ "futures 0.3.19",
  "futures-timer",
  "if-addrs",
  "ipnet",
@@ -2014,7 +2177,7 @@ version = "0.33.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "214cc0dd9c37cbed27f0bb1eba0c41bbafdb93a8be5e9d6ae1e6b4b42cd044bf"
 dependencies = [
- "futures",
+ "futures 0.3.19",
  "libp2p-core",
  "parking_lot",
  "thiserror",
@@ -2041,7 +2204,7 @@ checksum = "bd1137239ab33b41aa9637a88a28249e5e70c40a42ccc92db7f12cc356c1fcd7"
 dependencies = [
  "arrayref",
  "base64 0.12.3",
- "digest",
+ "digest 0.9.0",
  "hmac-drbg",
  "libsecp256k1-core",
  "libsecp256k1-gen-ecmult",
@@ -2059,7 +2222,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0f6ab710cec28cef759c5f18671a27dae2a5f952cdaaee1d8e2908cb2478a80"
 dependencies = [
  "crunchy",
- "digest",
+ "digest 0.9.0",
  "subtle",
 ]
 
@@ -2126,6 +2289,27 @@ name = "matches"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a3e378b66a060d48947b590737b30a1be76706c8dd7b8ba0f2fe3989c68a853f"
+
+[[package]]
+name = "md-5"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b5a279bb9607f9f53c22d496eade00d138d1bdcccd07d74650387cf94942a15"
+dependencies = [
+ "block-buffer 0.9.0",
+ "digest 0.9.0",
+ "opaque-debug",
+]
+
+[[package]]
+name = "md6"
+version = "2.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed426378c4745d1257e49ee3f729aaec2f0c6f29113ab7835a0b5938ca07b86f"
+dependencies = [
+ "cc",
+ "libc",
+]
 
 [[package]]
 name = "memchr"
@@ -2220,7 +2404,7 @@ version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "752a61cd890ff691b4411423d23816d5866dd5621e4d1c5687a53b94b5a979d8"
 dependencies = [
- "digest",
+ "digest 0.9.0",
  "generic-array",
  "multihash-derive",
  "sha2",
@@ -2272,7 +2456,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "56a336acba8bc87c8876f6425407dbbe6c417bf478b22015f8fb0994ef3bc0ab"
 dependencies = [
  "bytes",
- "futures",
+ "futures 0.3.19",
  "log",
  "pin-project 1.0.10",
  "smallvec",
@@ -2484,7 +2668,7 @@ version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d82fea0990fe54e75d575bbd9bc2ee5919fd10cc0b4a95f1967528083129fc4b"
 dependencies = [
- "futures",
+ "futures 0.3.19",
  "futures-timer",
  "libc",
  "log",
@@ -2523,6 +2707,18 @@ dependencies = [
  "libc",
  "redox_syscall",
  "smallvec",
+ "winapi",
+]
+
+[[package]]
+name = "pbr"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff5751d87f7c00ae6403eb1fcbba229b9c76c9a30de8c1cf87182177b168cea2"
+dependencies = [
+ "crossbeam-channel",
+ "libc",
+ "time 0.1.43",
  "winapi",
 ]
 
@@ -2973,6 +3169,8 @@ version = "1.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d07a8629359eb56f1e2fb1652bb04212c072a87ba68546a04065d525673ac461"
 dependencies = [
+ "aho-corasick",
+ "memchr",
  "regex-syntax",
 ]
 
@@ -3132,6 +3330,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
 
 [[package]]
+name = "rustc-serialize"
+version = "0.3.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dcf128d1287d2ea9d80910b5f1120d0b8eede3fbf1abe91c40d39ea7d51e6fda"
+
+[[package]]
 name = "rustc_version"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3155,7 +3359,7 @@ version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4da5fcb054c46f5a5dff833b129285a93d3f0179531735e6c866e8cc307d2020"
 dependencies = [
- "futures",
+ "futures 0.3.19",
  "pin-project 0.4.29",
  "static_assertions",
 ]
@@ -3342,10 +3546,10 @@ version = "0.9.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "99cd6713db3cf16b6c84e06321e049a9b9f699826e16096d23bbcc44d15d51a6"
 dependencies = [
- "block-buffer",
+ "block-buffer 0.9.0",
  "cfg-if",
  "cpufeatures 0.2.1",
- "digest",
+ "digest 0.9.0",
  "opaque-debug",
 ]
 
@@ -3355,10 +3559,10 @@ version = "0.9.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4d58a1e1bf39749807d89cf2d98ac2dfa0ff1cb3faa38fbb64dd88ac8013d800"
 dependencies = [
- "block-buffer",
+ "block-buffer 0.9.0",
  "cfg-if",
  "cpufeatures 0.2.1",
- "digest",
+ "digest 0.9.0",
  "opaque-debug",
 ]
 
@@ -3368,10 +3572,20 @@ version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f81199417d4e5de3f04b1e871023acea7389672c4135918f05aa9cbf2f2fa809"
 dependencies = [
- "block-buffer",
- "digest",
+ "block-buffer 0.9.0",
+ "digest 0.9.0",
  "keccak",
  "opaque-debug",
+]
+
+[[package]]
+name = "shaman"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b1a48b7e97a07b8f5771159e6914d8459557f8f833a60c4bd041f03736844f5"
+dependencies = [
+ "rand 0.8.4",
+ "rustc-serialize",
 ]
 
 [[package]]
@@ -3506,6 +3720,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
+name = "strsim"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ea5119cdb4c55b55d432abb513a0429384878c15dde60cc77b1c99de1a95a6a"
+
+[[package]]
 name = "structopt"
 version = "0.3.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3556,6 +3776,15 @@ dependencies = [
  "quote",
  "syn",
  "unicode-xid",
+]
+
+[[package]]
+name = "tabwriter"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "36205cfc997faadcc4b0b87aaef3fbedafe20d38d4959a7ca6ff803564051111"
+dependencies = [
+ "unicode-width",
 ]
 
 [[package]]
@@ -3973,6 +4202,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
 
 [[package]]
+name = "vec_map"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1bddf1187be692e79c5ffeab891132dfb0f236ed36a43c7ed39f1165ee20191"
+
+[[package]]
 name = "version_check"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4133,7 +4368,7 @@ version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "be0ecb0db480561e9a7642b5d3e4187c128914e58aa84330b9493e3eb68c5e7f"
 dependencies = [
- "futures",
+ "futures 0.3.19",
  "js-sys",
  "parking_lot",
  "pin-utils",
@@ -4161,6 +4396,17 @@ dependencies = [
  "either",
  "lazy_static",
  "libc",
+]
+
+[[package]]
+name = "whirlpool"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fd6b887d628151d048b725717536b20888cdf177c5673a5f5dfc48d700272664"
+dependencies = [
+ "block-buffer 0.9.0",
+ "digest 0.9.0",
+ "opaque-debug",
 ]
 
 [[package]]
@@ -4235,7 +4481,7 @@ version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e7d9028f208dd5e63c614be69f115c1b53cacc1111437d4c765185856666c107"
 dependencies = [
- "futures",
+ "futures 0.3.19",
  "log",
  "nohash-hasher",
  "parking_lot",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -162,9 +162,9 @@ dependencies = [
 
 [[package]]
 name = "autocfg"
-version = "1.0.1"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cdb031dd78e28731d87d56cc8ffef4a8f36ca26c38fe2de700543e627f8a464a"
+checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
 
 [[package]]
 name = "base64"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,12 @@
 version = 3
 
 [[package]]
+name = "adler"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
+
+[[package]]
 name = "aead"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -347,12 +353,14 @@ dependencies = [
  "paho-mqtt",
  "pkcs8",
  "rand 0.8.4",
+ "reqwest",
  "rpassword",
  "rust-embed",
  "serde",
  "serde_json",
  "serde_repr",
  "structopt",
+ "tempfile",
  "thiserror",
  "tokio",
  "tokio-stream",
@@ -360,6 +368,7 @@ dependencies = [
  "tracing",
  "warp",
  "warp-reverse-proxy",
+ "zip",
 ]
 
 [[package]]
@@ -717,6 +726,27 @@ name = "bytes"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c4872d67bab6358e59559027aa3b9157c53d9358c51423c17554809a8858e0f8"
+
+[[package]]
+name = "bzip2"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6afcd980b5f3a45017c57e57a2fcccbb351cc43a356ce117ef760ef8052b89b0"
+dependencies = [
+ "bzip2-sys",
+ "libc",
+]
+
+[[package]]
+name = "bzip2-sys"
+version = "0.1.11+1.0.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "736a955f3fa7875102d57c82b8cac37ec45224a07fd32d58f9f7a186b6cd4cdc"
+dependencies = [
+ "cc",
+ "libc",
+ "pkg-config",
+]
 
 [[package]]
 name = "cache-padded"
@@ -1221,6 +1251,18 @@ name = "fixedbitset"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37ab347416e802de484e4d03c7316c48f1ecb56574dfd4a46a80f173ce1de04d"
+
+[[package]]
+name = "flate2"
+version = "1.0.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e6988e897c1c9c485f43b47a529cef42fde0547f9d8d41a7062518f1d8fc53f"
+dependencies = [
+ "cfg-if",
+ "crc32fast",
+ "libc",
+ "miniz_oxide",
+]
 
 [[package]]
 name = "fnv"
@@ -2120,6 +2162,16 @@ name = "minimal-lexical"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
+
+[[package]]
+name = "miniz_oxide"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a92518e98c078586bc6c934028adcca4c92a53d6a958196de835170a01d84e4b"
+dependencies = [
+ "adler",
+ "autocfg",
+]
 
 [[package]]
 name = "mio"
@@ -4209,6 +4261,19 @@ dependencies = [
  "quote",
  "syn",
  "synstructure",
+]
+
+[[package]]
+name = "zip"
+version = "0.5.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93ab48844d61251bb3835145c521d88aa4031d7139e8485990f60ca911fa0815"
+dependencies = [
+ "byteorder",
+ "bzip2",
+ "crc32fast",
+ "flate2",
+ "thiserror",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -359,6 +359,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_repr",
+ "sha2",
  "structopt",
  "tempfile",
  "thiserror",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -55,24 +55,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "aho-corasick"
-version = "0.7.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e37cfd5e7657ada45f742d6e99ca5788580b5c529dc78faf11ece6dc702656f"
-dependencies = [
- "memchr",
-]
-
-[[package]]
-name = "ansi_term"
-version = "0.12.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d52a9bb7ec0cf484c551830a7ce27bd20d67eac647e1befb56b0be4ee39a55d2"
-dependencies = [
- "winapi",
-]
-
-[[package]]
 name = "anyhow"
 version = "1.0.53"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -97,12 +79,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "23b62fc65de8e4e7f52534fb52b0f3ed04746ae267519eef2a83941e8085068b"
 
 [[package]]
-name = "arrayvec"
-version = "0.7.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8da52d66c7071e2e3fa2a1e5c6d088fec47b593032b254f5e980de8ea54454d6"
-
-[[package]]
 name = "asn1_der"
 version = "0.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -125,7 +101,7 @@ version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "327a05f4e4b447de629293f84baf0fd25616c2dfad963c9bf2cd8507c95b7852"
 dependencies = [
- "futures 0.3.19",
+ "futures",
 ]
 
 [[package]]
@@ -282,7 +258,7 @@ dependencies = [
  "async-trait",
  "bee-runtime",
  "fern",
- "futures 0.3.19",
+ "futures",
  "hashbrown",
  "hex",
  "libp2p",
@@ -308,8 +284,8 @@ dependencies = [
  "bee-storage",
  "bee-tangle",
  "bytes",
- "digest 0.9.0",
- "futures 0.3.19",
+ "digest",
+ "futures",
  "hashbrown",
  "hex",
  "iota-crypto",
@@ -334,7 +310,7 @@ dependencies = [
  "bee-ternary 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "bee-test",
  "bytemuck",
- "digest 0.9.0",
+ "digest",
  "hex",
  "iota-crypto",
  "iterator-sorted",
@@ -364,11 +340,10 @@ dependencies = [
  "bee-storage-sled",
  "bee-tangle",
  "cap",
- "checksums",
  "chrono",
  "ed25519",
  "fern-logger",
- "futures 0.3.19",
+ "futures",
  "fxhash",
  "hex",
  "iota-crypto",
@@ -384,6 +359,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_repr",
+ "sha2",
  "structopt",
  "tempfile",
  "thiserror",
@@ -422,7 +398,7 @@ dependencies = [
  "bee-runtime",
  "bee-storage",
  "bee-tangle",
- "futures 0.3.19",
+ "futures",
  "futures-util",
  "fxhash",
  "hex",
@@ -453,8 +429,8 @@ dependencies = [
  "bee-runtime",
  "bee-storage",
  "bee-tangle",
- "digest 0.9.0",
- "futures 0.3.19",
+ "digest",
+ "futures",
  "hex",
  "iota-crypto",
  "log",
@@ -474,7 +450,7 @@ dependencies = [
  "async-trait",
  "bee-storage",
  "dashmap",
- "futures 0.3.19",
+ "futures",
  "log",
  "tokio",
 ]
@@ -582,7 +558,7 @@ dependencies = [
  "bee-test",
  "bitflags",
  "criterion",
- "futures 0.3.19",
+ "futures",
  "hashbrown",
  "log",
  "rand 0.8.4",
@@ -663,23 +639,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
-name = "blake"
-version = "2.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee55e9ca33be1f257d8356cfb29b10b1c8f86dc38cf1344ca01525464356cd0c"
-dependencies = [
- "cc",
- "libc",
-]
-
-[[package]]
 name = "blake2"
 version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0a4e37d16930f5459780f5621038b6382b9bb37c19016f39fb6b5808d831f174"
 dependencies = [
  "crypto-mac",
- "digest 0.9.0",
+ "digest",
  "opaque-debug",
 ]
 
@@ -690,22 +656,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "afa748e348ad3be8263be728124b24a24f268266f6f5d58af9d75f6a40b5c587"
 dependencies = [
  "arrayref",
- "arrayvec 0.5.2",
+ "arrayvec",
  "constant_time_eq",
-]
-
-[[package]]
-name = "blake3"
-version = "1.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a08e53fc5a564bb15bfe6fae56bd71522205f1f91893f9c0116edad6496c183f"
-dependencies = [
- "arrayref",
- "arrayvec 0.7.2",
- "cc",
- "cfg-if",
- "constant_time_eq",
- "digest 0.10.3",
 ]
 
 [[package]]
@@ -715,15 +667,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4152116fd6e9dadb291ae18fc1ec3575ed6d84c29642d97890f4b4a3417297e4"
 dependencies = [
  "block-padding",
- "generic-array",
-]
-
-[[package]]
-name = "block-buffer"
-version = "0.10.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0bf7fe51849ea569fd452f37822f606a5cabb684dc918707a0193fd4664ff324"
-dependencies = [
  "generic-array",
 ]
 
@@ -760,12 +703,6 @@ dependencies = [
  "memchr",
  "safemem",
 ]
-
-[[package]]
-name = "build_const"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4ae4235e6dac0694637c763029ecea1a2ec9e4e06ec2729bd21ba4d9c863eb7"
 
 [[package]]
 name = "bumpalo"
@@ -883,35 +820,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "checksums"
-version = "0.9.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e7b400ece158d2e69b09054f6ce3a5773510e7cbde7effbc289c95041e19c3f5"
-dependencies = [
- "blake",
- "blake2",
- "blake3",
- "clap",
- "crc",
- "crc16",
- "crc32c",
- "crc8",
- "futures 0.1.31",
- "futures-cpupool",
- "md-5",
- "md6",
- "num_cpus",
- "once_cell",
- "pbr",
- "regex",
- "shaman",
- "tabwriter",
- "tiny-keccak",
- "walkdir",
- "whirlpool",
-]
-
-[[package]]
 name = "chrono"
 version = "0.4.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -950,13 +858,9 @@ version = "2.34.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a0610544180c38b88101fecf2dd634b174a62eef6946f84dfc6a7127512b381c"
 dependencies = [
- "ansi_term",
- "atty",
  "bitflags",
- "strsim",
  "textwrap",
  "unicode-width",
- "vec_map",
 ]
 
 [[package]]
@@ -1035,30 +939,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "crc"
-version = "1.8.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d663548de7f5cca343f1e0a48d14dcfb0e9eb4e079ec58883b7251539fa10aeb"
-dependencies = [
- "build_const",
-]
-
-[[package]]
-name = "crc16"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "338089f42c427b86394a5ee60ff321da23a5c89c9d89514c829687b26359fcff"
-
-[[package]]
-name = "crc32c"
-version = "0.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee6b9c9389584bcba988bd0836086789b7f87ad91892d6a83d5291dbb24524b5"
-dependencies = [
- "rustc_version 0.4.0",
-]
-
-[[package]]
 name = "crc32fast"
 version = "1.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1066,12 +946,6 @@ checksum = "a2209c310e29876f7f0b2721e7e26b84aff178aa3da5d091f9bfbf47669e60e3"
 dependencies = [
  "cfg-if",
 ]
-
-[[package]]
-name = "crc8"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b31d2174830f395fd7e413c2f8a119252de36356982f805f495269331e97559e"
 
 [[package]]
 name = "criterion"
@@ -1084,7 +958,7 @@ dependencies = [
  "clap",
  "criterion-plot",
  "csv",
- "futures 0.3.19",
+ "futures",
  "itertools",
  "lazy_static",
  "num-traits",
@@ -1162,16 +1036,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a81dae078cea95a014a339291cec439d2f232ebe854a9d672b796c6afafa9b7"
 
 [[package]]
-name = "crypto-common"
-version = "0.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57952ca27b5e3606ff4dd79b0020231aaf9d6aa76dc05fd30137538c50bd3ce8"
-dependencies = [
- "generic-array",
- "typenum",
-]
-
-[[package]]
 name = "crypto-mac"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1219,7 +1083,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b9fdf9972b2bd6af2d913799d9ebc165ea4d2e65878e329d9c6b372c4491b61"
 dependencies = [
  "byteorder",
- "digest 0.9.0",
+ "digest",
  "rand_core 0.5.1",
  "subtle",
  "zeroize",
@@ -1258,17 +1122,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3dd60d1080a57a05ab032377049e0591415d2b31afd7028356dbf3cc6dcb066"
 dependencies = [
  "generic-array",
-]
-
-[[package]]
-name = "digest"
-version = "0.10.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2fb860ca6fafa5552fb6d0e816a69c8e49f0908bf524e30a90d97c85892d506"
-dependencies = [
- "block-buffer 0.10.2",
- "crypto-common",
- "subtle",
 ]
 
 [[package]]
@@ -1455,12 +1308,6 @@ dependencies = [
 
 [[package]]
 name = "futures"
-version = "0.1.31"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a471a38ef8ed83cd6e40aa59c1ffe17db6855c18e3604d9c4ed8c08ebc28678"
-
-[[package]]
-name = "futures"
 version = "0.3.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "28560757fe2bb34e79f907794bb6b22ae8b0e5c669b638a1132f2592b19035b4"
@@ -1489,16 +1336,6 @@ name = "futures-core"
 version = "0.3.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0c8ff0461b82559810cdccfde3215c3f373807f5e5232b71479bff7bb2583d7"
-
-[[package]]
-name = "futures-cpupool"
-version = "0.1.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab90cde24b3319636588d0c35fe03b1333857621051837ed769faefb4c2162e4"
-dependencies = [
- "futures 0.1.31",
- "num_cpus",
-]
 
 [[package]]
 name = "futures-executor"
@@ -1723,7 +1560,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "126888268dcc288495a26bf004b38c5fdbb31682f992c84ceb046a1f0fe38840"
 dependencies = [
  "crypto-mac",
- "digest 0.9.0",
+ "digest",
 ]
 
 [[package]]
@@ -1732,7 +1569,7 @@ version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "17ea0a1394df5b6574da6e0c1ade9e78868c9fb0a4e5ef4428e32da4676b85b1"
 dependencies = [
- "digest 0.9.0",
+ "digest",
  "generic-array",
  "hmac",
 ]
@@ -1878,7 +1715,7 @@ checksum = "8c98a3248cde6b42cb479a52089fe4fc20d12de51b8edd923294cd5240ec89b0"
 dependencies = [
  "bee-ternary 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "blake2",
- "digest 0.9.0",
+ "digest",
  "ed25519-zebra",
  "getrandom 0.2.4",
  "lazy_static",
@@ -2007,7 +1844,7 @@ checksum = "9004c06878ef8f3b4b4067e69a140d87ed20bf777287f82223e49713b36ee433"
 dependencies = [
  "atomic",
  "bytes",
- "futures 0.3.19",
+ "futures",
  "lazy_static",
  "libp2p-core",
  "libp2p-dns",
@@ -2036,7 +1873,7 @@ dependencies = [
  "ed25519-dalek",
  "either",
  "fnv",
- "futures 0.3.19",
+ "futures",
  "futures-timer",
  "lazy_static",
  "libsecp256k1",
@@ -2065,7 +1902,7 @@ version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "58ff08b3196b85a17f202d80589e93b1660a574af67275706657fdc762e42c32"
 dependencies = [
- "futures 0.3.19",
+ "futures",
  "libp2p-core",
  "log",
  "smallvec",
@@ -2078,7 +1915,7 @@ version = "0.30.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a7b61f6cf07664fb97016c318c4d4512b3dd4cc07238607f3f0163245f99008e"
 dependencies = [
- "futures 0.3.19",
+ "futures",
  "libp2p-core",
  "libp2p-swarm",
  "log",
@@ -2096,7 +1933,7 @@ checksum = "313d9ea526c68df4425f580024e67a9d3ffd49f2c33de5154b1f5019816f7a99"
 dependencies = [
  "asynchronous-codec",
  "bytes",
- "futures 0.3.19",
+ "futures",
  "libp2p-core",
  "log",
  "nohash-hasher",
@@ -2114,7 +1951,7 @@ checksum = "3f1db7212f342b6ba7c981cc40e31f76e9e56cb48e65fa4c142ecaca5839523e"
 dependencies = [
  "bytes",
  "curve25519-dalek",
- "futures 0.3.19",
+ "futures",
  "lazy_static",
  "libp2p-core",
  "log",
@@ -2135,7 +1972,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7083861341e1555467863b4cd802bea1e8c4787c0f7b5110097d0f1f3248f9a9"
 dependencies = [
  "either",
- "futures 0.3.19",
+ "futures",
  "libp2p-core",
  "log",
  "rand 0.7.3",
@@ -2160,7 +1997,7 @@ version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "79edd26b6b4bb5feee210dcda562dca186940dfecb0024b979c3f50824b3bf28"
 dependencies = [
- "futures 0.3.19",
+ "futures",
  "futures-timer",
  "if-addrs",
  "ipnet",
@@ -2177,7 +2014,7 @@ version = "0.33.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "214cc0dd9c37cbed27f0bb1eba0c41bbafdb93a8be5e9d6ae1e6b4b42cd044bf"
 dependencies = [
- "futures 0.3.19",
+ "futures",
  "libp2p-core",
  "parking_lot",
  "thiserror",
@@ -2204,7 +2041,7 @@ checksum = "bd1137239ab33b41aa9637a88a28249e5e70c40a42ccc92db7f12cc356c1fcd7"
 dependencies = [
  "arrayref",
  "base64 0.12.3",
- "digest 0.9.0",
+ "digest",
  "hmac-drbg",
  "libsecp256k1-core",
  "libsecp256k1-gen-ecmult",
@@ -2222,7 +2059,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0f6ab710cec28cef759c5f18671a27dae2a5f952cdaaee1d8e2908cb2478a80"
 dependencies = [
  "crunchy",
- "digest 0.9.0",
+ "digest",
  "subtle",
 ]
 
@@ -2289,27 +2126,6 @@ name = "matches"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a3e378b66a060d48947b590737b30a1be76706c8dd7b8ba0f2fe3989c68a853f"
-
-[[package]]
-name = "md-5"
-version = "0.9.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b5a279bb9607f9f53c22d496eade00d138d1bdcccd07d74650387cf94942a15"
-dependencies = [
- "block-buffer 0.9.0",
- "digest 0.9.0",
- "opaque-debug",
-]
-
-[[package]]
-name = "md6"
-version = "2.0.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed426378c4745d1257e49ee3f729aaec2f0c6f29113ab7835a0b5938ca07b86f"
-dependencies = [
- "cc",
- "libc",
-]
 
 [[package]]
 name = "memchr"
@@ -2404,7 +2220,7 @@ version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "752a61cd890ff691b4411423d23816d5866dd5621e4d1c5687a53b94b5a979d8"
 dependencies = [
- "digest 0.9.0",
+ "digest",
  "generic-array",
  "multihash-derive",
  "sha2",
@@ -2456,7 +2272,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "56a336acba8bc87c8876f6425407dbbe6c417bf478b22015f8fb0994ef3bc0ab"
 dependencies = [
  "bytes",
- "futures 0.3.19",
+ "futures",
  "log",
  "pin-project 1.0.10",
  "smallvec",
@@ -2668,7 +2484,7 @@ version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d82fea0990fe54e75d575bbd9bc2ee5919fd10cc0b4a95f1967528083129fc4b"
 dependencies = [
- "futures 0.3.19",
+ "futures",
  "futures-timer",
  "libc",
  "log",
@@ -2707,18 +2523,6 @@ dependencies = [
  "libc",
  "redox_syscall",
  "smallvec",
- "winapi",
-]
-
-[[package]]
-name = "pbr"
-version = "1.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ff5751d87f7c00ae6403eb1fcbba229b9c76c9a30de8c1cf87182177b168cea2"
-dependencies = [
- "crossbeam-channel",
- "libc",
- "time 0.1.43",
  "winapi",
 ]
 
@@ -3169,8 +2973,6 @@ version = "1.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d07a8629359eb56f1e2fb1652bb04212c072a87ba68546a04065d525673ac461"
 dependencies = [
- "aho-corasick",
- "memchr",
  "regex-syntax",
 ]
 
@@ -3330,12 +3132,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
 
 [[package]]
-name = "rustc-serialize"
-version = "0.3.24"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dcf128d1287d2ea9d80910b5f1120d0b8eede3fbf1abe91c40d39ea7d51e6fda"
-
-[[package]]
 name = "rustc_version"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3359,7 +3155,7 @@ version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4da5fcb054c46f5a5dff833b129285a93d3f0179531735e6c866e8cc307d2020"
 dependencies = [
- "futures 0.3.19",
+ "futures",
  "pin-project 0.4.29",
  "static_assertions",
 ]
@@ -3546,10 +3342,10 @@ version = "0.9.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "99cd6713db3cf16b6c84e06321e049a9b9f699826e16096d23bbcc44d15d51a6"
 dependencies = [
- "block-buffer 0.9.0",
+ "block-buffer",
  "cfg-if",
  "cpufeatures 0.2.1",
- "digest 0.9.0",
+ "digest",
  "opaque-debug",
 ]
 
@@ -3559,10 +3355,10 @@ version = "0.9.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4d58a1e1bf39749807d89cf2d98ac2dfa0ff1cb3faa38fbb64dd88ac8013d800"
 dependencies = [
- "block-buffer 0.9.0",
+ "block-buffer",
  "cfg-if",
  "cpufeatures 0.2.1",
- "digest 0.9.0",
+ "digest",
  "opaque-debug",
 ]
 
@@ -3572,20 +3368,10 @@ version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f81199417d4e5de3f04b1e871023acea7389672c4135918f05aa9cbf2f2fa809"
 dependencies = [
- "block-buffer 0.9.0",
- "digest 0.9.0",
+ "block-buffer",
+ "digest",
  "keccak",
  "opaque-debug",
-]
-
-[[package]]
-name = "shaman"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b1a48b7e97a07b8f5771159e6914d8459557f8f833a60c4bd041f03736844f5"
-dependencies = [
- "rand 0.8.4",
- "rustc-serialize",
 ]
 
 [[package]]
@@ -3720,12 +3506,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
-name = "strsim"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ea5119cdb4c55b55d432abb513a0429384878c15dde60cc77b1c99de1a95a6a"
-
-[[package]]
 name = "structopt"
 version = "0.3.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3776,15 +3556,6 @@ dependencies = [
  "quote",
  "syn",
  "unicode-xid",
-]
-
-[[package]]
-name = "tabwriter"
-version = "1.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "36205cfc997faadcc4b0b87aaef3fbedafe20d38d4959a7ca6ff803564051111"
-dependencies = [
- "unicode-width",
 ]
 
 [[package]]
@@ -4202,12 +3973,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
 
 [[package]]
-name = "vec_map"
-version = "0.8.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1bddf1187be692e79c5ffeab891132dfb0f236ed36a43c7ed39f1165ee20191"
-
-[[package]]
 name = "version_check"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4368,7 +4133,7 @@ version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "be0ecb0db480561e9a7642b5d3e4187c128914e58aa84330b9493e3eb68c5e7f"
 dependencies = [
- "futures 0.3.19",
+ "futures",
  "js-sys",
  "parking_lot",
  "pin-utils",
@@ -4396,17 +4161,6 @@ dependencies = [
  "either",
  "lazy_static",
  "libc",
-]
-
-[[package]]
-name = "whirlpool"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd6b887d628151d048b725717536b20888cdf177c5673a5f5dfc48d700272664"
-dependencies = [
- "block-buffer 0.9.0",
- "digest 0.9.0",
- "opaque-debug",
 ]
 
 [[package]]
@@ -4481,7 +4235,7 @@ version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e7d9028f208dd5e63c614be69f115c1b53cacc1111437d4c765185856666c107"
 dependencies = [
- "futures 0.3.19",
+ "futures",
  "log",
  "nohash-hasher",
  "parking_lot",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,6 +23,7 @@ members = [
 	"bee-ternary",
 	"bee-test",
 ]
+resolver = "2"
 
 [profile.dev]
 panic = "abort"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,6 @@ members = [
 	"bee-ternary",
 	"bee-test",
 ]
-resolver = "2"
 
 [profile.dev]
 panic = "abort"

--- a/bee-node/Cargo.toml
+++ b/bee-node/Cargo.toml
@@ -56,6 +56,14 @@ tracing = { version = "0.1.29", default-features = false, optional = true }
 warp = { version = "0.3.1", default-features = false }
 warp-reverse-proxy = { version = "0.4.0", default-features = false, optional = true }
 
+[build-dependencies]
+reqwest = { version = "0.11.5", default-features = false, features = [ "default-tls", "json" ] }
+serde = { version = "1.0.130", default-features = false, features = [ "derive" ] }
+serde_json = { version = "1.0.68", default-features = false }
+tempfile = { version = "3.3.0", default-features = false }
+tokio = { version = "1.12.0", default-features = false, features = [ "signal", "rt", "macros", "rt-multi-thread" ] }
+zip = { version = "0.5.13", default-features = false, features = [ "bzip2", "deflate" ] }
+
 [lib]
 name = "bee_node"
 path = "src/lib.rs"

--- a/bee-node/Cargo.toml
+++ b/bee-node/Cargo.toml
@@ -73,6 +73,6 @@ path = "src/main.rs"
 [features]
 default = [ "rocksdb" ]
 
-dashboard = [ "cap", "mime_guess", "reqwest", "rust-embed", "sha2", "tempfile", "warp-reverse-proxy", "zip" ]
+dashboard = [ "cap", "mime_guess", "reqwest", "rust-embed", "serde_repr", "sha2", "tempfile", "warp-reverse-proxy", "zip" ]
 rocksdb = [ "bee-storage-rocksdb" ]
 sled = [ "bee-storage-sled" ]

--- a/bee-node/Cargo.toml
+++ b/bee-node/Cargo.toml
@@ -57,8 +57,8 @@ warp = { version = "0.3.1", default-features = false }
 warp-reverse-proxy = { version = "0.4.0", default-features = false, optional = true }
 
 [build-dependencies]
-checksums = { version = "0.9.1", default-features = false, optional = true }
 reqwest = { version = "0.11.5", default-features = false, features = [ "blocking", "default-tls", "json" ], optional = true }
+sha2 = { version = "0.9.6", default-features = false, optional = true }
 tempfile = { version = "3.3.0", default-features = false, optional = true }
 zip = { version = "0.5.13", default-features = false, features = [ "bzip2", "deflate" ], optional = true }
 
@@ -73,6 +73,6 @@ path = "src/main.rs"
 [features]
 default = [ "rocksdb" ]
 
-dashboard = [ "cap", "checksums", "mime_guess", "reqwest", "rust-embed", "serde_repr", "tempfile", "warp-reverse-proxy", "zip" ]
+dashboard = [ "cap", "mime_guess", "reqwest", "rust-embed", "serde_repr", "sha2", "tempfile", "warp-reverse-proxy", "zip" ]
 rocksdb = [ "bee-storage-rocksdb" ]
 sled = [ "bee-storage-sled" ]

--- a/bee-node/Cargo.toml
+++ b/bee-node/Cargo.toml
@@ -57,11 +57,10 @@ warp = { version = "0.3.1", default-features = false }
 warp-reverse-proxy = { version = "0.4.0", default-features = false, optional = true }
 
 [build-dependencies]
-reqwest = { version = "0.11.5", default-features = false, features = [ "default-tls", "json" ], optional = true }
+reqwest = { version = "0.11.5", default-features = false, features = [ "blocking", "default-tls", "json" ], optional = true }
 serde = { version = "1.0.130", default-features = false, features = [ "derive" ], optional = true }
 serde_json = { version = "1.0.68", default-features = false, optional = true }
 tempfile = { version = "3.3.0", default-features = false, optional = true }
-tokio = { version = "1.12.0", default-features = false, features = [ "signal", "rt", "macros", "rt-multi-thread" ], optional = true }
 zip = { version = "0.5.13", default-features = false, features = [ "bzip2", "deflate" ], optional = true }
 
 [lib]
@@ -75,6 +74,6 @@ path = "src/main.rs"
 [features]
 default = [ "rocksdb" ]
 
-dashboard = [ "cap", "mime_guess", "reqwest", "rust-embed", "serde", "serde_repr", "serde_json", "tempfile", "tokio", "warp-reverse-proxy", "zip" ]
+dashboard = [ "cap", "mime_guess", "reqwest", "rust-embed", "serde", "serde_repr", "serde_json", "tempfile", "warp-reverse-proxy", "zip" ]
 rocksdb = [ "bee-storage-rocksdb" ]
 sled = [ "bee-storage-sled" ]

--- a/bee-node/Cargo.toml
+++ b/bee-node/Cargo.toml
@@ -57,12 +57,12 @@ warp = { version = "0.3.1", default-features = false }
 warp-reverse-proxy = { version = "0.4.0", default-features = false, optional = true }
 
 [build-dependencies]
-reqwest = { version = "0.11.5", default-features = false, features = [ "default-tls", "json" ] }
-serde = { version = "1.0.130", default-features = false, features = [ "derive" ] }
-serde_json = { version = "1.0.68", default-features = false }
-tempfile = { version = "3.3.0", default-features = false }
-tokio = { version = "1.12.0", default-features = false, features = [ "signal", "rt", "macros", "rt-multi-thread" ] }
-zip = { version = "0.5.13", default-features = false, features = [ "bzip2", "deflate" ] }
+reqwest = { version = "0.11.5", default-features = false, features = [ "default-tls", "json" ], optional = true }
+serde = { version = "1.0.130", default-features = false, features = [ "derive" ], optional = true }
+serde_json = { version = "1.0.68", default-features = false, optional = true }
+tempfile = { version = "3.3.0", default-features = false, optional = true }
+tokio = { version = "1.12.0", default-features = false, features = [ "signal", "rt", "macros", "rt-multi-thread" ], optional = true }
+zip = { version = "0.5.13", default-features = false, features = [ "bzip2", "deflate" ], optional = true }
 
 [lib]
 name = "bee_node"
@@ -75,6 +75,6 @@ path = "src/main.rs"
 [features]
 default = [ "rocksdb" ]
 
-dashboard = [ "cap", "mime_guess", "rust-embed", "serde_repr", "warp-reverse-proxy" ]
+dashboard = [ "cap", "mime_guess", "reqwest", "rust-embed", "serde", "serde_repr", "serde_json", "tempfile", "tokio", "warp-reverse-proxy", "zip" ]
 rocksdb = [ "bee-storage-rocksdb" ]
 sled = [ "bee-storage-sled" ]

--- a/bee-node/Cargo.toml
+++ b/bee-node/Cargo.toml
@@ -58,8 +58,7 @@ warp-reverse-proxy = { version = "0.4.0", default-features = false, optional = t
 
 [build-dependencies]
 reqwest = { version = "0.11.5", default-features = false, features = [ "blocking", "default-tls", "json" ], optional = true }
-serde = { version = "1.0.130", default-features = false, features = [ "derive" ], optional = true }
-serde_json = { version = "1.0.68", default-features = false, optional = true }
+sha2 = { version = "0.9.6", default-features = false, optional = true }
 tempfile = { version = "3.3.0", default-features = false, optional = true }
 zip = { version = "0.5.13", default-features = false, features = [ "bzip2", "deflate" ], optional = true }
 
@@ -74,6 +73,6 @@ path = "src/main.rs"
 [features]
 default = [ "rocksdb" ]
 
-dashboard = [ "cap", "mime_guess", "reqwest", "rust-embed", "serde", "serde_repr", "serde_json", "tempfile", "warp-reverse-proxy", "zip" ]
+dashboard = [ "cap", "mime_guess", "reqwest", "rust-embed", "sha2", "tempfile", "warp-reverse-proxy", "zip" ]
 rocksdb = [ "bee-storage-rocksdb" ]
 sled = [ "bee-storage-sled" ]

--- a/bee-node/Cargo.toml
+++ b/bee-node/Cargo.toml
@@ -57,8 +57,8 @@ warp = { version = "0.3.1", default-features = false }
 warp-reverse-proxy = { version = "0.4.0", default-features = false, optional = true }
 
 [build-dependencies]
+checksums = { version = "0.9.1", default-features = false, optional = true }
 reqwest = { version = "0.11.5", default-features = false, features = [ "blocking", "default-tls", "json" ], optional = true }
-sha2 = { version = "0.9.6", default-features = false, optional = true }
 tempfile = { version = "3.3.0", default-features = false, optional = true }
 zip = { version = "0.5.13", default-features = false, features = [ "bzip2", "deflate" ], optional = true }
 
@@ -73,6 +73,6 @@ path = "src/main.rs"
 [features]
 default = [ "rocksdb" ]
 
-dashboard = [ "cap", "mime_guess", "reqwest", "rust-embed", "serde_repr", "sha2", "tempfile", "warp-reverse-proxy", "zip" ]
+dashboard = [ "cap", "checksums", "mime_guess", "reqwest", "rust-embed", "serde_repr", "tempfile", "warp-reverse-proxy", "zip" ]
 rocksdb = [ "bee-storage-rocksdb" ]
 sled = [ "bee-storage-sled" ]

--- a/bee-node/README.md
+++ b/bee-node/README.md
@@ -9,14 +9,14 @@
 ```sh
 apt-get update
 apt-get upgrade
-apt-get install git npm build-essential cmake pkg-config librocksdb-dev llvm clang libclang-dev libssl-dev
+apt-get install git build-essential cmake pkg-config librocksdb-dev llvm clang libclang-dev libssl-dev
 ```
 
 ### MacOS
 
 ```sh
 /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
-brew install cmake npm
+brew install cmake
 ```
 
 ### Windows
@@ -24,7 +24,7 @@ brew install cmake npm
 Open Powershell and execute the following commands:
 ```sh
 Set-ExecutionPolicy Bypass -Scope Process -Force; [System.Net.ServicePointManager]::SecurityProtocol = [System.Net.ServicePointManager]::SecurityProtocol -bor 3072; iex ((New-Object System.Net.WebClient).DownloadString('https://chocolatey.org/install.ps1'))
-choco install git --params '/NoAutoCrlf' nodejs-lts cmake --installargs 'ADD_CMAKE_TO_PATH=System' llvm
+choco install git --params '/NoAutoCrlf' cmake --installargs 'ADD_CMAKE_TO_PATH=System' llvm
 ```
 Restart Powershell
 
@@ -59,11 +59,6 @@ cd bee/bee-node
 With dashboard
 
 ```sh
-git submodule update --init
-cd src/plugins/dashboard/frontend
-npm install
-npm run build-bee
-cd ../../../../
 cargo build --release --features dashboard
 ```
 

--- a/bee-node/build.rs
+++ b/bee-node/build.rs
@@ -81,14 +81,16 @@ fn parse_git_information() -> Result<(), BuildError> {
 }
 
 #[cfg(feature = "dashboard")]
-mod dashboard
-{
+mod dashboard {
     use super::*;
 
     use serde::Deserialize;
     use zip::ZipArchive;
 
-    use std::{io::{self, BufReader, Cursor}, path::Path};
+    use std::{
+        io::{self, BufReader, Cursor},
+        path::Path,
+    };
 
     const ASSET_PREFIX: &str = "node-dashboard-bee-";
     const RELEASES_URL: &str = "https://api.github.com/repos/iotaledger/node-dashboard/releases/latest";
@@ -117,7 +119,9 @@ mod dashboard
             .send()
             .await
             .and_then(|resp| resp.error_for_status())
-            .map_err(|e| BuildError::DashboardRequest(e.status().map(|code| code.as_u16()), RELEASES_URL.to_string()))?;
+            .map_err(|e| {
+                BuildError::DashboardRequest(e.status().map(|code| code.as_u16()), RELEASES_URL.to_string())
+            })?;
 
         let assets = response
             .json::<LatestReleaseAssets>()
@@ -154,7 +158,9 @@ mod dashboard
         let mut archive = ZipArchive::new(BufReader::new(archive)).map_err(|_| BuildError::DashboardInvalidArchive)?;
 
         println!("extracting release archive to {}", dashboard_dir.as_ref().display());
-        archive.extract(dashboard_dir).map_err(|_| BuildError::DashboardInvalidArchive)?;
+        archive
+            .extract(dashboard_dir)
+            .map_err(|_| BuildError::DashboardInvalidArchive)?;
 
         Ok(())
     }

--- a/bee-node/build.rs
+++ b/bee-node/build.rs
@@ -21,8 +21,8 @@ enum BuildError {
     DashboardInvalidArchive,
     DashboardNoSuitableRelease,
     DashboardRequest(Option<u16>, String),
-    GitCommit,
     GitBranch,
+    GitCommit,
 }
 
 impl fmt::Display for BuildError {
@@ -34,7 +34,8 @@ impl fmt::Display for BuildError {
             Self::DashboardNoSuitableRelease => write!(f, "no release assets found for latest version"),
             Self::DashboardRequest(Some(code), url) => write!(f, "failed request to `{}`: status code {}", url, code),
             Self::DashboardRequest(_, url) => write!(f, "failed request to `{}`", url),
-            _ => Ok(())
+            Self::GitBranch => write!(f, "failed to retrieve git branch name"),
+            Self::GitCommit => write!(f, "failed to retrieve git commit"),
         }
     }
 }

--- a/bee-node/build.rs
+++ b/bee-node/build.rs
@@ -1,19 +1,9 @@
 // Copyright 2020-2022 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
-use serde::Deserialize;
-use zip::ZipArchive;
+use std::{fmt, process::Command};
 
-use std::{
-    env, fmt,
-    io::{self, BufReader, Cursor},
-    path::Path,
-    process::Command,
-};
-
-const ASSET_PREFIX: &str = "node-dashboard-bee-";
-const RELEASES_URL: &str = "https://api.github.com/repos/iotaledger/node-dashboard/releases/latest";
-
+#[allow(dead_code)]
 #[derive(Debug)]
 enum BuildError {
     DashboardDecode,
@@ -40,19 +30,29 @@ impl fmt::Display for BuildError {
     }
 }
 
-#[derive(Deserialize, Debug)]
-struct LatestReleaseAssets {
-    assets: Vec<ReleaseAsset>,
+#[cfg(not(feature = "dashboard"))]
+fn main() -> Result<(), BuildError> {
+    parse_git_information()
 }
 
-#[derive(Deserialize, Debug)]
-struct ReleaseAsset {
-    name: String,
-    browser_download_url: String,
-}
-
+#[cfg(feature = "dashboard")]
 #[tokio::main]
 async fn main() -> Result<(), BuildError> {
+    parse_git_information()?;
+
+    let should_fetch = std::env::var("FETCH_DASHBOARD").map(|val| val == "1").unwrap_or(false);
+    let dashboard_dir = std::env::var("OUT_DIR").unwrap() + "/dashboard";
+
+    println!("cargo:rustc-env=DASHBOARD_DIR={}", dashboard_dir);
+
+    if should_fetch || !std::path::Path::new(&dashboard_dir).exists() {
+        dashboard::fetch(dashboard_dir).await?;
+    }
+
+    Ok(())
+}
+
+fn parse_git_information() -> Result<(), BuildError> {
     match Command::new("git").args(&["rev-parse", "HEAD"]).output() {
         Ok(output) => {
             println!(
@@ -77,69 +77,85 @@ async fn main() -> Result<(), BuildError> {
         Err(_) => return Err(BuildError::GitBranch),
     }
 
-    let should_fetch = env::var("FETCH_DASHBOARD").map(|val| val == "1").unwrap_or(false);
-    let dashboard_dir = env::var("OUT_DIR").unwrap() + "/dashboard";
-
-    println!("cargo:rustc-env=DASHBOARD_DIR={}", dashboard_dir);
-
-    if should_fetch || !Path::new(&dashboard_dir).exists() {
-        fetch_dashboard(dashboard_dir).await?;
-    }
-
     Ok(())
 }
 
-async fn fetch_dashboard<P: AsRef<Path>>(dashboard_dir: P) -> Result<(), BuildError> {
-    println!("fetching latest dashboard release");
+#[cfg(feature = "dashboard")]
+mod dashboard
+{
+    use super::*;
 
-    let client = reqwest::Client::builder()
-        .user_agent("bee-fetch-dashboard")
-        .build()
-        .expect("could not create client");
+    use serde::Deserialize;
+    use zip::ZipArchive;
 
-    let response = client
-        .get(RELEASES_URL)
-        .send()
-        .await
-        .and_then(|resp| resp.error_for_status())
-        .map_err(|e| BuildError::DashboardRequest(e.status().map(|code| code.as_u16()), RELEASES_URL.to_string()))?;
+    use std::{io::{self, BufReader, Cursor}, path::Path};
 
-    let assets = response
-        .json::<LatestReleaseAssets>()
-        .await
-        .map_err(|_| BuildError::DashboardDecode)?
-        .assets;
+    const ASSET_PREFIX: &str = "node-dashboard-bee-";
+    const RELEASES_URL: &str = "https://api.github.com/repos/iotaledger/node-dashboard/releases/latest";
 
-    let release_asset = assets
-        .iter()
-        .find(|asset| asset.name.starts_with(ASSET_PREFIX))
-        .ok_or(BuildError::DashboardNoSuitableRelease)?;
+    #[derive(Deserialize, Debug)]
+    struct LatestReleaseAssets {
+        assets: Vec<ReleaseAsset>,
+    }
 
-    println!(
-        "downloading latest dashboard release `{}` from {}",
-        release_asset.name, release_asset.browser_download_url
-    );
+    #[derive(Deserialize, Debug)]
+    struct ReleaseAsset {
+        name: String,
+        browser_download_url: String,
+    }
 
-    let mut archive = tempfile::tempfile().expect("could not create temp file");
+    pub(super) async fn fetch<P: AsRef<Path>>(dashboard_dir: P) -> Result<(), BuildError> {
+        println!("fetching latest dashboard release");
 
-    let response = client
-        .get(&release_asset.browser_download_url)
-        .send()
-        .await
-        .and_then(|resp| resp.error_for_status())
-        .map_err(|e| {
-            BuildError::DashboardRequest(
-                e.status().map(|code| code.as_u16()),
-                release_asset.browser_download_url.clone(),
-            )
-        })?;
+        let client = reqwest::Client::builder()
+            .user_agent("bee-fetch-dashboard")
+            .build()
+            .expect("could not create client");
 
-    let mut content = Cursor::new(response.bytes().await.map_err(|_| BuildError::DashboardDownload)?);
-    io::copy(&mut content, &mut archive).expect("copying failed");
-    let mut archive = ZipArchive::new(BufReader::new(archive)).map_err(|_| BuildError::DashboardInvalidArchive)?;
+        let response = client
+            .get(RELEASES_URL)
+            .send()
+            .await
+            .and_then(|resp| resp.error_for_status())
+            .map_err(|e| BuildError::DashboardRequest(e.status().map(|code| code.as_u16()), RELEASES_URL.to_string()))?;
 
-    println!("extracting release archive to {}", dashboard_dir.as_ref().display());
-    archive.extract(dashboard_dir).map_err(|_| BuildError::DashboardInvalidArchive)?;
+        let assets = response
+            .json::<LatestReleaseAssets>()
+            .await
+            .map_err(|_| BuildError::DashboardDecode)?
+            .assets;
 
-    Ok(())
+        let release_asset = assets
+            .iter()
+            .find(|asset| asset.name.starts_with(ASSET_PREFIX))
+            .ok_or(BuildError::DashboardNoSuitableRelease)?;
+
+        println!(
+            "downloading latest dashboard release `{}` from {}",
+            release_asset.name, release_asset.browser_download_url
+        );
+
+        let mut archive = tempfile::tempfile().expect("could not create temp file");
+
+        let response = client
+            .get(&release_asset.browser_download_url)
+            .send()
+            .await
+            .and_then(|resp| resp.error_for_status())
+            .map_err(|e| {
+                BuildError::DashboardRequest(
+                    e.status().map(|code| code.as_u16()),
+                    release_asset.browser_download_url.clone(),
+                )
+            })?;
+
+        let mut content = Cursor::new(response.bytes().await.map_err(|_| BuildError::DashboardDownload)?);
+        io::copy(&mut content, &mut archive).expect("copying failed");
+        let mut archive = ZipArchive::new(BufReader::new(archive)).map_err(|_| BuildError::DashboardInvalidArchive)?;
+
+        println!("extracting release archive to {}", dashboard_dir.as_ref().display());
+        archive.extract(dashboard_dir).map_err(|_| BuildError::DashboardInvalidArchive)?;
+
+        Ok(())
+    }
 }

--- a/bee-node/build.rs
+++ b/bee-node/build.rs
@@ -1,15 +1,57 @@
-// Copyright 2020-2021 IOTA Stiftung
+// Copyright 2020-2022 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
-use std::process::Command;
+use serde::Deserialize;
+use zip::ZipArchive;
+
+use std::{
+    env, fmt,
+    io::{self, BufReader, Cursor},
+    path::Path,
+    process::Command,
+};
+
+const ASSET_PREFIX: &str = "node-dashboard-bee-";
+const RELEASES_URL: &str = "https://api.github.com/repos/iotaledger/node-dashboard/releases/latest";
 
 #[derive(Debug)]
 enum BuildError {
+    DashboardDecode,
+    DashboardDownload,
+    DashboardInvalidArchive,
+    DashboardNoSuitableRelease,
+    DashboardRequest(Option<u16>, String),
     GitCommit,
     GitBranch,
 }
 
-fn main() -> Result<(), BuildError> {
+impl fmt::Display for BuildError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match &self {
+            Self::DashboardDecode => write!(f, "failed to decode response from JSON"),
+            Self::DashboardDownload => write!(f, "failed to download latest release archive"),
+            Self::DashboardInvalidArchive => write!(f, "failed to open or extract release archive"),
+            Self::DashboardNoSuitableRelease => write!(f, "no release assets found for latest version"),
+            Self::DashboardRequest(Some(code), url) => write!(f, "failed request to `{}`: status code {}", url, code),
+            Self::DashboardRequest(_, url) => write!(f, "failed request to `{}`", url),
+            _ => Ok(())
+        }
+    }
+}
+
+#[derive(Deserialize, Debug)]
+struct LatestReleaseAssets {
+    assets: Vec<ReleaseAsset>,
+}
+
+#[derive(Deserialize, Debug)]
+struct ReleaseAsset {
+    name: String,
+    browser_download_url: String,
+}
+
+#[tokio::main]
+async fn main() -> Result<(), BuildError> {
     match Command::new("git").args(&["rev-parse", "HEAD"]).output() {
         Ok(output) => {
             println!(
@@ -33,6 +75,70 @@ fn main() -> Result<(), BuildError> {
         }
         Err(_) => return Err(BuildError::GitBranch),
     }
+
+    let should_fetch = env::var("FETCH_DASHBOARD").map(|val| val == "1").unwrap_or(false);
+    let dashboard_dir = env::var("OUT_DIR").unwrap() + "/dashboard";
+
+    println!("cargo:rustc-env=DASHBOARD_DIR={}", dashboard_dir);
+
+    if should_fetch || !Path::new(&dashboard_dir).exists() {
+        fetch_dashboard(dashboard_dir).await?;
+    }
+
+    Ok(())
+}
+
+async fn fetch_dashboard<P: AsRef<Path>>(dashboard_dir: P) -> Result<(), BuildError> {
+    println!("fetching latest dashboard release");
+
+    let client = reqwest::Client::builder()
+        .user_agent("bee-fetch-dashboard")
+        .build()
+        .expect("could not create client");
+
+    let response = client
+        .get(RELEASES_URL)
+        .send()
+        .await
+        .and_then(|resp| resp.error_for_status())
+        .map_err(|e| BuildError::DashboardRequest(e.status().map(|code| code.as_u16()), RELEASES_URL.to_string()))?;
+
+    let assets = response
+        .json::<LatestReleaseAssets>()
+        .await
+        .map_err(|_| BuildError::DashboardDecode)?
+        .assets;
+
+    let release_asset = assets
+        .iter()
+        .find(|asset| asset.name.starts_with(ASSET_PREFIX))
+        .ok_or(BuildError::DashboardNoSuitableRelease)?;
+
+    println!(
+        "downloading latest dashboard release `{}` from {}",
+        release_asset.name, release_asset.browser_download_url
+    );
+
+    let mut archive = tempfile::tempfile().expect("could not create temp file");
+
+    let response = client
+        .get(&release_asset.browser_download_url)
+        .send()
+        .await
+        .and_then(|resp| resp.error_for_status())
+        .map_err(|e| {
+            BuildError::DashboardRequest(
+                e.status().map(|code| code.as_u16()),
+                release_asset.browser_download_url.clone(),
+            )
+        })?;
+
+    let mut content = Cursor::new(response.bytes().await.map_err(|_| BuildError::DashboardDownload)?);
+    io::copy(&mut content, &mut archive).expect("copying failed");
+    let mut archive = ZipArchive::new(BufReader::new(archive)).map_err(|_| BuildError::DashboardInvalidArchive)?;
+
+    println!("extracting release archive to {}", dashboard_dir.as_ref().display());
+    archive.extract(dashboard_dir).map_err(|_| BuildError::DashboardInvalidArchive)?;
 
     Ok(())
 }

--- a/bee-node/docker/Dockerfile
+++ b/bee-node/docker/Dockerfile
@@ -20,7 +20,7 @@ COPY . .
 # The following is required for `git submodule` to work.
 COPY .git/ ./.git/
 
-RUN if [ "$WITH_DASHBOARD" = true ] ; then FETCH_DASHBOARD=1 cargo build --profile production --features dashboard --bin bee ; else cargo build --profile production --bin bee ; fi
+RUN if [ "$WITH_DASHBOARD" = true ] ; then cargo build --profile production --features dashboard --bin bee ; else cargo build --profile production --bin bee ; fi
 
 ############################
 # Image

--- a/bee-node/docker/Dockerfile
+++ b/bee-node/docker/Dockerfile
@@ -20,23 +20,7 @@ COPY . .
 # The following is required for `git submodule` to work.
 COPY .git/ ./.git/
 
-ENV NVM_DIR /opt/nvm
-ENV NODE_VERSION 14.19.0
-
-RUN if [ "$WITH_DASHBOARD" = true ] ; then \ 
-    mkdir $NVM_DIR \
-    &&curl https://raw.githubusercontent.com/creationix/nvm/v0.39.1/install.sh | bash \
-    && . $NVM_DIR/nvm.sh \
-    && nvm install $NODE_VERSION \
-    && nvm alias default $NODE_VERSION \
-    && nvm use default \
-    && git submodule update --init --recursive \
-    && cd bee-node/src/plugins/dashboard/frontend \
-    && npm install \
-    && npm run build-bee \
-    ; fi
-
-RUN if [ "$WITH_DASHBOARD" = true ] ; then cargo build --profile production --features dashboard --bin bee ; else cargo build --profile production --bin bee ; fi
+RUN if [ "$WITH_DASHBOARD" = true ] ; then FETCH_DASHBOARD=1 cargo build --profile production --features dashboard --bin bee ; else cargo build --profile production --bin bee ; fi
 
 ############################
 # Image

--- a/bee-node/src/plugins/dashboard/asset.rs
+++ b/bee-node/src/plugins/dashboard/asset.rs
@@ -4,5 +4,5 @@
 use rust_embed::RustEmbed;
 
 #[derive(RustEmbed)]
-#[folder = "$CARGO_MANIFEST_DIR/src/plugins/dashboard/frontend/build/"]
+#[folder = "$DASHBOARD_DIR"]
 pub(crate) struct Asset;

--- a/documentation/docs/setup_a_node.mdx
+++ b/documentation/docs/setup_a_node.mdx
@@ -38,7 +38,6 @@ values={[
 To run a Bee node in a Debian base system you will need to install the following packages:
 
 - [git](https://git-scm.com/).
-- [npm](https://www.npmjs.com/).
 - [build-essential](https://packages.debian.org/sid/build-essential).
 - [cmake](https://cmake.org/).
 - [pkg-config](https://packages.debian.org/sid/pkg-config).
@@ -53,7 +52,7 @@ To install all of these packages, you can run the following commands:
 ```shell
 apt-get update
 apt-get upgrade
-apt-get install git npm build-essential cmake pkg-config librocksdb-dev llvm clang libclang-dev libssl-dev
+apt-get install git build-essential cmake pkg-config librocksdb-dev llvm clang libclang-dev libssl-dev
 ```
 
 </TabItem>
@@ -62,7 +61,6 @@ apt-get install git npm build-essential cmake pkg-config librocksdb-dev llvm cla
 To run a Bee node in a macOS system, you will need to install the following packages using the [brew](https://brew.sh/) package manager:
 
 - [cmake](https://cmake.org/).
-- [npm](https://www.npmjs.com/).
 
 You can run the following command to install brew:
 
@@ -73,7 +71,7 @@ You can run the following command to install brew:
 After the installer finishes, you can use brew to install the required packages by running:
 
 ```shell
-brew install cmake npm
+brew install cmake
 ```
 
 </TabItem>
@@ -83,7 +81,6 @@ To run a Bee node in a Windows system, you will need to install the following pa
 [chocolatey](https://chocolatey.org/) package manager:
 
 - [cmake](https://cmake.org/).
-- [nodejs-lts](https://nodejs.org/).
 - [git](https://git-scm.com/).
 
 To install chocolatey, open Powershell and execute the following command:
@@ -95,7 +92,7 @@ Set-ExecutionPolicy Bypass -Scope Process -Force; [System.Net.ServicePointManage
 After the installer finishes, you can use chocolatey to install the required packages by running:
 
 ```shell
-choco install git --params '/NoAutoCrlf' nodejs-lts cmake --installargs 'ADD_CMAKE_TO_PATH=System' llvm
+choco install git --params '/NoAutoCrlf' cmake --installargs 'ADD_CMAKE_TO_PATH=System' llvm
 ```
 
 :::info
@@ -176,52 +173,9 @@ You can compile Bee in two manners:
 
 If you want to build Bee with its Dashboard, you should run the following commands:
 
-<Tabs
-  groupId="operating-systems"
-  defaultValue="debian"
-  values={[
-    {label: 'Debian', value: 'debian'},
-    {label: 'macOS', value: 'mac'},
-    {label: 'Windows', value: 'win'},
-  ]
-}>
-<TabItem value="debian">
-
 ```shell
-git submodule update --init
-cd src/plugins/dashboard/frontend
-npm install
-npm run build-bee
-cd -
 cargo build --release --features dashboard
 ```
-
-</TabItem>
-<TabItem value="mac">
-
-```shell
-git submodule update --init
-cd src/plugins/dashboard/frontend
-npm install
-npm run build-bee
-cd -
-cargo build --release --features dashboard
-```
-
-</TabItem>
-<TabItem value="win">
-
-```shell
-git submodule update --init
-cd src/plugins/dashboard/frontend
-npm install
-npm run build-bee
-cd ../../../../
-cargo build --release --features dashboard
-```
-
-</TabItem>
-</Tabs>
 
 #### Without dashboard
 


### PR DESCRIPTION
Addresses #1144.

Adds to the `build.rs` script in `bee-node` to fetch the latest dashboard release from the [node-dashboard repository](https://github.com/iotaledger/node-dashboard), and place it in a subdirectory of `OUT_DIR` (defined by cargo at build-time) so that it can be used by `rust-embed`.

This will automatically run if `OUT_DIR/dashboard` fails to exist, or if `FETCH_DASHBOARD=1` is set.

Cargo recommends that build scripts *only* write any output files to this directory. Unfortunately that does mean that the files will hang around when the package is rebuilt and the build hash changes, so we might need to `cargo clean` more than normal...
