### PR TITLE
Update iota-crypto dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2068,9 +2068,9 @@ dependencies = [
 
 [[package]]
 name = "iota-crypto"
-version = "0.9.2"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13a3db4f13f4324788e4b870fdd264895a558cb523a851a9dd77bcfa43750b24"
+checksum = "1689fd8524d3516d499a94267f593ba9c984e31762a278ef66ce60d6621d16ff"
 dependencies = [
  "bee-ternary 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "blake2",

--- a/bee-api/bee-rest-api/CHANGELOG.md
+++ b/bee-api/bee-rest-api/CHANGELOG.md
@@ -19,6 +19,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Security -->
 
+<!-- ## 0.4.0 - 2022-XX-XX
+
+### Changed
+
+- Update dependencies; -->
+
 ## 0.3.0 - 2022-04-26
 
 ### Added
@@ -46,7 +52,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- Bump deps: 
+- Bump deps:
   + `bee-gossip` ~> 0.6.0;
   + `bee-protocol` ~> 0.2.2;
 

--- a/bee-api/bee-rest-api/Cargo.toml
+++ b/bee-api/bee-rest-api/Cargo.toml
@@ -64,11 +64,11 @@ endpoints = [
   "warp",
 ]
 peer = [ "bee-protocol" ]
-trace = [ 
-  "bee-common/trace", 
-  "bee-gossip/trace", 
-  "bee-protocol/trace", 
-  "bee-tangle/trace", 
-  "trace-tools/tokio-console", 
+trace = [
+  "bee-common/trace",
+  "bee-gossip/trace",
+  "bee-protocol/trace",
+  "bee-tangle/trace",
+  "trace-tools/tokio-console",
   "tracing",
 ]

--- a/bee-api/bee-rest-api/Cargo.toml
+++ b/bee-api/bee-rest-api/Cargo.toml
@@ -29,7 +29,7 @@ bech32 = { version = "0.8.1", default-features = false, optional = true }
 digest = { version = "0.9.0", default-features = false, optional = true }
 futures = { version = "0.3.17", default-features = false, optional = true }
 hex = { version = "0.4.3", default-features = false }
-iota-crypto = { version = "0.9.1", default-features = false, features = [ "blake2b" ], optional = true }
+iota-crypto = { version = "0.10.0", default-features = false, features = [ "blake2b" ], optional = true }
 lazy_static = {version = "1.4.0", default-features = false }
 log = { version = "0.4.14", default-features = false, optional = true }
 multiaddr = { version = "0.13.0", default-features = false }

--- a/bee-ledger/CHANGELOG.md
+++ b/bee-ledger/CHANGELOG.md
@@ -19,6 +19,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Security -->
 
+<!-- ## 0.8.0 - 2022-XX-XX
+
+### Changed
+
+- Update dependencies; -->
+
 ## 0.7.0 - 2022-04-26
 
 ### Changed

--- a/bee-ledger/Cargo.toml
+++ b/bee-ledger/Cargo.toml
@@ -23,7 +23,7 @@ digest = { version = "0.9.0", default-features = false, optional = true }
 futures = { version = "0.3.17", default-features = false, optional = true }
 hashbrown = { version = "0.11.2", default-features = false, optional = true }
 hex = { version = "0.4.3", default-features = false, optional = true }
-iota-crypto = { version = "0.9.1", default-features = false, features = [ "blake2b" ], optional = true }
+iota-crypto = { version = "0.10.0", default-features = false, features = [ "blake2b" ], optional = true }
 log = { version = "0.4.14", default-features = false, optional = true }
 ref-cast = { version = "1.0.6", default-features = false, optional = true }
 reqwest = { version = "0.11.5", default-features = false, features = [ "default-tls", "stream" ], optional = true }

--- a/bee-message/CHANGELOG.md
+++ b/bee-message/CHANGELOG.md
@@ -21,6 +21,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Security -->
 
+<!-- ## 0.3.0 - 2022-XX-XX
+
+### Changed
+
+- Update dependencies; -->
+
 ## 0.2.0 - 2022-04-26
 
 ### Changed

--- a/bee-message/Cargo.toml
+++ b/bee-message/Cargo.toml
@@ -19,7 +19,7 @@ bech32 = { version = "0.8.1", default-features = false }
 bytemuck = { version = "1.7.2", default-features = false }
 digest = { version = "0.9.0", default-features = false }
 hex = { version = "0.4.3", default-features = false }
-iota-crypto = { version = "0.9.2", default-features = false, features = [ "ed25519", "blake2b" ] }
+iota-crypto = { version = "0.10.0", default-features = false, features = [ "ed25519", "blake2b" ] }
 iterator-sorted = { version = "0.1.0", default-features = false }
 serde = { version = "1.0.130", default-features = false, features = [ "alloc" ], optional = true }
 thiserror = { version = "1.0.30", default-features = false }

--- a/bee-network/bee-autopeering/CHANGELOG.md
+++ b/bee-network/bee-autopeering/CHANGELOG.md
@@ -19,6 +19,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Security -->
 
+<!-- ## 0.6.0 - 2022-XX-XX
+
+### Changed
+
+- Update dependencies; -->
+
 ## 0.5.0 - 2022-03-07
 
 ### Changed

--- a/bee-network/bee-autopeering/Cargo.toml
+++ b/bee-network/bee-autopeering/Cargo.toml
@@ -20,7 +20,7 @@ bs58 = { version = "0.4", default-features = false, features = [ "alloc" ] }
 bytes = { version = "1.0", default-features = false }
 hash32 = { version = "0.2.1", default-features = false }
 hex = { version = "0.4.3", default-features = false }
-iota-crypto = { version = "0.9.1", default-features = false, features = [ "ed25519", "random", "sha" ] }
+iota-crypto = { version = "0.10.0", default-features = false, features = [ "ed25519", "random", "sha" ] }
 libp2p-core = { version = "0.30.0", default-features = false }
 log = { version = "0.4", default-features = false }
 num = { version = "0.4.0", default-features = false }

--- a/bee-node/bee-node/Cargo.toml
+++ b/bee-node/bee-node/Cargo.toml
@@ -40,7 +40,7 @@ fern-logger = { version = "0.5.0", default-features = false }
 futures = { version = "0.3.17", default-features = false }
 fxhash = { version = "0.2.1", default-features = false }
 hex = { version = "0.4.3", default-features = false }
-iota-crypto = { version = "0.9.1", default-features = false, features = [ "ed25519", "random", "blake2b" ] }
+iota-crypto = { version = "0.10.0", default-features = false, features = [ "ed25519", "random", "blake2b" ] }
 log = { version = "0.4.14", default-features = false }
 multiaddr = { version = "0.13.0", default-features = false }
 rand = { version = "0.8.4", default-features = false }

--- a/bee-pow/CHANGELOG.md
+++ b/bee-pow/CHANGELOG.md
@@ -19,6 +19,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Security -->
 
+<!-- ## 0.4.0 - 2022-XX-XX
+
+### Changed
+
+- Update dependencies; -->
+
 ## 0.3.0 - 2022-04-26
 
 ### Changed

--- a/bee-pow/Cargo.toml
+++ b/bee-pow/Cargo.toml
@@ -13,7 +13,7 @@ homepage = "https://www.iota.org"
 [dependencies]
 bee-ternary = { version = "0.6.0", default-features = false }
 
-iota-crypto = { version = "0.9.2", default-features = false, features = [ "blake2b", "digest", "curl-p" ] }
+iota-crypto = { version = "0.10.0", default-features = false, features = [ "blake2b", "digest", "curl-p" ] }
 thiserror = { version = "1.0.30", default-features = false }
 trace-tools = { version = "0.3.0", default-features = false, optional = true }
 tracing = { version = "0.1.29", default-features = false, optional = true }


### PR DESCRIPTION
# Description of change

<!-- Please write a summary of your changes and why you made them. -->

Use `iota-crypto-0.10.0` in all crates.

#1255 is depending on this to pass Audit CI. 