### PR TITLE
Remove pruning bug mitigation code

### DIFF
--- a/bee-ledger/src/workers/consensus/worker.rs
+++ b/bee-ledger/src/workers/consensus/worker.rs
@@ -352,7 +352,8 @@ where
                                         .await
                                 {
                                     error!("Pruning failed: {:?}.", e);
-                                    unreachable!()
+                                    // TODO: consider initiating an emergency (but graceful) shutdown instead of just panicking.
+                                    panic!("Aborting due to an unexpected pruning error.");
                                 }
                             }
                             Err(reason) => {

--- a/bee-ledger/src/workers/consensus/worker.rs
+++ b/bee-ledger/src/workers/consensus/worker.rs
@@ -352,7 +352,8 @@ where
                                         .await
                                 {
                                     error!("Pruning failed: {:?}.", e);
-                                    // TODO: consider initiating an emergency (but graceful) shutdown instead of just panicking.
+                                    // TODO: consider initiating an emergency (but graceful) shutdown instead of just
+                                    // panicking.
                                     panic!("Aborting due to an unexpected pruning error.");
                                 }
                             }

--- a/bee-ledger/src/workers/consensus/worker.rs
+++ b/bee-ledger/src/workers/consensus/worker.rs
@@ -352,6 +352,7 @@ where
                                         .await
                                 {
                                     error!("Pruning failed: {:?}.", e);
+                                    unreachable!()
                                 }
                             }
                             Err(reason) => {

--- a/bee-ledger/src/workers/pruning/batch.rs
+++ b/bee-ledger/src/workers/pruning/batch.rs
@@ -194,7 +194,14 @@ pub fn batch_prunable_confirmed_data<S: StorageBackend>(
                 //     prune_index + mitigation_threshold
                 // });
 
-                let conf_index = unvisited_md.milestone_index().expect("mitigation required");
+                // A non-existing milestone index means the message wasn't confirmed. In that case such an approver
+                // is irrelevant for a message to be considered an SEP, because the next past-cone traversals won't
+                // go through such an unconfirmed message. We can therefore assign smallest possible index which
+                // means that this approver is irrelevant.
+                let conf_index = unvisited_md.milestone_index().unwrap_or_else(|| {
+                    log::trace!("Unconfirmed approver (no milestone index): {unvisited_id}");
+                    prune_index
+                });
 
                 // Update the approver cache.
                 approver_cache.insert(unvisited_id, conf_index);

--- a/bee-ledger/src/workers/pruning/batch.rs
+++ b/bee-ledger/src/workers/pruning/batch.rs
@@ -167,10 +167,9 @@ pub fn batch_prunable_confirmed_data<S: StorageBackend>(
                     .map_err(|e| Error::Storage(Box::new(e)))?
                     .ok_or(Error::MissingMetadata(unvisited_id))?;
 
-                // A non-existing milestone index means the message wasn't confirmed. In that case such an approver
-                // is irrelevant for a message to be considered as an SEP, because the next past-cone traversals won't
-                // go through such an unconfirmed message. We can therefore assign smallest possible index which
-                // means that this approver is irrelevant.
+                // A non-existing milestone index means that a message remained unconfirmed and therefore is neglibable
+                // for its parent in terms of SEP consideration. This can be expressed by assigning the
+                // current pruning index.
                 let conf_index = unvisited_md.milestone_index().unwrap_or_else(|| {
                     log::trace!("Unconfirmed approver (no milestone index): {unvisited_id}");
                     prune_index

--- a/bee-ledger/src/workers/pruning/batch.rs
+++ b/bee-ledger/src/workers/pruning/batch.rs
@@ -169,33 +169,8 @@ pub fn batch_prunable_confirmed_data<S: StorageBackend>(
                     .map_err(|e| Error::Storage(Box::new(e)))?
                     .ok_or(Error::MissingMetadata(unvisited_id))?;
 
-                // Note, that an unvisited approver of this message can still be confirmed by the same milestone
-                // (despite the breadth-first traversal), if it is also its sibling.
-                // let conf_index = unvisited_md.milestone_index().unwrap_or_else(|| {
-                //     // ---
-                //     // BUG/FIXME:
-                //     // In very rare situations the milestone index has not been set for a confirmed message. If that
-                //     // message happens to be the one with the highest confirmation index, then the SEP created from
-                // the     // current message would be removed too early, i.e. before all of its
-                // referrers, and pruning would     // fail without a way to ever recover. We suspect
-                // the bug to be a race condition in the     // `update_metadata` method of the `Tangle`
-                // implementation.     //
-                //     // Mitigation strategy:
-                //     // We rely on the coordinator to not confirm something that attaches to a message that was
-                // confirmed     // more than 20 milestones (BMD + EXTRA_PRUNING_DEPTH) ago, i.e. a lazy
-                // tip.     // ---
-                //     log::trace!(
-                //         "Bug mitigation: Using '{} + mitigation_threshold ({})' for approver '{}'",
-                //         prune_index,
-                //         mitigation_threshold,
-                //         &unvisited_id
-                //     );
-
-                //     prune_index + mitigation_threshold
-                // });
-
                 // A non-existing milestone index means the message wasn't confirmed. In that case such an approver
-                // is irrelevant for a message to be considered an SEP, because the next past-cone traversals won't
+                // is irrelevant for a message to be considered as an SEP, because the next past-cone traversals won't
                 // go through such an unconfirmed message. We can therefore assign smallest possible index which
                 // means that this approver is irrelevant.
                 let conf_index = unvisited_md.milestone_index().unwrap_or_else(|| {
@@ -255,51 +230,19 @@ pub fn batch_prunable_unconfirmed_data<S: StorageBackend>(
 
     // TODO: consider using `MultiFetch`
     'next_unconf_msg: for unconf_msg_id in unconf_msgs.iter().map(|unconf_msg| unconf_msg.message_id()) {
-        // Skip those that were confirmed.
         match Fetch::<MessageId, MessageMetadata>::fetch(storage, unconf_msg_id)
             .map_err(|e| Error::Storage(Box::new(e)))?
         {
             Some(msg_meta) => {
                 if msg_meta.flags().is_referenced() {
                     metrics.were_confirmed += 1;
+                    // Skip confirmed messages.
                     continue 'next_unconf_msg;
-                } else {
-                    // We log which messages were never confirmed.
-                    log::trace!("'referenced' flag not set for {}", unconf_msg_id);
-
-                    // // ---
-                    // // BUG/FIXME:
-                    // // In very rare situations the `referenced` flag has not been set for a confirmed message. This
-                    // // would lead to it being removed as an unconfirmed message causing the past-cone traversal of a
-                    // // milestone to fail. That would cause pruning to fail without a way to ever recover. We suspect
-                    // the // bug to be a race condition in the `update_metadata` method of the
-                    // `Tangle` implementation. //
-                    // // Mitigation strategy:
-                    // // To make occurring this scenario sufficiently unlikely, we only prune a message with
-                    // // the flag indicating "not referenced", if all its approvers are also flagged as "not
-                    // referenced". // In other words: If we find at least one confirmed approver,
-                    // then we know the flag wasn't set // appropriatedly for the current message
-                    // due to THE bug, and that we cannot prune it. // ---
-                    // let unconf_approvers = Fetch::<MessageId, Vec<MessageId>>::fetch(storage, unconf_msg_id)
-                    //     .map_err(|e| Error::Storage(Box::new(e)))?
-                    //     .ok_or(Error::MissingApprovers(*unconf_msg_id))?;
-
-                    // for unconf_approver_id in unconf_approvers {
-                    //     if let Some(unconf_approver_md) =
-                    //         Fetch::<MessageId, MessageMetadata>::fetch(storage, &unconf_approver_id)
-                    //             .map_err(|e| Error::Storage(Box::new(e)))?
-                    //     {
-                    //         if unconf_approver_md.flags().is_referenced() {
-                    //             continue 'outer_loop;
-                    //         }
-                    //     }
-                    // }
-
-                    // log::trace!("all of '{}'s approvers are flagged 'unreferenced'", unconf_msg_id);
                 }
             }
             None => {
                 metrics.already_pruned += 1;
+                // Skip already pruned messages.
                 continue 'next_unconf_msg;
             }
         }

--- a/bee-ledger/src/workers/pruning/batch.rs
+++ b/bee-ledger/src/workers/pruning/batch.rs
@@ -15,7 +15,7 @@ use bee_message::{
 };
 use bee_storage::access::{Batch, Fetch};
 use bee_tangle::{
-    metadata::MessageMetadata, solid_entry_point::SolidEntryPoint, unreferenced_message::UnreferencedMessage, Tangle,
+    metadata::MessageMetadata, solid_entry_point::SolidEntryPoint, unreferenced_message::UnreferencedMessage,
 };
 use hashbrown::{HashMap, HashSet};
 use ref_cast::RefCast;
@@ -42,7 +42,6 @@ pub struct Edge {
 }
 
 pub fn batch_prunable_confirmed_data<S: StorageBackend>(
-    _tangle: &Tangle<S>,
     storage: &S,
     batch: &mut S::Batch,
     prune_index: MilestoneIndex,

--- a/bee-ledger/src/workers/pruning/batch.rs
+++ b/bee-ledger/src/workers/pruning/batch.rs
@@ -56,8 +56,6 @@ pub fn batch_prunable_confirmed_data<S: StorageBackend>(
     let mut new_seps = Seps::with_capacity(512);
     // We collect stats during the traversal, and return them as a result of this function.
     let mut metrics = ConfirmedDataPruningMetrics::default();
-    // // FIXME: mitigation code
-    // let mitigation_threshold = tangle.config().below_max_depth() + EXTRA_PRUNING_DEPTH; // = BMD + 5
 
     // Get the `MessageId` of the milestone we are about to prune from the storage.
     let prune_id = *Fetch::<MilestoneIndex, Milestone>::fetch(storage, &prune_index)

--- a/bee-ledger/src/workers/pruning/prune.rs
+++ b/bee-ledger/src/workers/pruning/prune.rs
@@ -78,7 +78,7 @@ pub async fn prune<S: StorageBackend>(
         // NOTE: This is the most costly thing during pruning, because it has to perform a past-cone traversal.
         let batch_confirmed_data = Instant::now();
         let (mut new_seps, confirmed_data_metrics) =
-            batch::batch_prunable_confirmed_data(tangle, storage, &mut batch, index, &curr_seps)?;
+            batch::batch_prunable_confirmed_data(storage, &mut batch, index, &curr_seps)?;
         timings.batch_confirmed_data = batch_confirmed_data.elapsed();
 
         metrics.new_seps = new_seps.len();

--- a/bee-ledger/src/workers/pruning/prune.rs
+++ b/bee-ledger/src/workers/pruning/prune.rs
@@ -78,7 +78,7 @@ pub async fn prune<S: StorageBackend>(
         // NOTE: This is the most costly thing during pruning, because it has to perform a past-cone traversal.
         let batch_confirmed_data = Instant::now();
         let (mut new_seps, confirmed_data_metrics) =
-            batch::prune_confirmed_data(tangle, storage, &mut batch, index, &curr_seps)?;
+            batch::batch_prunable_confirmed_data(tangle, storage, &mut batch, index, &curr_seps)?;
         timings.batch_confirmed_data = batch_confirmed_data.elapsed();
 
         metrics.new_seps = new_seps.len();
@@ -136,7 +136,7 @@ pub async fn prune<S: StorageBackend>(
 
         // Add unconfirmed data to the delete batch.
         let batch_unconfirmed_data = Instant::now();
-        let unconfirmed_data_metrics = batch::prune_unconfirmed_data(storage, &mut batch, index)?;
+        let unconfirmed_data_metrics = batch::batch_prunable_unconfirmed_data(storage, &mut batch, index)?;
         timings.batch_unconfirmed_data = batch_unconfirmed_data.elapsed();
 
         metrics.messages += unconfirmed_data_metrics.prunable_messages;

--- a/bee-network/bee-gossip/src/swarm/protocols/iota_gossip/handler.rs
+++ b/bee-network/bee-gossip/src/swarm/protocols/iota_gossip/handler.rs
@@ -64,9 +64,9 @@ impl ProtocolsHandler for GossipProtocolHandler {
     /// substreams to negotiate the desired protocols.
     ///
     /// > **Note**: The returned `InboundUpgrade` should always accept all the generally
-    /// >           supported protocols, even if in a specific context a particular one is
-    /// >           not supported, (eg. when only allowing one substream at a time for a protocol).
-    /// >           This allows a remote to put the list of supported protocols in a cache.
+    /// > supported protocols, even if in a specific context a particular one is
+    /// > not supported, (eg. when only allowing one substream at a time for a protocol).
+    /// > This allows a remote to put the list of supported protocols in a cache.
     fn listen_protocol(&self) -> SubstreamProtocol<Self::InboundProtocol, Self::InboundOpenInfo> {
         debug!("gossip handler: responding to listen protocol request.");
 

--- a/bee-protocol/src/workers/index_updater.rs
+++ b/bee-protocol/src/workers/index_updater.rs
@@ -118,6 +118,8 @@ async fn update_past_cone<B: StorageBackend>(
         }
 
         tangle.update_metadata(&parent_id, |metadata| {
+            log::trace!("Confirmed message {parent_id} (Milestone index = {index}).");
+
             metadata.set_milestone_index(index);
 
             let index = IndexId::new(index, parent_id);

--- a/bee-tangle/src/tangle.rs
+++ b/bee-tangle/src/tangle.rs
@@ -92,6 +92,9 @@ impl<B: StorageBackend> Tangle<B> {
 
         self.update_metadata(milestone.message_id(), |metadata| {
             metadata.flags_mut().set_milestone(true);
+
+            log::trace!("Milestone message {} (Milestone index = {}).", milestone.message_id(), idx);
+
             metadata.set_milestone_index(idx);
             metadata.set_omrsi_and_ymrsi(index, index);
         });

--- a/bee-tangle/src/tangle.rs
+++ b/bee-tangle/src/tangle.rs
@@ -93,7 +93,11 @@ impl<B: StorageBackend> Tangle<B> {
         self.update_metadata(milestone.message_id(), |metadata| {
             metadata.flags_mut().set_milestone(true);
 
-            log::trace!("Milestone message {} (Milestone index = {}).", milestone.message_id(), idx);
+            log::trace!(
+                "Milestone message {} (Milestone index = {}).",
+                milestone.message_id(),
+                idx
+            );
 
             metadata.set_milestone_index(idx);
             metadata.set_omrsi_and_ymrsi(index, index);


### PR DESCRIPTION
# Description of change

<!-- Please write a summary of your changes and why you made them. -->

Removes the mitigation code in the pruning module of `bee-ledger`, that was necessary due to a bug in `bee-tangle` which on rare occasions failed to set the metadata of a message correctly causing the pruning to fail. 

With the bug now fixed, the mitigation code is no longer necessary and will be removed in this PR.

## Links to any relevant issues

<!-- Be sure to reference any related issues by adding `fixes issue #`. -->

Addresses #1039 

## Type of change

<!-- Choose a type of change, and delete any options that are not relevant. -->

- Enhancement (a non-breaking change which adds functionality)

## How the change has been tested

<!-- Describe the tests that you ran to verify your changes. -->

2 VPS ran several days without pruning to fail (it usually failed between a few hours and at most 24 hours)

<!-- Make sure to provide instructions for the maintainer as well as any relevant configurations. -->

## Change checklist

<!-- Tick the boxes that are relevant to your changes, and delete any items that are not. -->

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that new and existing unit tests pass locally with my changes
- [x] I have updated the CHANGELOG.md, if my changes are significant enough
