### PR TITLE
Make `mps` module logs consistent

### DIFF
--- a/bee-node/src/plugins/mps.rs
+++ b/bee-node/src/plugins/mps.rs
@@ -21,7 +21,7 @@ impl Plugin for Mps {
     async fn start(_: Self::Config, bus: &Bus<'_>) -> Result<Self, Self::Error> {
         bus.add_listener::<(), MpsMetricsUpdated, _>(|metrics| {
             info!(
-                "incoming {} new {} known {} invalid {} outgoing {}",
+                "Incoming {} New {} Known {} Invalid {} Outgoing {}",
                 metrics.incoming, metrics.new, metrics.known, metrics.invalid, metrics.outgoing
             );
         });

--- a/bee-node/src/plugins/mps.rs
+++ b/bee-node/src/plugins/mps.rs
@@ -21,7 +21,7 @@ impl Plugin for Mps {
     async fn start(_: Self::Config, bus: &Bus<'_>) -> Result<Self, Self::Error> {
         bus.add_listener::<(), MpsMetricsUpdated, _>(|metrics| {
             info!(
-                "Incoming {} New {} Known {} Invalid {} Outgoing {}",
+                "Mps: incoming {} new {} known {} invalid {} outgoing {}",
                 metrics.incoming, metrics.new, metrics.known, metrics.invalid, metrics.outgoing
             );
         });


### PR DESCRIPTION
All of our logs start with an uppercase letter except for the `mps` plugin. I tried two versions:
Option 1:
```
2022-03-03 10:56:43 (UTC) bee_node::plugins::mps       INFO  Incoming 75 New 18 Known 57 Invalid 0 Outgoing 126
```
and

Option 2:
```
2022-03-03 10:56:43 (UTC) bee_node::plugins::mps       INFO  Mps: incoming 75 new 18 known 57 invalid 0 outgoing 126
```

I personally prefer Option 2 over Option 1, because it keeps the log message meaningful (in terms of giving the numbers a concrete unit) even if we'ld rename the `mps` module to something else.
