### PR TITLE
Version checker plugin

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -435,6 +435,10 @@ dependencies = [
  "bee-runtime",
  "futures",
  "log",
+ "reqwest",
+ "semver 1.0.4",
+ "serde",
+ "serde_json",
  "tokio",
  "tokio-stream",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -436,7 +436,7 @@ dependencies = [
  "futures",
  "log",
  "reqwest",
- "semver 1.0.4",
+ "semver 1.0.6",
  "serde",
  "serde_json",
  "tokio",

--- a/bee-node/bee-node/src/fullnode/builder.rs
+++ b/bee-node/bee-node/src/fullnode/builder.rs
@@ -154,7 +154,7 @@ impl<S: NodeStorageBackend> NodeBuilder<FullNode<S>> for FullNodeBuilder<S> {
         let builder = initialize_tangle(builder);
 
         // Start the version checker.
-        let builder = builder.with_worker::<VersionCheckerPlugin>();
+        let builder = builder.with_worker_cfg::<VersionCheckerPlugin>(std::env!("CARGO_PKG_VERSION").to_string());
 
         // Start serving the dashboard (if enabled).
         #[cfg(feature = "dashboard")]

--- a/bee-node/bee-node/src/fullnode/builder.rs
+++ b/bee-node/bee-node/src/fullnode/builder.rs
@@ -8,7 +8,7 @@ use crate::{
     core::{Core, CoreError, ResourceRegister, TopologicalOrder, WorkerStart, WorkerStop},
     shutdown,
     storage::NodeStorageBackend,
-    util, AUTOPEERING_VERSION,
+    util, AUTOPEERING_VERSION, BEE_VERSION,
 };
 
 use bee_autopeering::{
@@ -154,7 +154,7 @@ impl<S: NodeStorageBackend> NodeBuilder<FullNode<S>> for FullNodeBuilder<S> {
         let builder = initialize_tangle(builder);
 
         // Start the version checker.
-        let builder = builder.with_worker_cfg::<VersionCheckerPlugin>(std::env!("CARGO_PKG_VERSION").to_string());
+        let builder = builder.with_worker_cfg::<VersionCheckerPlugin>(BEE_VERSION.to_string());
 
         // Start serving the dashboard (if enabled).
         #[cfg(feature = "dashboard")]

--- a/bee-node/bee-plugin/bee-plugin-version-checker/Cargo.toml
+++ b/bee-node/bee-plugin/bee-plugin-version-checker/Cargo.toml
@@ -16,5 +16,9 @@ bee-runtime = { version = "0.1.1-alpha", path = "../../../bee-runtime", default-
 async-trait = { version = "0.1.51", default-features = false }
 futures = { version = "0.3.17", default-features = false }
 log = { version = "0.4.14", default-features = false }
+reqwest = { version = "0.11.5", default-features = false, features = [ "json", "default-tls" ] }
+semver = { version = "1.0.4", default-features = false }
+serde = { version = "1.0.130", default-features = false, features = [ "derive" ] }
+serde_json = { version = "1.0.68", default-features = false }
 tokio = { version = "1.12.0", default-features = false, features = [ "signal", "rt", "macros", "rt-multi-thread" ] }
-tokio-stream = { version = "0.1.7", default-features = false }
+tokio-stream = { version = "0.1.7", default-features = false, features = [ "time" ] }

--- a/bee-node/bee-plugin/bee-plugin-version-checker/src/lib.rs
+++ b/bee-node/bee-plugin/bee-plugin-version-checker/src/lib.rs
@@ -18,7 +18,7 @@ use tokio_stream::wrappers::IntervalStream;
 
 use std::{convert::Infallible, time::Duration};
 
-const CHECK_INTERVAL_SEC: u64 = 5;
+const CHECK_INTERVAL_SEC: u64 = 3600;
 
 type VersionCheckerConfig = String;
 

--- a/bee-node/bee-plugin/bee-plugin-version-checker/src/lib.rs
+++ b/bee-node/bee-plugin/bee-plugin-version-checker/src/lib.rs
@@ -7,7 +7,7 @@
 
 mod release_info;
 
-use crate::release_info::{ReleaseInfo, ReleaseInfoBuilder};
+use release_info::{ReleaseInfo, ReleaseInfoBuilder};
 
 use bee_runtime::{node::Node, shutdown_stream::ShutdownStream, worker::Worker};
 
@@ -33,7 +33,7 @@ impl<N: Node> Worker<N> for VersionCheckerPlugin {
 
     async fn start(node: &mut N, current_version: Self::Config) -> Result<Self, Self::Error> {
         node.spawn::<Self, _, _>(|shutdown| async move {
-            log::info!("Running.");
+            log::info!("Version checker running.");
 
             let mut ticker = ShutdownStream::new(
                 shutdown,
@@ -44,7 +44,7 @@ impl<N: Node> Worker<N> for VersionCheckerPlugin {
                 show_version_status(&current_version).await;
             }
 
-            log::info!("Stopped.");
+            log::info!("Version checker stopped.");
         });
 
         Ok(Self::default())
@@ -56,19 +56,19 @@ impl<N: Node> Worker<N> for VersionCheckerPlugin {
 async fn show_version_status(current_version: &str) {
     if let Some(release_info) = get_release_info().await {
         match (semver::Version::parse(current_version), latest(release_info)) {
-            (Err(e), _) => println!("Error parsing current Bee version ({}): {}", current_version, e),
+            (Err(e), _) => println!("Error parsing current Bee version ({}): {}.", current_version, e),
             (Ok(current), Some(latest)) => {
                 if latest.version > current {
                     log::warn!(
-                        "Found a more recent release version ({}), available at {}",
+                        "Found a more recent release version ({}), available at {}.",
                         latest.version,
                         latest.html_url,
                     );
                 } else {
-                    log::info!("On the latest release version ({})", current_version);
+                    log::info!("On the latest release version ({}).", current_version);
                 }
             }
-            _ => log::warn!("Could not identify the latest release version"),
+            _ => log::warn!("Could not identify the latest release version."),
         }
     }
 }

--- a/bee-node/bee-plugin/bee-plugin-version-checker/src/release_info.rs
+++ b/bee-node/bee-plugin/bee-plugin-version-checker/src/release_info.rs
@@ -7,9 +7,9 @@ use serde::Deserialize;
 use std::cmp;
 
 #[derive(Deserialize, Debug, Clone)]
-pub(crate) struct ReleaseInfoBuilder {
-    html_url: String,
-    tag_name: String,
+pub struct ReleaseInfoBuilder {
+    pub html_url: String,
+    pub tag_name: String,
 }
 
 impl ReleaseInfoBuilder {
@@ -17,9 +17,9 @@ impl ReleaseInfoBuilder {
     ///
     /// Returns:
     ///  - `None` if there is an error parsing a version from the release tag.
-    ///  - `None` if this is a pre-release.
+    ///  - `None` if this is a pre-release, and the current `bee-node` is *not* a pre-release.
     ///  - `Some` otherwise.
-    pub(crate) fn build(self) -> Option<ReleaseInfo> {
+    pub(crate) fn build(self, pre_release: bool) -> Option<ReleaseInfo> {
         let mut version = self.tag_name.clone();
         version.retain(|c| c != 'v');
 
@@ -28,16 +28,20 @@ impl ReleaseInfoBuilder {
                 log::warn!("Error parsing version from tag {}: {}", self.tag_name, e);
                 None
             }
-            Ok(version) => version.pre.is_empty().then(|| ReleaseInfo {
-                html_url: self.html_url,
-                version,
-            }),
+            Ok(version) => {
+                let selected = if pre_release { true } else { version.pre.is_empty() };
+
+                selected.then(|| ReleaseInfo {
+                    html_url: self.html_url,
+                    version,
+                })
+            }
         }
     }
 }
 
 #[derive(Debug, PartialEq, Eq)]
-pub(crate) struct ReleaseInfo {
+pub struct ReleaseInfo {
     pub html_url: String,
     pub version: Version,
 }

--- a/bee-node/bee-plugin/bee-plugin-version-checker/src/release_info.rs
+++ b/bee-node/bee-plugin/bee-plugin-version-checker/src/release_info.rs
@@ -13,12 +13,18 @@ pub(crate) struct ReleaseInfoBuilder {
 }
 
 impl ReleaseInfoBuilder {
+    /// Attempts to build a [`ReleaseInfo`].
+    ///
+    /// Returns:
+    ///  - `None` if there is an error parsing a version from the release tag.
+    ///  - `None` if this is a pre-release.
+    ///  - `Some` otherwise.
     pub(crate) fn build(self) -> Option<ReleaseInfo> {
         let version = self.tag_name.replace("v", "");
 
         match Version::parse(&version) {
             Err(e) => {
-                println!("error parsing version from tag {}: {}", self.tag_name, e);
+                log::warn!("error parsing version from tag {}: {}", self.tag_name, e);
                 None
             }
             Ok(version) => version.pre.is_empty().then(|| ReleaseInfo {

--- a/bee-node/bee-plugin/bee-plugin-version-checker/src/release_info.rs
+++ b/bee-node/bee-plugin/bee-plugin-version-checker/src/release_info.rs
@@ -25,7 +25,7 @@ impl ReleaseInfoBuilder {
 
         match Version::parse(&version) {
             Err(e) => {
-                log::warn!("error parsing version from tag {}: {}", self.tag_name, e);
+                log::warn!("Error parsing version from tag {}: {}", self.tag_name, e);
                 None
             }
             Ok(version) => version.pre.is_empty().then(|| ReleaseInfo {

--- a/bee-node/bee-plugin/bee-plugin-version-checker/src/release_info.rs
+++ b/bee-node/bee-plugin/bee-plugin-version-checker/src/release_info.rs
@@ -20,7 +20,8 @@ impl ReleaseInfoBuilder {
     ///  - `None` if this is a pre-release.
     ///  - `Some` otherwise.
     pub(crate) fn build(self) -> Option<ReleaseInfo> {
-        let version = self.tag_name.replace("v", "");
+        let mut version = self.tag_name.clone();
+        version.retain(|c| c != 'v');
 
         match Version::parse(&version) {
             Err(e) => {

--- a/bee-node/bee-plugin/bee-plugin-version-checker/src/release_info.rs
+++ b/bee-node/bee-plugin/bee-plugin-version-checker/src/release_info.rs
@@ -1,0 +1,48 @@
+// Copyright 2022 IOTA Stiftung
+// SPDX-License-Identifier: Apache-2.0
+
+use semver::Version;
+use serde::Deserialize;
+
+use std::cmp;
+
+#[derive(Deserialize, Debug, Clone)]
+pub(crate) struct ReleaseInfoBuilder {
+    html_url: String,
+    tag_name: String,
+}
+
+impl ReleaseInfoBuilder {
+    pub(crate) fn build(self) -> Option<ReleaseInfo> {
+        let version = self.tag_name.replace("v", "");
+
+        match Version::parse(&version) {
+            Err(e) => {
+                println!("error parsing version from tag {}: {}", self.tag_name, e);
+                None
+            }
+            Ok(version) => version.pre.is_empty().then(|| ReleaseInfo {
+                html_url: self.html_url,
+                version,
+            }),
+        }
+    }
+}
+
+#[derive(Debug, PartialEq, Eq)]
+pub(crate) struct ReleaseInfo {
+    pub html_url: String,
+    pub version: Version,
+}
+
+impl Ord for ReleaseInfo {
+    fn cmp(&self, other: &Self) -> cmp::Ordering {
+        self.version.cmp(&other.version)
+    }
+}
+
+impl PartialOrd for ReleaseInfo {
+    fn partial_cmp(&self, other: &Self) -> Option<cmp::Ordering> {
+        Some(self.cmp(other))
+    }
+}

--- a/bee-node/bee-plugin/bee-plugin-version-checker/src/release_info.rs
+++ b/bee-node/bee-plugin/bee-plugin-version-checker/src/release_info.rs
@@ -21,7 +21,7 @@ impl ReleaseInfoBuilder {
     ///  - `Some` otherwise.
     pub(crate) fn build(self, pre_release: bool) -> Option<ReleaseInfo> {
         let mut version = self.tag_name.clone();
-        
+
         if version.starts_with('v') {
             version.remove(0);
         }

--- a/bee-node/bee-plugin/bee-plugin-version-checker/src/release_info.rs
+++ b/bee-node/bee-plugin/bee-plugin-version-checker/src/release_info.rs
@@ -21,21 +21,20 @@ impl ReleaseInfoBuilder {
     ///  - `Some` otherwise.
     pub(crate) fn build(self, pre_release: bool) -> Option<ReleaseInfo> {
         let mut version = self.tag_name.clone();
-        version.retain(|c| c != 'v');
+        
+        if version.starts_with('v') {
+            version.remove(0);
+        }
 
         match Version::parse(&version) {
             Err(e) => {
                 log::warn!("Error parsing version from tag {}: {}", self.tag_name, e);
                 None
             }
-            Ok(version) => {
-                let selected = if pre_release { true } else { version.pre.is_empty() };
-
-                selected.then(|| ReleaseInfo {
-                    html_url: self.html_url,
-                    version,
-                })
-            }
+            Ok(version) => (pre_release || version.pre.is_empty()).then(|| ReleaseInfo {
+                html_url: self.html_url,
+                version,
+            }),
         }
     }
 }


### PR DESCRIPTION
Adds a version checker plugin to notify the user if there is a more recent release version of the `bee-node` crate available (ignoring pre-release versions). Addresses #219.