### PR TITLE
Add convenience `finish_output` method

### DIFF
--- a/bee-message/src/output/alias.rs
+++ b/bee-message/src/output/alias.rs
@@ -237,6 +237,11 @@ impl AliasOutputBuilder {
 
         Ok(output)
     }
+
+    /// Finishes the [`AliasOutputBuilder`] into an [`Output`].
+    pub fn finish_output(self) -> Result<Output, Error> {
+        Ok(Output::Alias(self.finish()?))
+    }
 }
 
 impl From<&AliasOutput> for AliasOutputBuilder {

--- a/bee-message/src/output/basic.rs
+++ b/bee-message/src/output/basic.rs
@@ -146,6 +146,11 @@ impl BasicOutputBuilder {
 
         Ok(output)
     }
+
+    /// Finishes the [`BasicOutputBuilder`] into an [`Output`].
+    pub fn finish_output(self) -> Result<Output, Error> {
+        Ok(Output::Basic(self.finish()?))
+    }
 }
 
 impl From<&BasicOutput> for BasicOutputBuilder {

--- a/bee-message/src/output/foundry.rs
+++ b/bee-message/src/output/foundry.rs
@@ -223,6 +223,11 @@ impl FoundryOutputBuilder {
 
         Ok(output)
     }
+
+    /// Finishes the [`FoundryOutputBuilder`] into an [`Output`].
+    pub fn finish_output(self) -> Result<Output, Error> {
+        Ok(Output::Foundry(self.finish()?))
+    }
 }
 
 impl From<&FoundryOutput> for FoundryOutputBuilder {

--- a/bee-message/src/output/nft.rs
+++ b/bee-message/src/output/nft.rs
@@ -194,6 +194,11 @@ impl NftOutputBuilder {
 
         Ok(output)
     }
+
+    /// Finishes the [`NftOutputBuilder`] into an [`Output`].
+    pub fn finish_output(self) -> Result<Output, Error> {
+        Ok(Output::Nft(self.finish()?))
+    }
 }
 
 impl From<&NftOutput> for NftOutputBuilder {


### PR DESCRIPTION
It's very common to have to convert to the `Output` enum after having built an output.

## Change checklist

<!-- Tick the boxes that are relevant to your changes, and delete any items that are not. -->

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that new and existing unit tests pass locally with my changes
- [x] I have updated the CHANGELOG.md, if my changes are significant enough
