### PR TITLE
Add InputsCommitment type

### DIFF
--- a/bee-message/src/output/inputs_commitment.rs
+++ b/bee-message/src/output/inputs_commitment.rs
@@ -13,7 +13,7 @@ use crate::output::Output;
 pub struct InputsCommitment([u8; 32]);
 
 impl InputsCommitment {
-    /// Creates a new [`InputsCommitment`] from a sequence of [`Outputs`].
+    /// Creates a new [`InputsCommitment`] from a sequence of [`Output`]s.
     pub fn new<'a>(inputs: impl Iterator<Item = &'a Output>) -> Self {
         let mut hasher = Blake2b256::new();
 

--- a/bee-message/src/output/inputs_commitment.rs
+++ b/bee-message/src/output/inputs_commitment.rs
@@ -1,0 +1,46 @@
+// Copyright 2022 IOTA Stiftung
+// SPDX-License-Identifier: Apache-2.0
+
+use crypto::hashes::{blake2b::Blake2b256, Digest};
+use derive_more::{Deref, From};
+use packable::PackableExt;
+
+use crate::output::Output;
+
+/// Represents a commitment to transaction inputs.
+#[derive(Copy, Clone, Eq, PartialEq, Hash, Ord, PartialOrd, From, Deref, packable::Packable)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+pub struct InputsCommitment([u8; 32]);
+
+impl InputsCommitment {
+    /// Creates a new [`InputsCommitment`] from a sequence of [`Outputs`].
+    pub fn new<'a>(inputs: impl Iterator<Item = &'a Output>) -> Self {
+        let mut hasher = Blake2b256::new();
+
+        inputs.for_each(|output| hasher.update(output.pack_to_vec()));
+
+        Self(hasher.finalize().into())
+    }
+}
+
+impl core::str::FromStr for InputsCommitment {
+    type Err = crate::Error;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        Ok(InputsCommitment::from(
+            prefix_hex::decode::<[u8; 32]>(s).map_err(crate::Error::HexError)?,
+        ))
+    }
+}
+
+impl core::fmt::Display for InputsCommitment {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        write!(f, "{}", prefix_hex::encode(self.0))
+    }
+}
+
+impl core::fmt::Debug for InputsCommitment {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        write!(f, "InputsCommitment({})", self)
+    }
+}

--- a/bee-message/src/output/mod.rs
+++ b/bee-message/src/output/mod.rs
@@ -8,6 +8,7 @@ mod byte_cost;
 mod chain_id;
 mod foundry;
 mod foundry_id;
+mod inputs_commitment;
 mod native_token;
 mod nft;
 mod nft_id;
@@ -24,7 +25,6 @@ pub mod unlock_condition;
 
 use core::ops::RangeInclusive;
 
-use crypto::hashes::{blake2b::Blake2b256, Digest};
 use derive_more::From;
 use packable::{bounded::BoundedU64, PackableExt};
 
@@ -45,6 +45,7 @@ pub use self::{
     feature_block::{FeatureBlock, FeatureBlocks},
     foundry::{FoundryOutput, FoundryOutputBuilder},
     foundry_id::FoundryId,
+    inputs_commitment::InputsCommitment,
     native_token::{NativeToken, NativeTokens, NativeTokensBuilder},
     nft::{NftOutput, NftOutputBuilder},
     nft_id::NftId,
@@ -275,15 +276,6 @@ fn minimum_storage_deposit(config: &ByteCostConfig, address: &Address) -> u64 {
         .finish()
         .unwrap()
         .amount()
-}
-
-///
-pub fn create_inputs_commitment<'a>(inputs: impl Iterator<Item = &'a Output>) -> [u8; 32] {
-    let mut hasher = Blake2b256::new();
-
-    inputs.for_each(|output| hasher.update(output.pack_to_vec()));
-
-    hasher.finalize().into()
 }
 
 #[cfg(feature = "dto")]

--- a/bee-message/src/payload/transaction/essence/regular.rs
+++ b/bee-message/src/payload/transaction/essence/regular.rs
@@ -9,25 +9,25 @@ use packable::{bounded::BoundedU16, prefix::BoxedSlicePrefix, Packable};
 use crate::{
     constant::TOKEN_SUPPLY,
     input::{Input, INPUT_COUNT_RANGE},
-    output::{NativeTokens, Output, OUTPUT_COUNT_RANGE},
+    output::{InputsCommitment, NativeTokens, Output, OUTPUT_COUNT_RANGE},
     payload::{OptionalPayload, Payload},
     Error,
 };
 
 /// A builder to build a [`RegularTransactionEssence`].
-#[derive(Debug, Default)]
+#[derive(Debug)]
 #[must_use]
 pub struct RegularTransactionEssenceBuilder {
     network_id: u64,
     inputs: Vec<Input>,
-    inputs_commitment: [u8; 32],
+    inputs_commitment: InputsCommitment,
     outputs: Vec<Output>,
     payload: Option<Payload>,
 }
 
 impl RegularTransactionEssenceBuilder {
     /// Creates a new [`RegularTransactionEssenceBuilder`].
-    pub fn new(network_id: u64, inputs_commitment: [u8; 32]) -> Self {
+    pub fn new(network_id: u64, inputs_commitment: InputsCommitment) -> Self {
         Self {
             network_id,
             inputs: Vec::new(),
@@ -113,7 +113,7 @@ pub struct RegularTransactionEssence {
     #[packable(unpack_error_with = |e| e.unwrap_item_err_or_else(|p| Error::InvalidInputCount(p.into())))]
     inputs: BoxedSlicePrefix<Input, InputCount>,
     /// BLAKE2b-256 hash of the serialized outputs referenced in inputs by their OutputId.
-    inputs_commitment: [u8; 32],
+    inputs_commitment: InputsCommitment,
     #[packable(verify_with = verify_outputs)]
     #[packable(unpack_error_with = |e| e.unwrap_item_err_or_else(|p| Error::InvalidOutputCount(p.into())))]
     outputs: BoxedSlicePrefix<Output, OutputCount>,
@@ -126,7 +126,7 @@ impl RegularTransactionEssence {
     pub const KIND: u8 = 1;
 
     /// Creates a new [`RegularTransactionEssenceBuilder`] to build a [`RegularTransactionEssence`].
-    pub fn builder(network_id: u64, inputs_commitment: [u8; 32]) -> RegularTransactionEssenceBuilder {
+    pub fn builder(network_id: u64, inputs_commitment: InputsCommitment) -> RegularTransactionEssenceBuilder {
         RegularTransactionEssenceBuilder::new(network_id, inputs_commitment)
     }
 
@@ -141,7 +141,7 @@ impl RegularTransactionEssence {
     }
 
     /// Returns the inputs commitment of a [`RegularTransactionEssence`].
-    pub fn inputs_commitment(&self) -> &[u8; 32] {
+    pub fn inputs_commitment(&self) -> &InputsCommitment {
         &self.inputs_commitment
     }
 
@@ -217,6 +217,8 @@ fn verify_payload<const VERIFY: bool>(payload: &OptionalPayload) -> Result<(), E
 #[cfg(feature = "dto")]
 #[allow(missing_docs)]
 pub mod dto {
+    use core::str::FromStr;
+
     use serde::{Deserialize, Serialize};
 
     use super::*;
@@ -243,7 +245,7 @@ pub mod dto {
                 kind: RegularTransactionEssence::KIND,
                 network_id: value.network_id().to_string(),
                 inputs: value.inputs().iter().map(Into::into).collect::<Vec<_>>(),
-                inputs_commitment: prefix_hex::encode(value.inputs_commitment()),
+                inputs_commitment: value.inputs_commitment().to_string(),
                 outputs: value.outputs().iter().map(Into::into).collect::<Vec<_>>(),
                 payload: match value.payload() {
                     Some(Payload::TaggedData(i)) => Some(PayloadDto::TaggedData(Box::new(i.as_ref().into()))),
@@ -274,7 +276,7 @@ pub mod dto {
                     .network_id
                     .parse::<u64>()
                     .map_err(|_| DtoError::InvalidField("networkId"))?,
-                prefix_hex::decode(&value.inputs_commitment).map_err(Error::HexError)?,
+                InputsCommitment::from_str(&value.inputs_commitment)?,
             )
             .with_inputs(inputs)
             .with_outputs(outputs);

--- a/bee-message/src/semantic.rs
+++ b/bee-message/src/semantic.rs
@@ -9,7 +9,7 @@ use primitive_types::U256;
 use crate::{
     address::Address,
     error::Error,
-    output::{create_inputs_commitment, ChainId, NativeTokens, Output, OutputId, TokenId, UnlockCondition},
+    output::{ChainId, InputsCommitment, NativeTokens, Output, OutputId, TokenId, UnlockCondition},
     payload::{
         milestone::MilestoneIndex,
         transaction::{RegularTransactionEssence, TransactionEssence, TransactionId},
@@ -127,7 +127,7 @@ pub struct ValidationContext<'a> {
     ///
     pub essence_hash: [u8; 32],
     ///
-    pub inputs_commitment: [u8; 32],
+    pub inputs_commitment: InputsCommitment,
     ///
     pub unlock_blocks: &'a UnlockBlocks,
     ///
@@ -168,7 +168,7 @@ impl<'a> ValidationContext<'a> {
             essence,
             unlock_blocks,
             essence_hash: TransactionEssence::from(essence.clone()).hash(),
-            inputs_commitment: create_inputs_commitment(inputs.clone().map(|(_, output)| output)),
+            inputs_commitment: InputsCommitment::new(inputs.clone().map(|(_, output)| output)),
             milestone_index,
             milestone_timestamp,
             input_amount: 0,

--- a/bee-message/tests/payload.rs
+++ b/bee-message/tests/payload.rs
@@ -16,9 +16,7 @@ use bee_message::{
     unlock_block::{ReferenceUnlockBlock, SignatureUnlockBlock, UnlockBlock, UnlockBlocks},
 };
 use bee_test::rand::{
-    bytes::{rand_bytes, rand_bytes_array},
-    milestone::rand_milestone_id,
-    parents::rand_parents,
+    bytes::rand_bytes, milestone::rand_milestone_id, output::rand_inputs_commitment, parents::rand_parents,
 };
 use packable::PackableExt;
 
@@ -44,7 +42,7 @@ fn transaction() {
             .unwrap(),
     );
     let essence = TransactionEssence::Regular(
-        RegularTransactionEssence::builder(0, rand_bytes_array())
+        RegularTransactionEssence::builder(0, rand_inputs_commitment())
             .with_inputs(vec![input1, input2])
             .add_output(output)
             .finish()

--- a/bee-message/tests/transaction_essence.rs
+++ b/bee-message/tests/transaction_essence.rs
@@ -8,7 +8,7 @@ use bee_message::{
     payload::transaction::{RegularTransactionEssence, TransactionEssence, TransactionId},
     Error,
 };
-use bee_test::rand::bytes::rand_bytes_array;
+use bee_test::rand::output::rand_inputs_commitment;
 use packable::{error::UnpackError, PackableExt};
 
 const TRANSACTION_ID: &str = "0x52fdfc072182654f163f5f0f9a621d729566c74d10037c4d7bbb0407d1e2c649";
@@ -30,7 +30,7 @@ fn essence_kind() {
             .unwrap(),
     );
     let essence = TransactionEssence::Regular(
-        RegularTransactionEssence::builder(0, rand_bytes_array())
+        RegularTransactionEssence::builder(0, rand_inputs_commitment())
             .with_inputs(vec![input1, input2])
             .add_output(output)
             .finish()

--- a/bee-message/tests/transaction_payload.rs
+++ b/bee-message/tests/transaction_payload.rs
@@ -10,7 +10,7 @@ use bee_message::{
     unlock_block::{ReferenceUnlockBlock, SignatureUnlockBlock, UnlockBlock, UnlockBlocks},
     Error,
 };
-use bee_test::rand::bytes::rand_bytes_array;
+use bee_test::rand::output::rand_inputs_commitment;
 use packable::PackableExt;
 
 const TRANSACTION_ID: &str = "0x52fdfc072182654f163f5f0f9a621d729566c74d10037c4d7bbb0407d1e2c649";
@@ -42,7 +42,7 @@ fn builder_no_essence_too_few_unlock_blocks() {
             .unwrap(),
     );
     let essence = TransactionEssence::Regular(
-        RegularTransactionEssence::builder(0, rand_bytes_array())
+        RegularTransactionEssence::builder(0, rand_inputs_commitment())
             .with_inputs(vec![input1, input2])
             .add_output(output)
             .finish()
@@ -80,7 +80,7 @@ fn builder_no_essence_too_many_unlock_blocks() {
             .unwrap(),
     );
     let essence = TransactionEssence::Regular(
-        RegularTransactionEssence::builder(0, rand_bytes_array())
+        RegularTransactionEssence::builder(0, rand_inputs_commitment())
             .add_input(input1)
             .add_output(output)
             .finish()
@@ -120,7 +120,7 @@ fn pack_unpack_valid() {
             .unwrap(),
     );
     let essence = TransactionEssence::Regular(
-        RegularTransactionEssence::builder(0, rand_bytes_array())
+        RegularTransactionEssence::builder(0, rand_inputs_commitment())
             .with_inputs(vec![input1, input2])
             .add_output(output)
             .finish()
@@ -162,7 +162,7 @@ fn getters() {
             .unwrap(),
     );
     let essence = TransactionEssence::Regular(
-        RegularTransactionEssence::builder(0, rand_bytes_array())
+        RegularTransactionEssence::builder(0, rand_inputs_commitment())
             .with_inputs(vec![input1, input2])
             .add_output(output)
             .finish()

--- a/bee-message/tests/transaction_regular_essence.rs
+++ b/bee-message/tests/transaction_regular_essence.rs
@@ -15,6 +15,7 @@ use bee_message::{
 };
 use bee_test::rand::{
     bytes::rand_bytes_array,
+    output::rand_inputs_commitment,
     payload::{rand_tagged_data_payload, rand_treasury_transaction_payload},
 };
 use packable::bounded::TryIntoBoundedU16Error;
@@ -44,7 +45,7 @@ fn build_valid() {
             .unwrap(),
     );
 
-    let essence = RegularTransactionEssence::builder(0, rand_bytes_array())
+    let essence = RegularTransactionEssence::builder(0, rand_inputs_commitment())
         .with_inputs(vec![input1, input2])
         .add_output(output)
         .finish();
@@ -69,7 +70,7 @@ fn build_valid_with_payload() {
     );
     let payload = Payload::from(rand_tagged_data_payload());
 
-    let essence = RegularTransactionEssence::builder(0, rand_bytes_array())
+    let essence = RegularTransactionEssence::builder(0, rand_inputs_commitment())
         .with_inputs(vec![input1, input2])
         .add_output(output)
         .with_payload(payload)
@@ -94,7 +95,7 @@ fn build_valid_add_inputs_outputs() {
             .unwrap(),
     );
 
-    let essence = RegularTransactionEssence::builder(0, rand_bytes_array())
+    let essence = RegularTransactionEssence::builder(0, rand_inputs_commitment())
         .with_inputs(vec![input1, input2])
         .add_output(output)
         .finish();
@@ -119,7 +120,7 @@ fn build_invalid_payload_kind() {
     );
     let payload = rand_treasury_transaction_payload();
 
-    let essence = RegularTransactionEssence::builder(0, rand_bytes_array())
+    let essence = RegularTransactionEssence::builder(0, rand_inputs_commitment())
         .with_inputs(vec![input1, input2])
         .add_output(output)
         .with_payload(payload.into())
@@ -141,7 +142,7 @@ fn build_invalid_input_count_low() {
             .unwrap(),
     );
 
-    let essence = RegularTransactionEssence::builder(0, rand_bytes_array())
+    let essence = RegularTransactionEssence::builder(0, rand_inputs_commitment())
         .add_output(output)
         .finish();
 
@@ -166,7 +167,7 @@ fn build_invalid_input_count_high() {
             .unwrap(),
     );
 
-    let essence = RegularTransactionEssence::builder(0, rand_bytes_array())
+    let essence = RegularTransactionEssence::builder(0, rand_inputs_commitment())
         .with_inputs(vec![input; 129])
         .add_output(output)
         .finish();
@@ -182,7 +183,7 @@ fn build_invalid_output_count_low() {
     let txid = TransactionId::new(prefix_hex::decode(TRANSACTION_ID).unwrap());
     let input = Input::Utxo(UtxoInput::new(txid, 0).unwrap());
 
-    let essence = RegularTransactionEssence::builder(0, rand_bytes_array())
+    let essence = RegularTransactionEssence::builder(0, rand_inputs_commitment())
         .add_input(input)
         .finish();
 
@@ -207,7 +208,7 @@ fn build_invalid_output_count_high() {
             .unwrap(),
     );
 
-    let essence = RegularTransactionEssence::builder(0, rand_bytes_array())
+    let essence = RegularTransactionEssence::builder(0, rand_inputs_commitment())
         .add_input(input)
         .with_outputs(vec![output; 129])
         .finish();
@@ -233,7 +234,7 @@ fn build_invalid_duplicate_utxo() {
             .unwrap(),
     );
 
-    let essence = RegularTransactionEssence::builder(0, rand_bytes_array())
+    let essence = RegularTransactionEssence::builder(0, rand_inputs_commitment())
         .with_inputs(vec![input; 2])
         .add_output(output)
         .finish();
@@ -255,7 +256,7 @@ fn build_invalid_input_kind() {
             .unwrap(),
     );
 
-    let essence = RegularTransactionEssence::builder(0, rand_bytes_array())
+    let essence = RegularTransactionEssence::builder(0, rand_inputs_commitment())
         .add_input(input)
         .add_output(output)
         .finish();
@@ -270,7 +271,7 @@ fn build_invalid_output_kind() {
     let amount = 1_000_000;
     let output = Output::Treasury(TreasuryOutput::new(amount).unwrap());
 
-    let essence = RegularTransactionEssence::builder(0, rand_bytes_array())
+    let essence = RegularTransactionEssence::builder(0, rand_inputs_commitment())
         .add_input(input)
         .add_output(output)
         .finish();
@@ -305,7 +306,7 @@ fn build_invalid_accumulated_output() {
             .unwrap(),
     );
 
-    let essence = RegularTransactionEssence::builder(0, rand_bytes_array())
+    let essence = RegularTransactionEssence::builder(0, rand_inputs_commitment())
         .add_input(input)
         .with_outputs(vec![output1, output2])
         .finish();
@@ -330,7 +331,7 @@ fn getters() {
     )];
     let payload = Payload::from(rand_tagged_data_payload());
 
-    let essence = RegularTransactionEssence::builder(0, rand_bytes_array())
+    let essence = RegularTransactionEssence::builder(0, rand_inputs_commitment())
         .with_inputs(vec![input1, input2])
         .with_outputs(outputs.clone())
         .with_payload(payload.clone())

--- a/bee-test/src/rand/output.rs
+++ b/bee-test/src/rand/output.rs
@@ -1,6 +1,18 @@
 // Copyright 2020-2021 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
+/// Module providing random feature block generation utilities.
+pub mod feature_block;
+/// Module providing random unlock condition generation utilities.
+pub mod unlock_condition;
+
+use bee_ledger::types::{ConsumedOutput, CreatedOutput, TreasuryOutput, Unspent};
+use bee_message::output::{
+    self, unlock_condition::ImmutableAliasAddressUnlockCondition, InputsCommitment, Output, OutputId,
+    SimpleTokenScheme, TokenScheme, TokenTag, OUTPUT_INDEX_RANGE,
+};
+use primitive_types::U256;
+
 use crate::rand::{
     address::rand_alias_address,
     bytes::rand_bytes_array,
@@ -17,18 +29,6 @@ use crate::rand::{
     },
     transaction::rand_transaction_id,
 };
-
-/// Module providing random feature block generation utilities.
-pub mod feature_block;
-/// Module providing random unlock condition generation utilities.
-pub mod unlock_condition;
-
-use bee_ledger::types::{ConsumedOutput, CreatedOutput, TreasuryOutput, Unspent};
-use bee_message::output::{
-    self, unlock_condition::ImmutableAliasAddressUnlockCondition, Output, OutputId, SimpleTokenScheme, TokenScheme,
-    TokenTag, OUTPUT_INDEX_RANGE,
-};
-use primitive_types::U256;
 
 /// Generates a random [`OutputId`].
 pub fn rand_output_id() -> OutputId {
@@ -139,4 +139,9 @@ pub fn rand_consumed_output() -> ConsumedOutput {
 /// Generates a random [`CreatedOutput`].
 pub fn rand_created_output() -> CreatedOutput {
     CreatedOutput::new(rand_message_id(), rand_milestone_index(), rand_number(), rand_output())
+}
+
+/// Generates a random [`InputsCommitment`].
+pub fn rand_inputs_commitment() -> InputsCommitment {
+    InputsCommitment::from(rand_bytes_array())
 }


### PR DESCRIPTION
Provides better display like `InputsCommitment(0xc5a8cf6c58614b5ccf58acd2f81abf65a7bc93ee169149b9554430163fb18d0f)` instead of `inputs_commitment: [184, 239, 13, 189, 56, 223, 81, 140, 74, 164, 63, 132, 215, 106, 14, 35, 250, 161, 250, 207, 182, 160, 37, 79, 112, 166, 175, 56, 100, 237, 133, 54]`.

## Change checklist

<!-- Tick the boxes that are relevant to your changes, and delete any items that are not. -->

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that new and existing unit tests pass locally with my changes
- [x] I have updated the CHANGELOG.md, if my changes are significant enough
