### PR TITLE
Make `Tangle::update_metadata` atomic by using entries

### DIFF
--- a/bee-tangle/src/tangle.rs
+++ b/bee-tangle/src/tangle.rs
@@ -405,7 +405,7 @@ impl<B: StorageBackend> Tangle<B> {
         metadata: MessageMetadata,
         prevent_eviction: bool,
     ) -> Option<MessageRef> {
-        let mut vertex = self.vertices.get_mut_or_empty(message_id).await;
+        let mut vertex = self.vertices.entry(message_id).await.or_empty();
 
         if prevent_eviction {
             vertex.prevent_eviction();
@@ -423,7 +423,7 @@ impl<B: StorageBackend> Tangle<B> {
 
             // Insert children for parents
             for &parent in parents.iter() {
-                self.vertices.get_mut_or_empty(parent).await.add_child(message_id);
+                self.vertices.entry(parent).await.or_empty().add_child(message_id);
             }
 
             msg
@@ -550,7 +550,7 @@ impl<B: StorageBackend> Tangle<B> {
                     Ok(Some(approvers)) => approvers,
                 };
 
-                let mut vertex = self.vertices.get_mut_or_empty(*message_id).await;
+                let mut vertex = self.vertices.entry(*message_id).await.or_empty();
 
                 // We've just fetched approvers from the database, so we have all the information available to us now.
                 // Therefore, the approvers list is exhaustive (i.e: it contains all knowledge we have).

--- a/bee-tangle/src/tangle.rs
+++ b/bee-tangle/src/tangle.rs
@@ -526,6 +526,12 @@ impl<B: StorageBackend> Tangle<B> {
             self.perform_eviction();
         }
 
+        let cache_size = self.vertices.real_len().await;
+
+        if cache_size % 128 == 0 {
+            info!("Cache size: {}. Estimated size: {}", cache_size, self.vertices.len());
+        }
+
         output
     }
 

--- a/bee-tangle/src/tangle.rs
+++ b/bee-tangle/src/tangle.rs
@@ -497,8 +497,6 @@ impl<B: StorageBackend> Tangle<B> {
 
         if was_vacant || vertex.message().is_none() {
             if let Ok(Some((msg, metadata))) = self.storage_get(message_id) {
-                vertex.prevent_eviction();
-
                 if vertex.message().is_none() {
                     parents = Some(msg.parents().clone());
                     vertex.insert_message_and_metadata(msg, metadata);
@@ -507,8 +505,6 @@ impl<B: StorageBackend> Tangle<B> {
                 // This shouldn't deadlock because `pop_random` calls `try_write` over a random
                 // lock and this is non-blocking.
                 self.perform_eviction();
-
-                vertex.allow_eviction();
             }
         }
 

--- a/bee-tangle/src/vertices.rs
+++ b/bee-tangle/src/vertices.rs
@@ -182,4 +182,12 @@ impl Vertices {
     pub(crate) fn len(&self) -> usize {
         self.len.load(Ordering::Relaxed)
     }
+
+    pub(crate) async fn real_len(&self) -> usize {
+        let mut len = 0;
+        for table in self.tables.iter() {
+            len += table.read().await.len();
+        }
+        len
+    }
 }

--- a/bee-tangle/src/vertices.rs
+++ b/bee-tangle/src/vertices.rs
@@ -120,7 +120,7 @@ impl Vertices {
         .ok()
     }
 
-    pub(crate) async fn pop_random(&self, max_retries: usize) -> Option<Vertex> {
+    pub(crate) fn pop_random(&self, max_retries: usize) -> Option<Vertex> {
         let mut retries = 0;
 
         while retries < max_retries {

--- a/bee-tangle/src/vertices.rs
+++ b/bee-tangle/src/vertices.rs
@@ -42,6 +42,7 @@ pub(crate) struct VacantEntry<'a> {
     message_id: MessageId,
     table: RwLockWriteGuard<'a, RawTable<(MessageId, Vertex)>>,
     hash_builder: &'a DefaultHashBuilder,
+    len: &'a AtomicUsize,
 }
 
 impl<'a> VacantEntry<'a> {
@@ -50,6 +51,7 @@ impl<'a> VacantEntry<'a> {
             let entry = table.insert_entry(self.hash, (self.message_id, Vertex::empty()), move |(message_id, _)| {
                 make_hash(&self.hash_builder, message_id)
             });
+            self.len.fetch_add(1, Ordering::Relaxed);
             &mut entry.1
         })
     }
@@ -172,6 +174,7 @@ impl Vertices {
                 message_id,
                 table,
                 hash_builder: &self.hash_builder,
+                len: &self.len,
             })
         }
     }


### PR DESCRIPTION
This should fix our data race or at least make it less likely.

I'd appreciate if you could check that the `update_metadata` logic is still the same as before. The main difference is that we acquire a write guard over the `Vertices` partition we need only once, which should forbid other threads from introducing inconsistencies while `update_metadata` is running.

The only possible issue I was able to see is that `update_metadata` is not completely atomic because parents need to be updated after the write guard is dropped. This is because parents might potentially be in other partitions.  Even then, this shouldn't affect the metadata updates done over the vertex itself.