### PR TITLE
Use secured base image for Docker

### DIFF
--- a/bee-node/docker/Dockerfile
+++ b/bee-node/docker/Dockerfile
@@ -22,14 +22,9 @@ RUN if [ "$WITH_DASHBOARD" = true ] ; then cargo build --profile production --fe
 ############################
 # Image
 ############################
-FROM debian:buster-slim
-
-RUN apt-get update && \
-    apt-get install openssl ca-certificates -y
-
-RUN update-ca-certificates
-
-RUN rm -rf /var/lib/apt
+# https://console.cloud.google.com/gcr/images/distroless/global/cc-debian11
+# using distroless cc "nonroot" image, which includes everything in the base image (glibc, libssl and openssl)
+FROM gcr.io/distroless/cc-debian11:nonroot
 
 # API
 EXPOSE 14265/tcp
@@ -42,7 +37,7 @@ EXPOSE 8081/tcp
 # Autopeering
 EXPOSE 14626/udp
 
-COPY --from=build /bee/target/production/bee /
+COPY --chown=nonroot:nonroot --from=build /bee/target/production/bee /
 
 # Copy the profiles
 COPY --from=build /bee/bee-node/config.chrysalis-comnet.toml .
@@ -52,5 +47,7 @@ COPY --from=build /bee/bee-node/config.chrysalis-mainnet.toml .
 COPY --from=build /bee/bee-node/config.chrysalis-comnet.json .
 COPY --from=build /bee/bee-node/config.chrysalis-devnet.json .
 COPY --from=build /bee/bee-node/config.chrysalis-mainnet.json .
+
+USER nonroot
 
 ENTRYPOINT ["/bee"]


### PR DESCRIPTION
# Description of change

We now use the same base image as Hornet.

## Links to any relevant issues

Closes #1208.

<!-- Be sure to reference any related issues by adding `fixes issue #`. -->

## Change checklist

<!-- Tick the boxes that are relevant to your changes, and delete any items that are not. -->

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that new and existing unit tests pass locally with my changes
- [x] I have updated the CHANGELOG.md, if my changes are significant enough
