### PR TITLE
Do access operations in `bee-storage` using an extension trait

### DIFF
--- a/bee-api/bee-rest-api/src/endpoints/routes/api/v1/messages_find.rs
+++ b/bee-api/bee-rest-api/src/endpoints/routes/api/v1/messages_find.rs
@@ -7,7 +7,7 @@ use bee_message::{
     payload::indexation::{IndexationPayload, PaddedIndex},
     MessageId,
 };
-use bee_storage::access::Fetch;
+use bee_storage::{backend::StorageBackendExt};
 use warp::{filters::BoxedFilter, reject, Filter, Rejection, Reply};
 
 use crate::{
@@ -46,7 +46,7 @@ pub(crate) fn messages_find<B: StorageBackend>(
         .map_err(|_| reject::custom(CustomRejection::BadRequest("Invalid index".to_owned())))?;
     let hashed_index = IndexationPayload::new(&index_bytes, &[]).unwrap().padded_index();
 
-    let all_message_ids = match Fetch::<PaddedIndex, Vec<MessageId>>::fetch(&*args.storage, &hashed_index) {
+    let all_message_ids = match args.storage.fetch_access::<PaddedIndex, Vec<MessageId>>(&hashed_index) {
         Ok(result) => match result {
             Some(ids) => ids,
             None => vec![],

--- a/bee-api/bee-rest-api/src/endpoints/routes/api/v1/messages_find.rs
+++ b/bee-api/bee-rest-api/src/endpoints/routes/api/v1/messages_find.rs
@@ -7,7 +7,7 @@ use bee_message::{
     payload::indexation::{IndexationPayload, PaddedIndex},
     MessageId,
 };
-use bee_storage::{backend::StorageBackendExt};
+use bee_storage::backend::StorageBackendExt;
 use warp::{filters::BoxedFilter, reject, Filter, Rejection, Reply};
 
 use crate::{
@@ -46,7 +46,7 @@ pub(crate) fn messages_find<B: StorageBackend>(
         .map_err(|_| reject::custom(CustomRejection::BadRequest("Invalid index".to_owned())))?;
     let hashed_index = IndexationPayload::new(&index_bytes, &[]).unwrap().padded_index();
 
-    let all_message_ids = match args.storage.fetch_access::<PaddedIndex, Vec<MessageId>>(&hashed_index) {
+    let all_message_ids = match args.storage.fetch::<PaddedIndex, Vec<MessageId>>(&hashed_index) {
         Ok(result) => match result {
             Some(ids) => ids,
             None => vec![],

--- a/bee-api/bee-rest-api/src/endpoints/routes/api/v1/milestone_utxo_changes.rs
+++ b/bee-api/bee-rest-api/src/endpoints/routes/api/v1/milestone_utxo_changes.rs
@@ -3,7 +3,7 @@
 
 use bee_ledger::types::OutputDiff;
 use bee_message::milestone::MilestoneIndex;
-use bee_storage::{backend::StorageBackendExt};
+use bee_storage::backend::StorageBackendExt;
 use warp::{filters::BoxedFilter, reject, Filter, Rejection, Reply};
 
 use crate::{
@@ -36,7 +36,7 @@ pub(crate) fn milestone_utxo_changes<B: StorageBackend>(
 ) -> Result<impl Reply, Rejection> {
     let fetched = args
         .storage
-        .fetch_access::<MilestoneIndex, OutputDiff>(&index)
+        .fetch::<MilestoneIndex, OutputDiff>(&index)
         .map_err(|_| {
             reject::custom(CustomRejection::ServiceUnavailable(
                 "can not fetch from storage".to_string(),

--- a/bee-api/bee-rest-api/src/endpoints/routes/api/v1/milestone_utxo_changes.rs
+++ b/bee-api/bee-rest-api/src/endpoints/routes/api/v1/milestone_utxo_changes.rs
@@ -3,7 +3,7 @@
 
 use bee_ledger::types::OutputDiff;
 use bee_message::milestone::MilestoneIndex;
-use bee_storage::access::Fetch;
+use bee_storage::{backend::StorageBackendExt};
 use warp::{filters::BoxedFilter, reject, Filter, Rejection, Reply};
 
 use crate::{
@@ -34,7 +34,9 @@ pub(crate) fn milestone_utxo_changes<B: StorageBackend>(
     index: MilestoneIndex,
     args: ApiArgsFullNode<B>,
 ) -> Result<impl Reply, Rejection> {
-    let fetched = Fetch::<MilestoneIndex, OutputDiff>::fetch(&*args.storage, &index)
+    let fetched = args
+        .storage
+        .fetch_access::<MilestoneIndex, OutputDiff>(&index)
         .map_err(|_| {
             reject::custom(CustomRejection::ServiceUnavailable(
                 "can not fetch from storage".to_string(),

--- a/bee-api/bee-rest-api/src/endpoints/routes/api/v1/output.rs
+++ b/bee-api/bee-rest-api/src/endpoints/routes/api/v1/output.rs
@@ -6,7 +6,7 @@ use bee_ledger::{
     workers::{consensus::ConsensusWorkerCommand, error::Error},
 };
 use bee_message::output::OutputId;
-use bee_storage::{backend::StorageBackendExt};
+use bee_storage::backend::StorageBackendExt;
 use futures::channel::oneshot;
 use log::error;
 use warp::{filters::BoxedFilter, reject, Filter, Rejection, Reply};
@@ -55,7 +55,7 @@ pub(crate) async fn output<B: StorageBackend>(
     })? {
         (Ok(response), ledger_index) => match response {
             Some(output) => {
-                let consumed_output = match args.storage.fetch_access::<OutputId, ConsumedOutput>(&output_id) {
+                let consumed_output = match args.storage.fetch::<OutputId, ConsumedOutput>(&output_id) {
                     Err(e) => {
                         error!("unable to fetch the output: {}", e);
                         return Err(reject::custom(CustomRejection::ServiceUnavailable(

--- a/bee-api/bee-rest-api/src/endpoints/routes/api/v1/output.rs
+++ b/bee-api/bee-rest-api/src/endpoints/routes/api/v1/output.rs
@@ -6,7 +6,7 @@ use bee_ledger::{
     workers::{consensus::ConsensusWorkerCommand, error::Error},
 };
 use bee_message::output::OutputId;
-use bee_storage::access::Fetch;
+use bee_storage::{backend::StorageBackendExt};
 use futures::channel::oneshot;
 use log::error;
 use warp::{filters::BoxedFilter, reject, Filter, Rejection, Reply};
@@ -55,7 +55,7 @@ pub(crate) async fn output<B: StorageBackend>(
     })? {
         (Ok(response), ledger_index) => match response {
             Some(output) => {
-                let consumed_output = match Fetch::<OutputId, ConsumedOutput>::fetch(&*args.storage, &output_id) {
+                let consumed_output = match args.storage.fetch_access::<OutputId, ConsumedOutput>(&output_id) {
                     Err(e) => {
                         error!("unable to fetch the output: {}", e);
                         return Err(reject::custom(CustomRejection::ServiceUnavailable(

--- a/bee-api/bee-rest-api/src/endpoints/routes/api/v1/receipts.rs
+++ b/bee-api/bee-rest-api/src/endpoints/routes/api/v1/receipts.rs
@@ -3,7 +3,7 @@
 
 use bee_ledger::types::Receipt;
 use bee_message::milestone::MilestoneIndex;
-use bee_storage::access::AsIterator;
+use bee_storage::backend::StorageBackendExt;
 use warp::{filters::BoxedFilter, Filter, Rejection, Reply};
 
 use crate::{
@@ -25,7 +25,9 @@ pub(crate) fn filter<B: StorageBackend>(args: ApiArgsFullNode<B>) -> BoxedFilter
 
 pub(crate) fn receipts<B: StorageBackend>(args: ApiArgsFullNode<B>) -> Result<impl Reply, Rejection> {
     let mut receipts_dto = Vec::new();
-    let iterator = AsIterator::<(MilestoneIndex, Receipt), ()>::iter_op(&*args.storage)
+    let iterator = args
+        .storage
+        .iter::<(MilestoneIndex, Receipt), ()>()
         .map_err(|_| CustomRejection::InternalError)?;
 
     for result in iterator {

--- a/bee-api/bee-rest-api/src/endpoints/routes/api/v1/receipts.rs
+++ b/bee-api/bee-rest-api/src/endpoints/routes/api/v1/receipts.rs
@@ -25,7 +25,7 @@ pub(crate) fn filter<B: StorageBackend>(args: ApiArgsFullNode<B>) -> BoxedFilter
 
 pub(crate) fn receipts<B: StorageBackend>(args: ApiArgsFullNode<B>) -> Result<impl Reply, Rejection> {
     let mut receipts_dto = Vec::new();
-    let iterator = AsIterator::<(MilestoneIndex, Receipt), ()>::iter(&*args.storage)
+    let iterator = AsIterator::<(MilestoneIndex, Receipt), ()>::iter_op(&*args.storage)
         .map_err(|_| CustomRejection::InternalError)?;
 
     for result in iterator {

--- a/bee-api/bee-rest-api/src/endpoints/routes/api/v1/receipts_at.rs
+++ b/bee-api/bee-rest-api/src/endpoints/routes/api/v1/receipts_at.rs
@@ -3,7 +3,7 @@
 
 use bee_ledger::types::Receipt;
 use bee_message::milestone::MilestoneIndex;
-use bee_storage::{backend::StorageBackendExt};
+use bee_storage::backend::StorageBackendExt;
 use warp::{filters::BoxedFilter, Filter, Rejection, Reply};
 
 use crate::{
@@ -37,7 +37,7 @@ pub(crate) fn receipts_at<B: StorageBackend>(
 
     if let Some(receipts) = args
         .storage
-        .fetch_access::<MilestoneIndex, Vec<Receipt>>(&milestone_index)
+        .fetch::<MilestoneIndex, Vec<Receipt>>(&milestone_index)
         .map_err(|_| CustomRejection::InternalError)?
     {
         for receipt in receipts {

--- a/bee-api/bee-rest-api/src/endpoints/routes/api/v1/receipts_at.rs
+++ b/bee-api/bee-rest-api/src/endpoints/routes/api/v1/receipts_at.rs
@@ -3,7 +3,7 @@
 
 use bee_ledger::types::Receipt;
 use bee_message::milestone::MilestoneIndex;
-use bee_storage::access::Fetch;
+use bee_storage::{backend::StorageBackendExt};
 use warp::{filters::BoxedFilter, Filter, Rejection, Reply};
 
 use crate::{
@@ -35,7 +35,9 @@ pub(crate) fn receipts_at<B: StorageBackend>(
 ) -> Result<impl Reply, Rejection> {
     let mut receipts_dto = Vec::new();
 
-    if let Some(receipts) = Fetch::<MilestoneIndex, Vec<Receipt>>::fetch(&*args.storage, &milestone_index)
+    if let Some(receipts) = args
+        .storage
+        .fetch_access::<MilestoneIndex, Vec<Receipt>>(&milestone_index)
         .map_err(|_| CustomRejection::InternalError)?
     {
         for receipt in receipts {

--- a/bee-api/bee-rest-api/src/endpoints/routes/api/v1/transaction_included_message.rs
+++ b/bee-api/bee-rest-api/src/endpoints/routes/api/v1/transaction_included_message.rs
@@ -3,7 +3,7 @@
 
 use bee_ledger::types::CreatedOutput;
 use bee_message::{output::OutputId, payload::transaction::TransactionId};
-use bee_storage::access::Fetch;
+use bee_storage::{backend::StorageBackendExt};
 use warp::{filters::BoxedFilter, reject, Filter, Rejection, Reply};
 
 use crate::endpoints::{
@@ -34,11 +34,14 @@ pub(crate) fn transaction_included_message<B: StorageBackend>(
     // Safe to unwrap since 0 is a valid index;
     let output_id = OutputId::new(transaction_id, 0).unwrap();
 
-    match Fetch::<OutputId, CreatedOutput>::fetch(&*args.storage, &output_id).map_err(|_| {
-        reject::custom(CustomRejection::ServiceUnavailable(
-            "Can not fetch from storage".to_string(),
-        ))
-    })? {
+    match args
+        .storage
+        .fetch_access::<OutputId, CreatedOutput>(&output_id)
+        .map_err(|_| {
+            reject::custom(CustomRejection::ServiceUnavailable(
+                "Can not fetch from storage".to_string(),
+            ))
+        })? {
         Some(output) => message::message(*output.message_id(), args),
         None => Err(reject::custom(CustomRejection::NotFound(
             "Can not find output".to_string(),

--- a/bee-api/bee-rest-api/src/endpoints/routes/api/v1/transaction_included_message.rs
+++ b/bee-api/bee-rest-api/src/endpoints/routes/api/v1/transaction_included_message.rs
@@ -3,7 +3,7 @@
 
 use bee_ledger::types::CreatedOutput;
 use bee_message::{output::OutputId, payload::transaction::TransactionId};
-use bee_storage::{backend::StorageBackendExt};
+use bee_storage::backend::StorageBackendExt;
 use warp::{filters::BoxedFilter, reject, Filter, Rejection, Reply};
 
 use crate::endpoints::{
@@ -34,14 +34,11 @@ pub(crate) fn transaction_included_message<B: StorageBackend>(
     // Safe to unwrap since 0 is a valid index;
     let output_id = OutputId::new(transaction_id, 0).unwrap();
 
-    match args
-        .storage
-        .fetch_access::<OutputId, CreatedOutput>(&output_id)
-        .map_err(|_| {
-            reject::custom(CustomRejection::ServiceUnavailable(
-                "Can not fetch from storage".to_string(),
-            ))
-        })? {
+    match args.storage.fetch::<OutputId, CreatedOutput>(&output_id).map_err(|_| {
+        reject::custom(CustomRejection::ServiceUnavailable(
+            "Can not fetch from storage".to_string(),
+        ))
+    })? {
         Some(output) => message::message(*output.message_id(), args),
         None => Err(reject::custom(CustomRejection::NotFound(
             "Can not find output".to_string(),

--- a/bee-ledger/src/workers/consensus/state.rs
+++ b/bee-ledger/src/workers/consensus/state.rs
@@ -17,7 +17,7 @@ use crate::{
 };
 
 fn validate_ledger_unspent_state<B: StorageBackend>(storage: &B, treasury: u64) -> Result<(), Error> {
-    let iterator = AsIterator::<Unspent, ()>::iter(storage).map_err(|e| Error::Storage(Box::new(e)))?;
+    let iterator = AsIterator::<Unspent, ()>::iter_op(storage).map_err(|e| Error::Storage(Box::new(e)))?;
     let mut supply: u64 = 0;
 
     for result in iterator {
@@ -47,7 +47,7 @@ fn validate_ledger_unspent_state<B: StorageBackend>(storage: &B, treasury: u64) 
 }
 
 fn validate_ledger_balance_state<B: StorageBackend>(storage: &B, treasury: u64) -> Result<(), Error> {
-    let iterator = AsIterator::<Address, Balance>::iter(storage).map_err(|e| Error::Storage(Box::new(e)))?;
+    let iterator = AsIterator::<Address, Balance>::iter_op(storage).map_err(|e| Error::Storage(Box::new(e)))?;
     let mut supply: u64 = 0;
 
     for result in iterator {

--- a/bee-ledger/src/workers/consensus/state.rs
+++ b/bee-ledger/src/workers/consensus/state.rs
@@ -6,7 +6,7 @@ use bee_message::{
     constants::IOTA_SUPPLY,
     output::{self, dust_outputs_max},
 };
-use bee_storage::access::AsIterator;
+use bee_storage::backend::StorageBackendExt;
 
 use crate::{
     types::{Balance, Unspent},
@@ -17,7 +17,7 @@ use crate::{
 };
 
 fn validate_ledger_unspent_state<B: StorageBackend>(storage: &B, treasury: u64) -> Result<(), Error> {
-    let iterator = AsIterator::<Unspent, ()>::iter_op(storage).map_err(|e| Error::Storage(Box::new(e)))?;
+    let iterator = storage.iter::<Unspent, ()>().map_err(|e| Error::Storage(Box::new(e)))?;
     let mut supply: u64 = 0;
 
     for result in iterator {
@@ -47,7 +47,9 @@ fn validate_ledger_unspent_state<B: StorageBackend>(storage: &B, treasury: u64) 
 }
 
 fn validate_ledger_balance_state<B: StorageBackend>(storage: &B, treasury: u64) -> Result<(), Error> {
-    let iterator = AsIterator::<Address, Balance>::iter_op(storage).map_err(|e| Error::Storage(Box::new(e)))?;
+    let iterator = storage
+        .iter::<Address, Balance>()
+        .map_err(|e| Error::Storage(Box::new(e)))?;
     let mut supply: u64 = 0;
 
     for result in iterator {

--- a/bee-ledger/src/workers/pruning/batch.rs
+++ b/bee-ledger/src/workers/pruning/batch.rs
@@ -286,7 +286,7 @@ pub fn batch_prunable_unconfirmed_data<S: StorageBackend>(
             }
         }
 
-        Batch::<(MilestoneIndex, UnreferencedMessage), ()>::batch_delete(
+        Batch::<(MilestoneIndex, UnreferencedMessage), ()>::batch_delete_op(
             storage,
             batch,
             &(prune_index, (*unconf_msg_id).into()),
@@ -323,8 +323,9 @@ fn prune_message_and_metadata<S: StorageBackend>(
     batch: &mut S::Batch,
     message_id: &MessageId,
 ) -> Result<(), Error> {
-    Batch::<MessageId, Message>::batch_delete(storage, batch, message_id).map_err(|e| Error::Storage(Box::new(e)))?;
-    Batch::<MessageId, MessageMetadata>::batch_delete(storage, batch, message_id)
+    Batch::<MessageId, Message>::batch_delete_op(storage, batch, message_id)
+        .map_err(|e| Error::Storage(Box::new(e)))?;
+    Batch::<MessageId, MessageMetadata>::batch_delete_op(storage, batch, message_id)
         .map_err(|e| Error::Storage(Box::new(e)))?;
 
     Ok(())
@@ -335,7 +336,8 @@ fn prune_edge<S: StorageBackend>(
     batch: &mut S::Batch,
     edge: &(MessageId, MessageId),
 ) -> Result<(), Error> {
-    Batch::<(MessageId, MessageId), ()>::batch_delete(storage, batch, edge).map_err(|e| Error::Storage(Box::new(e)))?;
+    Batch::<(MessageId, MessageId), ()>::batch_delete_op(storage, batch, edge)
+        .map_err(|e| Error::Storage(Box::new(e)))?;
 
     Ok(())
 }
@@ -345,14 +347,14 @@ fn prune_indexation_data<S: StorageBackend>(
     batch: &mut S::Batch,
     index_message_id: &(PaddedIndex, MessageId),
 ) -> Result<(), Error> {
-    Batch::<(PaddedIndex, MessageId), ()>::batch_delete(storage, batch, index_message_id)
+    Batch::<(PaddedIndex, MessageId), ()>::batch_delete_op(storage, batch, index_message_id)
         .map_err(|e| Error::Storage(Box::new(e)))?;
 
     Ok(())
 }
 
 fn prune_milestone<S: StorageBackend>(storage: &S, batch: &mut S::Batch, index: MilestoneIndex) -> Result<(), Error> {
-    Batch::<MilestoneIndex, Milestone>::batch_delete(storage, batch, &index)
+    Batch::<MilestoneIndex, Milestone>::batch_delete_op(storage, batch, &index)
         .map_err(|e| Error::Storage(Box::new(e)))?;
 
     Ok(())
@@ -364,9 +366,9 @@ fn prune_output_diff<S: StorageBackend>(storage: &S, batch: &mut S::Batch, index
         .map_err(|e| Error::Storage(Box::new(e)))?
     {
         for consumed_output in output_diff.consumed_outputs() {
-            Batch::<OutputId, ConsumedOutput>::batch_delete(storage, batch, consumed_output)
+            Batch::<OutputId, ConsumedOutput>::batch_delete_op(storage, batch, consumed_output)
                 .map_err(|e| Error::Storage(Box::new(e)))?;
-            Batch::<OutputId, CreatedOutput>::batch_delete(storage, batch, consumed_output)
+            Batch::<OutputId, CreatedOutput>::batch_delete_op(storage, batch, consumed_output)
                 .map_err(|e| Error::Storage(Box::new(e)))?;
         }
 
@@ -375,7 +377,7 @@ fn prune_output_diff<S: StorageBackend>(storage: &S, batch: &mut S::Batch, index
         }
     }
 
-    Batch::<MilestoneIndex, OutputDiff>::batch_delete(storage, batch, &index)
+    Batch::<MilestoneIndex, OutputDiff>::batch_delete_op(storage, batch, &index)
         .map_err(|e| Error::Storage(Box::new(e)))?;
 
     Ok(())
@@ -390,7 +392,7 @@ fn prune_receipts<S: StorageBackend>(storage: &S, batch: &mut S::Batch, index: M
 
     let mut num = 0;
     for receipt in receipts.into_iter() {
-        Batch::<(MilestoneIndex, Receipt), ()>::batch_delete(storage, batch, &(index, receipt))
+        Batch::<(MilestoneIndex, Receipt), ()>::batch_delete_op(storage, batch, &(index, receipt))
             .map_err(|e| Error::Storage(Box::new(e)))?;
 
         num += 1;
@@ -424,7 +426,7 @@ fn unwrap_indexation(payload: Option<&Payload>) -> Option<&IndexationPayload> {
 fn prune_seps<S: StorageBackend>(storage: &S, batch: &mut S::Batch, seps: &[SolidEntryPoint]) -> Result<usize, Error> {
     let mut num = 0;
     for sep in seps {
-        Batch::<SolidEntryPoint, MilestoneIndex>::batch_delete(storage, batch, sep)
+        Batch::<SolidEntryPoint, MilestoneIndex>::batch_delete_op(storage, batch, sep)
             .map_err(|e| Error::Storage(Box::new(e)))?;
 
         num += 1;

--- a/bee-ledger/src/workers/pruning/prune.rs
+++ b/bee-ledger/src/workers/pruning/prune.rs
@@ -116,7 +116,7 @@ pub async fn prune<S: StorageBackend>(
         let batch_new_seps = Instant::now();
         for (new_sep, index) in &new_seps {
             storage
-                .batch_insert::<SolidEntryPoint, MilestoneIndex>(&mut batch, new_sep, index)
+                .batch_insert(&mut batch, new_sep, index)
                 .map_err(|e| Error::Storage(Box::new(e)))?;
         }
         timings.batch_new_seps = batch_new_seps.elapsed();

--- a/bee-ledger/src/workers/pruning/prune.rs
+++ b/bee-ledger/src/workers/pruning/prune.rs
@@ -8,7 +8,7 @@ use std::{
 
 use bee_message::milestone::MilestoneIndex;
 use bee_runtime::event::Bus;
-use bee_storage::{access::Truncate, backend::StorageBackendExt};
+use bee_storage::backend::StorageBackendExt;
 use bee_tangle::{solid_entry_point::SolidEntryPoint, Tangle};
 use log::{debug, info};
 
@@ -151,7 +151,8 @@ pub async fn prune<S: StorageBackend>(
         // TODO: consider batching deletes rather than using Truncate. Is one faster than the other? Do we care if its
         // atomic or not?
         let truncate_old_seps = Instant::now();
-        Truncate::<SolidEntryPoint, MilestoneIndex>::truncate_op(storage)
+        storage
+            .truncate::<SolidEntryPoint, MilestoneIndex>()
             .expect("truncating solid entry points failed");
         timings.truncate_curr_seps = truncate_old_seps.elapsed();
 

--- a/bee-ledger/src/workers/pruning/prune.rs
+++ b/bee-ledger/src/workers/pruning/prune.rs
@@ -8,7 +8,7 @@ use std::{
 
 use bee_message::milestone::MilestoneIndex;
 use bee_runtime::event::Bus;
-use bee_storage::access::{Batch, Truncate};
+use bee_storage::{access::Truncate, backend::StorageBackendExt};
 use bee_tangle::{solid_entry_point::SolidEntryPoint, Tangle};
 use log::{debug, info};
 
@@ -115,7 +115,8 @@ pub async fn prune<S: StorageBackend>(
         // Write the new set of SEPs to the storage.
         let batch_new_seps = Instant::now();
         for (new_sep, index) in &new_seps {
-            Batch::<SolidEntryPoint, MilestoneIndex>::batch_insert_op(storage, &mut batch, new_sep, index)
+            storage
+                .batch_insert::<SolidEntryPoint, MilestoneIndex>(&mut batch, new_sep, index)
                 .map_err(|e| Error::Storage(Box::new(e)))?;
         }
         timings.batch_new_seps = batch_new_seps.elapsed();

--- a/bee-ledger/src/workers/pruning/prune.rs
+++ b/bee-ledger/src/workers/pruning/prune.rs
@@ -115,7 +115,7 @@ pub async fn prune<S: StorageBackend>(
         // Write the new set of SEPs to the storage.
         let batch_new_seps = Instant::now();
         for (new_sep, index) in &new_seps {
-            Batch::<SolidEntryPoint, MilestoneIndex>::batch_insert(storage, &mut batch, new_sep, index)
+            Batch::<SolidEntryPoint, MilestoneIndex>::batch_insert_op(storage, &mut batch, new_sep, index)
                 .map_err(|e| Error::Storage(Box::new(e)))?;
         }
         timings.batch_new_seps = batch_new_seps.elapsed();
@@ -150,7 +150,8 @@ pub async fn prune<S: StorageBackend>(
         // TODO: consider batching deletes rather than using Truncate. Is one faster than the other? Do we care if its
         // atomic or not?
         let truncate_old_seps = Instant::now();
-        Truncate::<SolidEntryPoint, MilestoneIndex>::truncate(storage).expect("truncating solid entry points failed");
+        Truncate::<SolidEntryPoint, MilestoneIndex>::truncate_op(storage)
+            .expect("truncating solid entry points failed");
         timings.truncate_curr_seps = truncate_old_seps.elapsed();
 
         // Execute the batch operation.

--- a/bee-ledger/src/workers/snapshot/import.rs
+++ b/bee-ledger/src/workers/snapshot/import.rs
@@ -50,9 +50,9 @@ fn import_solid_entry_points<R: Read, B: StorageBackend>(
     sep_count: u64,
     index: MilestoneIndex,
 ) -> Result<(), Error> {
-    Truncate::<SolidEntryPoint, MilestoneIndex>::truncate(storage).map_err(|e| Error::Storage(Box::new(e)))?;
+    Truncate::<SolidEntryPoint, MilestoneIndex>::truncate_op(storage).map_err(|e| Error::Storage(Box::new(e)))?;
     for _ in 0..sep_count {
-        Insert::<SolidEntryPoint, MilestoneIndex>::insert(&*storage, &SolidEntryPoint::unpack(reader)?, &index)
+        Insert::<SolidEntryPoint, MilestoneIndex>::insert_op(&*storage, &SolidEntryPoint::unpack(reader)?, &index)
             .map_err(|e| Error::Storage(Box::new(e)))?;
     }
 

--- a/bee-ledger/src/workers/snapshot/import.rs
+++ b/bee-ledger/src/workers/snapshot/import.rs
@@ -15,7 +15,7 @@ use bee_message::{
     payload::Payload,
     MessageId,
 };
-use bee_storage::access::{Insert, Truncate};
+use bee_storage::{access::Truncate, backend::StorageBackendExt};
 use bee_tangle::solid_entry_point::SolidEntryPoint;
 use log::info;
 use time_helper as time;
@@ -52,7 +52,8 @@ fn import_solid_entry_points<R: Read, B: StorageBackend>(
 ) -> Result<(), Error> {
     Truncate::<SolidEntryPoint, MilestoneIndex>::truncate_op(storage).map_err(|e| Error::Storage(Box::new(e)))?;
     for _ in 0..sep_count {
-        Insert::<SolidEntryPoint, MilestoneIndex>::insert_op(&*storage, &SolidEntryPoint::unpack(reader)?, &index)
+        storage
+            .insert::<SolidEntryPoint, MilestoneIndex>(&SolidEntryPoint::unpack(reader)?, &index)
             .map_err(|e| Error::Storage(Box::new(e)))?;
     }
 

--- a/bee-ledger/src/workers/snapshot/import.rs
+++ b/bee-ledger/src/workers/snapshot/import.rs
@@ -55,7 +55,7 @@ fn import_solid_entry_points<R: Read, B: StorageBackend>(
         .map_err(|e| Error::Storage(Box::new(e)))?;
     for _ in 0..sep_count {
         storage
-            .insert::<SolidEntryPoint, MilestoneIndex>(&SolidEntryPoint::unpack(reader)?, &index)
+            .insert(&SolidEntryPoint::unpack(reader)?, &index)
             .map_err(|e| Error::Storage(Box::new(e)))?;
     }
 

--- a/bee-ledger/src/workers/snapshot/import.rs
+++ b/bee-ledger/src/workers/snapshot/import.rs
@@ -15,7 +15,7 @@ use bee_message::{
     payload::Payload,
     MessageId,
 };
-use bee_storage::{access::Truncate, backend::StorageBackendExt};
+use bee_storage::backend::StorageBackendExt;
 use bee_tangle::solid_entry_point::SolidEntryPoint;
 use log::info;
 use time_helper as time;
@@ -50,7 +50,9 @@ fn import_solid_entry_points<R: Read, B: StorageBackend>(
     sep_count: u64,
     index: MilestoneIndex,
 ) -> Result<(), Error> {
-    Truncate::<SolidEntryPoint, MilestoneIndex>::truncate_op(storage).map_err(|e| Error::Storage(Box::new(e)))?;
+    storage
+        .truncate::<SolidEntryPoint, MilestoneIndex>()
+        .map_err(|e| Error::Storage(Box::new(e)))?;
     for _ in 0..sep_count {
         storage
             .insert::<SolidEntryPoint, MilestoneIndex>(&SolidEntryPoint::unpack(reader)?, &index)

--- a/bee-ledger/src/workers/snapshot/worker.rs
+++ b/bee-ledger/src/workers/snapshot/worker.rs
@@ -59,7 +59,7 @@ where
             return Err(e);
         }
 
-        let solid_entry_points = AsIterator::<SolidEntryPoint, MilestoneIndex>::iter(&*storage)
+        let solid_entry_points = AsIterator::<SolidEntryPoint, MilestoneIndex>::iter_op(&*storage)
             .map_err(|e| Error::Storage(Box::new(e)))?
             .map(|result| result.map_err(|e| Error::Storage(Box::new(e))))
             .collect::<Result<HashMap<SolidEntryPoint, MilestoneIndex>, _>>()?;

--- a/bee-ledger/src/workers/snapshot/worker.rs
+++ b/bee-ledger/src/workers/snapshot/worker.rs
@@ -6,7 +6,10 @@ use std::{any::TypeId, collections::HashMap};
 use async_trait::async_trait;
 use bee_message::milestone::MilestoneIndex;
 use bee_runtime::{node::Node, worker::Worker};
-use bee_storage::{access::AsIterator, backend::StorageBackend as _, system::StorageHealth};
+use bee_storage::{
+    backend::{StorageBackend as _, StorageBackendExt},
+    system::StorageHealth,
+};
 use bee_tangle::{solid_entry_point::SolidEntryPoint, Tangle, TangleWorker};
 use log::info;
 use time_helper as time;
@@ -59,7 +62,8 @@ where
             return Err(e);
         }
 
-        let solid_entry_points = AsIterator::<SolidEntryPoint, MilestoneIndex>::iter_op(&*storage)
+        let solid_entry_points = storage
+            .iter::<SolidEntryPoint, MilestoneIndex>()
             .map_err(|e| Error::Storage(Box::new(e)))?
             .map(|result| result.map_err(|e| Error::Storage(Box::new(e))))
             .collect::<Result<HashMap<SolidEntryPoint, MilestoneIndex>, _>>()?;

--- a/bee-ledger/src/workers/storage.rs
+++ b/bee-ledger/src/workers/storage.rs
@@ -346,7 +346,7 @@ pub(crate) fn rollback_milestone<B: StorageBackend>(
 #[cfg_attr(feature = "trace", trace_tools::observe)]
 pub(crate) fn fetch_balance<B: StorageBackend>(storage: &B, address: &Address) -> Result<Option<Balance>, Error> {
     storage
-        .fetch_access::<Address, Balance>(address)
+        .fetch::<Address, Balance>(address)
         .map_err(|e| Error::Storage(Box::new(e)))
 }
 
@@ -368,7 +368,7 @@ pub(crate) fn insert_ledger_index_batch<B: StorageBackend>(
 
 pub(crate) fn fetch_ledger_index<B: StorageBackend>(storage: &B) -> Result<Option<LedgerIndex>, Error> {
     storage
-        .fetch_access::<(), LedgerIndex>(&())
+        .fetch::<(), LedgerIndex>(&())
         .map_err(|e| Error::Storage(Box::new(e)))
 }
 
@@ -406,7 +406,7 @@ pub(crate) fn insert_snapshot_info<B: StorageBackend>(storage: &B, snapshot_info
 #[cfg_attr(feature = "trace", trace_tools::observe)]
 pub(crate) fn fetch_snapshot_info<B: StorageBackend>(storage: &B) -> Result<Option<SnapshotInfo>, Error> {
     storage
-        .fetch_access::<(), SnapshotInfo>(&())
+        .fetch::<(), SnapshotInfo>(&())
         .map_err(|e| Error::Storage(Box::new(e)))
 }
 
@@ -416,7 +416,7 @@ pub(crate) fn fetch_output<B: StorageBackend>(
     output_id: &OutputId,
 ) -> Result<Option<CreatedOutput>, Error> {
     storage
-        .fetch_access::<OutputId, CreatedOutput>(output_id)
+        .fetch::<OutputId, CreatedOutput>(output_id)
         .map_err(|e| Error::Storage(Box::new(e)))
 }
 
@@ -426,7 +426,7 @@ pub(crate) fn fetch_outputs_for_ed25519_address<B: StorageBackend>(
     address: &Ed25519Address,
 ) -> Result<Option<Vec<OutputId>>, Error> {
     storage
-        .fetch_access::<Ed25519Address, Vec<OutputId>>(address)
+        .fetch::<Ed25519Address, Vec<OutputId>>(address)
         .map_err(|e| Error::Storage(Box::new(e)))
 }
 
@@ -485,7 +485,7 @@ pub(crate) fn unspend_treasury_output_batch<B: StorageBackend>(
 /// Fetches the unspent treasury output from the storage.
 pub fn fetch_unspent_treasury_output<B: StorageBackend>(storage: &B) -> Result<TreasuryOutput, Error> {
     if let Some(outputs) = storage
-        .fetch_access::<bool, Vec<TreasuryOutput>>(&false)
+        .fetch::<bool, Vec<TreasuryOutput>>(&false)
         .map_err(|e| Error::Storage(Box::new(e)))?
     {
         match outputs.as_slice() {

--- a/bee-ledger/src/workers/storage.rs
+++ b/bee-ledger/src/workers/storage.rs
@@ -436,7 +436,9 @@ pub(crate) fn fetch_outputs_for_ed25519_address<B: StorageBackend>(
 }
 
 pub(crate) fn is_output_unspent<B: StorageBackend>(storage: &B, output_id: &OutputId) -> Result<bool, Error> {
-    Exist::<Unspent, ()>::exist_op(storage, &(*output_id).into()).map_err(|e| Error::Storage(Box::new(e)))
+    storage
+        .exist::<Unspent, ()>(&(*output_id).into())
+        .map_err(|e| Error::Storage(Box::new(e)))
 }
 
 pub(crate) fn insert_treasury_output<B: StorageBackend>(

--- a/bee-ledger/src/workers/storage.rs
+++ b/bee-ledger/src/workers/storage.rs
@@ -365,7 +365,9 @@ pub(crate) fn fetch_balance_or_default<B: StorageBackend>(storage: &B, address: 
 }
 
 pub(crate) fn insert_ledger_index<B: StorageBackend>(storage: &B, index: &LedgerIndex) -> Result<(), Error> {
-    Insert::<(), LedgerIndex>::insert_op(storage, &(), index).map_err(|e| Error::Storage(Box::new(e)))
+    storage
+        .insert::<(), LedgerIndex>(&(), index)
+        .map_err(|e| Error::Storage(Box::new(e)))
 }
 
 pub(crate) fn insert_ledger_index_batch<B: StorageBackend>(
@@ -405,7 +407,9 @@ pub(crate) fn delete_receipt_batch<B: StorageBackend>(
 }
 
 pub(crate) fn insert_snapshot_info<B: StorageBackend>(storage: &B, snapshot_info: &SnapshotInfo) -> Result<(), Error> {
-    Insert::<(), SnapshotInfo>::insert_op(&*storage, &(), snapshot_info).map_err(|e| Error::Storage(Box::new(e)))
+    storage
+        .insert::<(), SnapshotInfo>(&(), snapshot_info)
+        .map_err(|e| Error::Storage(Box::new(e)))
 }
 
 #[cfg_attr(feature = "trace", trace_tools::observe)]
@@ -445,7 +449,8 @@ pub(crate) fn insert_treasury_output<B: StorageBackend>(
     storage: &B,
     treasury_output: &TreasuryOutput,
 ) -> Result<(), Error> {
-    Insert::<(bool, TreasuryOutput), ()>::insert_op(storage, &(false, treasury_output.clone()), &())
+    storage
+        .insert::<(bool, TreasuryOutput), ()>(&(false, treasury_output.clone()), &())
         .map_err(|e| Error::Storage(Box::new(e)))
 }
 

--- a/bee-node/bee-node/src/tools/rocksdb.rs
+++ b/bee-node/bee-node/src/tools/rocksdb.rs
@@ -15,7 +15,7 @@ use bee_message::{
     Message, MessageId,
 };
 use bee_storage::{
-    access::{AsIterator},
+    access::AsIterator,
     backend::{StorageBackend, StorageBackendExt},
 };
 use bee_storage_rocksdb::{

--- a/bee-node/bee-node/src/tools/rocksdb.rs
+++ b/bee-node/bee-node/src/tools/rocksdb.rs
@@ -14,9 +14,7 @@ use bee_message::{
     payload::indexation::{IndexationPayload, PaddedIndex},
     Message, MessageId,
 };
-use bee_storage::{
-    backend::{StorageBackend, StorageBackendExt},
-};
+use bee_storage::backend::{StorageBackend, StorageBackendExt};
 use bee_storage_rocksdb::{
     column_families::*,
     config::RocksDbConfigBuilder,

--- a/bee-node/bee-node/src/tools/rocksdb.rs
+++ b/bee-node/bee-node/src/tools/rocksdb.rs
@@ -63,7 +63,7 @@ fn exec_inner(tool: &RocksdbTool, storage: &Storage) -> Result<(), RocksdbError>
         CF_SYSTEM => match &tool.command {
             RocksdbCommand::Fetch { key } => {
                 let key = u8::from_str(key).map_err(|_| RocksdbError::InvalidKey(key.clone()))?;
-                let value = storage.fetch_access::<u8, System>(&key)?;
+                let value = storage.fetch::<u8, System>(&key)?;
 
                 println!("Key: {:?}\nValue: {:?}\n", key, value);
             }
@@ -79,7 +79,7 @@ fn exec_inner(tool: &RocksdbTool, storage: &Storage) -> Result<(), RocksdbError>
         CF_MESSAGE_ID_TO_MESSAGE => match &tool.command {
             RocksdbCommand::Fetch { key } => {
                 let key = MessageId::from_str(key).map_err(|_| RocksdbError::InvalidKey(key.clone()))?;
-                let value = storage.fetch_access::<MessageId, Message>(&key)?;
+                let value = storage.fetch::<MessageId, Message>(&key)?;
 
                 println!("Key: {:?}\nValue: {:?}\n", key, value);
             }
@@ -95,7 +95,7 @@ fn exec_inner(tool: &RocksdbTool, storage: &Storage) -> Result<(), RocksdbError>
         CF_MESSAGE_ID_TO_METADATA => match &tool.command {
             RocksdbCommand::Fetch { key } => {
                 let key = MessageId::from_str(key).map_err(|_| RocksdbError::InvalidKey(key.clone()))?;
-                let value = storage.fetch_access::<MessageId, MessageMetadata>(&key)?;
+                let value = storage.fetch::<MessageId, MessageMetadata>(&key)?;
 
                 println!("Key: {:?}\nValue: {:?}\n", key, value);
             }
@@ -111,7 +111,7 @@ fn exec_inner(tool: &RocksdbTool, storage: &Storage) -> Result<(), RocksdbError>
         CF_MESSAGE_ID_TO_MESSAGE_ID => match &tool.command {
             RocksdbCommand::Fetch { key } => {
                 let key = MessageId::from_str(key).map_err(|_| RocksdbError::InvalidKey(key.clone()))?;
-                let value = storage.fetch_access::<MessageId, Vec<MessageId>>(&key)?;
+                let value = storage.fetch::<MessageId, Vec<MessageId>>(&key)?;
 
                 println!("Key: {:?}\nValue: {:?}\n", key, value);
             }
@@ -132,7 +132,7 @@ fn exec_inner(tool: &RocksdbTool, storage: &Storage) -> Result<(), RocksdbError>
                 )
                 .map_err(|_| RocksdbError::InvalidKey(key.clone()))?
                 .padded_index();
-                let value = storage.fetch_access::<PaddedIndex, Vec<MessageId>>(&key)?;
+                let value = storage.fetch::<PaddedIndex, Vec<MessageId>>(&key)?;
 
                 println!("Key: {:?}\nValue: {:?}\n", key, value);
             }
@@ -148,7 +148,7 @@ fn exec_inner(tool: &RocksdbTool, storage: &Storage) -> Result<(), RocksdbError>
         CF_OUTPUT_ID_TO_CREATED_OUTPUT => match &tool.command {
             RocksdbCommand::Fetch { key } => {
                 let key = OutputId::from_str(key).map_err(|_| RocksdbError::InvalidKey(key.clone()))?;
-                let value = storage.fetch_access::<OutputId, CreatedOutput>(&key)?;
+                let value = storage.fetch::<OutputId, CreatedOutput>(&key)?;
 
                 println!("Key: {:?}\nValue: {:?}\n", key, value);
             }
@@ -164,7 +164,7 @@ fn exec_inner(tool: &RocksdbTool, storage: &Storage) -> Result<(), RocksdbError>
         CF_OUTPUT_ID_TO_CONSUMED_OUTPUT => match &tool.command {
             RocksdbCommand::Fetch { key } => {
                 let key = OutputId::from_str(key).map_err(|_| RocksdbError::InvalidKey(key.clone()))?;
-                let value = storage.fetch_access::<OutputId, ConsumedOutput>(&key)?;
+                let value = storage.fetch::<OutputId, ConsumedOutput>(&key)?;
 
                 println!("Key: {:?}\nValue: {:?}\n", key, value);
             }
@@ -196,7 +196,7 @@ fn exec_inner(tool: &RocksdbTool, storage: &Storage) -> Result<(), RocksdbError>
         CF_ED25519_ADDRESS_TO_OUTPUT_ID => match &tool.command {
             RocksdbCommand::Fetch { key } => {
                 let key = Ed25519Address::from_str(key).map_err(|_| RocksdbError::InvalidKey(key.clone()))?;
-                let value = storage.fetch_access::<Ed25519Address, Vec<OutputId>>(&key)?;
+                let value = storage.fetch::<Ed25519Address, Vec<OutputId>>(&key)?;
 
                 println!("Key: {:?}\nValue: {:?}\n", key, value);
             }
@@ -223,7 +223,7 @@ fn exec_inner(tool: &RocksdbTool, storage: &Storage) -> Result<(), RocksdbError>
         CF_MILESTONE_INDEX_TO_MILESTONE => match &tool.command {
             RocksdbCommand::Fetch { key } => {
                 let key = MilestoneIndex(u32::from_str(key).map_err(|_| RocksdbError::InvalidKey(key.clone()))?);
-                let value = storage.fetch_access::<MilestoneIndex, Milestone>(&key)?;
+                let value = storage.fetch::<MilestoneIndex, Milestone>(&key)?;
 
                 println!("Key: {:?}\nValue: {:?}\n", key, value);
             }
@@ -251,7 +251,7 @@ fn exec_inner(tool: &RocksdbTool, storage: &Storage) -> Result<(), RocksdbError>
             RocksdbCommand::Fetch { key } => {
                 let key =
                     SolidEntryPoint::from(MessageId::from_str(key).map_err(|_| RocksdbError::InvalidKey(key.clone()))?);
-                let value = storage.fetch_access::<SolidEntryPoint, MilestoneIndex>(&key)?;
+                let value = storage.fetch::<SolidEntryPoint, MilestoneIndex>(&key)?;
 
                 println!("Key: {:?}\nValue: {:?}\n", key, value);
             }
@@ -267,7 +267,7 @@ fn exec_inner(tool: &RocksdbTool, storage: &Storage) -> Result<(), RocksdbError>
         CF_MILESTONE_INDEX_TO_OUTPUT_DIFF => match &tool.command {
             RocksdbCommand::Fetch { key } => {
                 let key = MilestoneIndex(u32::from_str(key).map_err(|_| RocksdbError::InvalidKey(key.clone()))?);
-                let value = storage.fetch_access::<MilestoneIndex, OutputDiff>(&key)?;
+                let value = storage.fetch::<MilestoneIndex, OutputDiff>(&key)?;
 
                 println!("Key: {:?}\nValue: {:?}\n", key, value);
             }
@@ -284,7 +284,7 @@ fn exec_inner(tool: &RocksdbTool, storage: &Storage) -> Result<(), RocksdbError>
             RocksdbCommand::Fetch { key } => {
                 let key =
                     Address::from(Ed25519Address::from_str(key).map_err(|_| RocksdbError::InvalidKey(key.clone()))?);
-                let value = storage.fetch_access::<Address, Balance>(&key)?;
+                let value = storage.fetch::<Address, Balance>(&key)?;
 
                 println!("Key: {:?}\nValue: {:?}\n", key, value);
             }
@@ -300,7 +300,7 @@ fn exec_inner(tool: &RocksdbTool, storage: &Storage) -> Result<(), RocksdbError>
         CF_MILESTONE_INDEX_TO_UNREFERENCED_MESSAGE => match &tool.command {
             RocksdbCommand::Fetch { key } => {
                 let key = MilestoneIndex(u32::from_str(key).map_err(|_| RocksdbError::InvalidKey(key.clone()))?);
-                let value = storage.fetch_access::<MilestoneIndex, Vec<UnreferencedMessage>>(&key)?;
+                let value = storage.fetch::<MilestoneIndex, Vec<UnreferencedMessage>>(&key)?;
 
                 println!("Key: {:?}\nValue: {:?}\n", key, value);
             }
@@ -316,7 +316,7 @@ fn exec_inner(tool: &RocksdbTool, storage: &Storage) -> Result<(), RocksdbError>
         CF_MILESTONE_INDEX_TO_RECEIPT => match &tool.command {
             RocksdbCommand::Fetch { key } => {
                 let key = MilestoneIndex(u32::from_str(key).map_err(|_| RocksdbError::InvalidKey(key.clone()))?);
-                let value = storage.fetch_access::<MilestoneIndex, Vec<Receipt>>(&key)?;
+                let value = storage.fetch::<MilestoneIndex, Vec<Receipt>>(&key)?;
 
                 println!("Key: {:?}\nValue: {:?}\n", key, value);
             }
@@ -332,7 +332,7 @@ fn exec_inner(tool: &RocksdbTool, storage: &Storage) -> Result<(), RocksdbError>
         CF_SPENT_TO_TREASURY_OUTPUT => match &tool.command {
             RocksdbCommand::Fetch { key } => {
                 let key = bool::from_str(key).map_err(|_| RocksdbError::InvalidKey(key.clone()))?;
-                let value = storage.fetch_access::<bool, Vec<TreasuryOutput>>(&key)?;
+                let value = storage.fetch::<bool, Vec<TreasuryOutput>>(&key)?;
 
                 println!("Key: {:?}\nValue: {:?}\n", key, value);
             }

--- a/bee-node/bee-node/src/tools/rocksdb.rs
+++ b/bee-node/bee-node/src/tools/rocksdb.rs
@@ -15,7 +15,7 @@ use bee_message::{
     Message, MessageId,
 };
 use bee_storage::{
-    access::{AsIterator, Exist},
+    access::{AsIterator},
     backend::{StorageBackend, StorageBackendExt},
 };
 use bee_storage_rocksdb::{
@@ -180,7 +180,7 @@ fn exec_inner(tool: &RocksdbTool, storage: &Storage) -> Result<(), RocksdbError>
         CF_OUTPUT_ID_UNSPENT => match &tool.command {
             RocksdbCommand::Fetch { key } => {
                 let key = Unspent::from(OutputId::from_str(key).map_err(|_| RocksdbError::InvalidKey(key.clone()))?);
-                let value = Exist::<Unspent, ()>::exist_op(storage, &key)?;
+                let value = storage.exist::<Unspent, ()>(&key)?;
 
                 println!("Key: {:?}\nValue: {:?}\n", key, value);
             }

--- a/bee-node/bee-node/src/tools/rocksdb.rs
+++ b/bee-node/bee-node/src/tools/rocksdb.rs
@@ -15,8 +15,8 @@ use bee_message::{
     Message, MessageId,
 };
 use bee_storage::{
-    access::{AsIterator, Exist, Fetch},
-    backend::StorageBackend,
+    access::{AsIterator, Exist},
+    backend::{StorageBackend, StorageBackendExt},
 };
 use bee_storage_rocksdb::{
     column_families::*,
@@ -63,7 +63,7 @@ fn exec_inner(tool: &RocksdbTool, storage: &Storage) -> Result<(), RocksdbError>
         CF_SYSTEM => match &tool.command {
             RocksdbCommand::Fetch { key } => {
                 let key = u8::from_str(key).map_err(|_| RocksdbError::InvalidKey(key.clone()))?;
-                let value = Fetch::<u8, System>::fetch(storage, &key)?;
+                let value = storage.fetch_access::<u8, System>(&key)?;
 
                 println!("Key: {:?}\nValue: {:?}\n", key, value);
             }
@@ -79,7 +79,7 @@ fn exec_inner(tool: &RocksdbTool, storage: &Storage) -> Result<(), RocksdbError>
         CF_MESSAGE_ID_TO_MESSAGE => match &tool.command {
             RocksdbCommand::Fetch { key } => {
                 let key = MessageId::from_str(key).map_err(|_| RocksdbError::InvalidKey(key.clone()))?;
-                let value = Fetch::<MessageId, Message>::fetch(storage, &key)?;
+                let value = storage.fetch_access::<MessageId, Message>(&key)?;
 
                 println!("Key: {:?}\nValue: {:?}\n", key, value);
             }
@@ -95,7 +95,7 @@ fn exec_inner(tool: &RocksdbTool, storage: &Storage) -> Result<(), RocksdbError>
         CF_MESSAGE_ID_TO_METADATA => match &tool.command {
             RocksdbCommand::Fetch { key } => {
                 let key = MessageId::from_str(key).map_err(|_| RocksdbError::InvalidKey(key.clone()))?;
-                let value = Fetch::<MessageId, MessageMetadata>::fetch(storage, &key)?;
+                let value = storage.fetch_access::<MessageId, MessageMetadata>(&key)?;
 
                 println!("Key: {:?}\nValue: {:?}\n", key, value);
             }
@@ -111,7 +111,7 @@ fn exec_inner(tool: &RocksdbTool, storage: &Storage) -> Result<(), RocksdbError>
         CF_MESSAGE_ID_TO_MESSAGE_ID => match &tool.command {
             RocksdbCommand::Fetch { key } => {
                 let key = MessageId::from_str(key).map_err(|_| RocksdbError::InvalidKey(key.clone()))?;
-                let value = Fetch::<MessageId, Vec<MessageId>>::fetch(storage, &key)?;
+                let value = storage.fetch_access::<MessageId, Vec<MessageId>>(&key)?;
 
                 println!("Key: {:?}\nValue: {:?}\n", key, value);
             }
@@ -132,7 +132,7 @@ fn exec_inner(tool: &RocksdbTool, storage: &Storage) -> Result<(), RocksdbError>
                 )
                 .map_err(|_| RocksdbError::InvalidKey(key.clone()))?
                 .padded_index();
-                let value = Fetch::<PaddedIndex, Vec<MessageId>>::fetch(storage, &key)?;
+                let value = storage.fetch_access::<PaddedIndex, Vec<MessageId>>(&key)?;
 
                 println!("Key: {:?}\nValue: {:?}\n", key, value);
             }
@@ -148,7 +148,7 @@ fn exec_inner(tool: &RocksdbTool, storage: &Storage) -> Result<(), RocksdbError>
         CF_OUTPUT_ID_TO_CREATED_OUTPUT => match &tool.command {
             RocksdbCommand::Fetch { key } => {
                 let key = OutputId::from_str(key).map_err(|_| RocksdbError::InvalidKey(key.clone()))?;
-                let value = Fetch::<OutputId, CreatedOutput>::fetch(storage, &key)?;
+                let value = storage.fetch_access::<OutputId, CreatedOutput>(&key)?;
 
                 println!("Key: {:?}\nValue: {:?}\n", key, value);
             }
@@ -164,7 +164,7 @@ fn exec_inner(tool: &RocksdbTool, storage: &Storage) -> Result<(), RocksdbError>
         CF_OUTPUT_ID_TO_CONSUMED_OUTPUT => match &tool.command {
             RocksdbCommand::Fetch { key } => {
                 let key = OutputId::from_str(key).map_err(|_| RocksdbError::InvalidKey(key.clone()))?;
-                let value = Fetch::<OutputId, ConsumedOutput>::fetch(storage, &key)?;
+                let value = storage.fetch_access::<OutputId, ConsumedOutput>(&key)?;
 
                 println!("Key: {:?}\nValue: {:?}\n", key, value);
             }
@@ -196,7 +196,7 @@ fn exec_inner(tool: &RocksdbTool, storage: &Storage) -> Result<(), RocksdbError>
         CF_ED25519_ADDRESS_TO_OUTPUT_ID => match &tool.command {
             RocksdbCommand::Fetch { key } => {
                 let key = Ed25519Address::from_str(key).map_err(|_| RocksdbError::InvalidKey(key.clone()))?;
-                let value = Fetch::<Ed25519Address, Vec<OutputId>>::fetch(storage, &key)?;
+                let value = storage.fetch_access::<Ed25519Address, Vec<OutputId>>(&key)?;
 
                 println!("Key: {:?}\nValue: {:?}\n", key, value);
             }
@@ -223,7 +223,7 @@ fn exec_inner(tool: &RocksdbTool, storage: &Storage) -> Result<(), RocksdbError>
         CF_MILESTONE_INDEX_TO_MILESTONE => match &tool.command {
             RocksdbCommand::Fetch { key } => {
                 let key = MilestoneIndex(u32::from_str(key).map_err(|_| RocksdbError::InvalidKey(key.clone()))?);
-                let value = Fetch::<MilestoneIndex, Milestone>::fetch(storage, &key)?;
+                let value = storage.fetch_access::<MilestoneIndex, Milestone>(&key)?;
 
                 println!("Key: {:?}\nValue: {:?}\n", key, value);
             }
@@ -251,7 +251,7 @@ fn exec_inner(tool: &RocksdbTool, storage: &Storage) -> Result<(), RocksdbError>
             RocksdbCommand::Fetch { key } => {
                 let key =
                     SolidEntryPoint::from(MessageId::from_str(key).map_err(|_| RocksdbError::InvalidKey(key.clone()))?);
-                let value = Fetch::<SolidEntryPoint, MilestoneIndex>::fetch(storage, &key)?;
+                let value = storage.fetch_access::<SolidEntryPoint, MilestoneIndex>(&key)?;
 
                 println!("Key: {:?}\nValue: {:?}\n", key, value);
             }
@@ -267,7 +267,7 @@ fn exec_inner(tool: &RocksdbTool, storage: &Storage) -> Result<(), RocksdbError>
         CF_MILESTONE_INDEX_TO_OUTPUT_DIFF => match &tool.command {
             RocksdbCommand::Fetch { key } => {
                 let key = MilestoneIndex(u32::from_str(key).map_err(|_| RocksdbError::InvalidKey(key.clone()))?);
-                let value = Fetch::<MilestoneIndex, OutputDiff>::fetch(storage, &key)?;
+                let value = storage.fetch_access::<MilestoneIndex, OutputDiff>(&key)?;
 
                 println!("Key: {:?}\nValue: {:?}\n", key, value);
             }
@@ -284,7 +284,7 @@ fn exec_inner(tool: &RocksdbTool, storage: &Storage) -> Result<(), RocksdbError>
             RocksdbCommand::Fetch { key } => {
                 let key =
                     Address::from(Ed25519Address::from_str(key).map_err(|_| RocksdbError::InvalidKey(key.clone()))?);
-                let value = Fetch::<Address, Balance>::fetch(storage, &key)?;
+                let value = storage.fetch_access::<Address, Balance>(&key)?;
 
                 println!("Key: {:?}\nValue: {:?}\n", key, value);
             }
@@ -300,7 +300,7 @@ fn exec_inner(tool: &RocksdbTool, storage: &Storage) -> Result<(), RocksdbError>
         CF_MILESTONE_INDEX_TO_UNREFERENCED_MESSAGE => match &tool.command {
             RocksdbCommand::Fetch { key } => {
                 let key = MilestoneIndex(u32::from_str(key).map_err(|_| RocksdbError::InvalidKey(key.clone()))?);
-                let value = Fetch::<MilestoneIndex, Vec<UnreferencedMessage>>::fetch(storage, &key)?;
+                let value = storage.fetch_access::<MilestoneIndex, Vec<UnreferencedMessage>>(&key)?;
 
                 println!("Key: {:?}\nValue: {:?}\n", key, value);
             }
@@ -316,7 +316,7 @@ fn exec_inner(tool: &RocksdbTool, storage: &Storage) -> Result<(), RocksdbError>
         CF_MILESTONE_INDEX_TO_RECEIPT => match &tool.command {
             RocksdbCommand::Fetch { key } => {
                 let key = MilestoneIndex(u32::from_str(key).map_err(|_| RocksdbError::InvalidKey(key.clone()))?);
-                let value = Fetch::<MilestoneIndex, Vec<Receipt>>::fetch(storage, &key)?;
+                let value = storage.fetch_access::<MilestoneIndex, Vec<Receipt>>(&key)?;
 
                 println!("Key: {:?}\nValue: {:?}\n", key, value);
             }
@@ -332,7 +332,7 @@ fn exec_inner(tool: &RocksdbTool, storage: &Storage) -> Result<(), RocksdbError>
         CF_SPENT_TO_TREASURY_OUTPUT => match &tool.command {
             RocksdbCommand::Fetch { key } => {
                 let key = bool::from_str(key).map_err(|_| RocksdbError::InvalidKey(key.clone()))?;
-                let value = Fetch::<bool, Vec<TreasuryOutput>>::fetch(storage, &key)?;
+                let value = storage.fetch_access::<bool, Vec<TreasuryOutput>>(&key)?;
 
                 println!("Key: {:?}\nValue: {:?}\n", key, value);
             }

--- a/bee-node/bee-node/src/tools/rocksdb.rs
+++ b/bee-node/bee-node/src/tools/rocksdb.rs
@@ -15,7 +15,6 @@ use bee_message::{
     Message, MessageId,
 };
 use bee_storage::{
-    access::AsIterator,
     backend::{StorageBackend, StorageBackendExt},
 };
 use bee_storage_rocksdb::{
@@ -68,7 +67,7 @@ fn exec_inner(tool: &RocksdbTool, storage: &Storage) -> Result<(), RocksdbError>
                 println!("Key: {:?}\nValue: {:?}\n", key, value);
             }
             RocksdbCommand::Iterator => {
-                let iterator = AsIterator::<u8, System>::iter_op(storage)?;
+                let iterator = storage.iter::<u8, System>()?;
 
                 for result in iterator {
                     let (key, value) = result?;
@@ -84,7 +83,7 @@ fn exec_inner(tool: &RocksdbTool, storage: &Storage) -> Result<(), RocksdbError>
                 println!("Key: {:?}\nValue: {:?}\n", key, value);
             }
             RocksdbCommand::Iterator => {
-                let iterator = AsIterator::<MessageId, Message>::iter_op(storage)?;
+                let iterator = storage.iter::<MessageId, Message>()?;
 
                 for result in iterator {
                     let (key, value) = result?;
@@ -100,7 +99,7 @@ fn exec_inner(tool: &RocksdbTool, storage: &Storage) -> Result<(), RocksdbError>
                 println!("Key: {:?}\nValue: {:?}\n", key, value);
             }
             RocksdbCommand::Iterator => {
-                let iterator = AsIterator::<MessageId, MessageMetadata>::iter_op(storage)?;
+                let iterator = storage.iter::<MessageId, MessageMetadata>()?;
 
                 for result in iterator {
                     let (key, value) = result?;
@@ -116,7 +115,7 @@ fn exec_inner(tool: &RocksdbTool, storage: &Storage) -> Result<(), RocksdbError>
                 println!("Key: {:?}\nValue: {:?}\n", key, value);
             }
             RocksdbCommand::Iterator => {
-                let iterator = AsIterator::<(MessageId, MessageId), ()>::iter_op(storage)?;
+                let iterator = storage.iter::<(MessageId, MessageId), ()>()?;
 
                 for result in iterator {
                     let (key, value) = result?;
@@ -137,7 +136,7 @@ fn exec_inner(tool: &RocksdbTool, storage: &Storage) -> Result<(), RocksdbError>
                 println!("Key: {:?}\nValue: {:?}\n", key, value);
             }
             RocksdbCommand::Iterator => {
-                let iterator = AsIterator::<(PaddedIndex, MessageId), ()>::iter_op(storage)?;
+                let iterator = storage.iter::<(PaddedIndex, MessageId), ()>()?;
 
                 for result in iterator {
                     let (key, value) = result?;
@@ -153,7 +152,7 @@ fn exec_inner(tool: &RocksdbTool, storage: &Storage) -> Result<(), RocksdbError>
                 println!("Key: {:?}\nValue: {:?}\n", key, value);
             }
             RocksdbCommand::Iterator => {
-                let iterator = AsIterator::<OutputId, CreatedOutput>::iter_op(storage)?;
+                let iterator = storage.iter::<OutputId, CreatedOutput>()?;
 
                 for result in iterator {
                     let (key, value) = result?;
@@ -169,7 +168,7 @@ fn exec_inner(tool: &RocksdbTool, storage: &Storage) -> Result<(), RocksdbError>
                 println!("Key: {:?}\nValue: {:?}\n", key, value);
             }
             RocksdbCommand::Iterator => {
-                let iterator = AsIterator::<OutputId, ConsumedOutput>::iter_op(storage)?;
+                let iterator = storage.iter::<OutputId, ConsumedOutput>()?;
 
                 for result in iterator {
                     let (key, value) = result?;
@@ -185,7 +184,7 @@ fn exec_inner(tool: &RocksdbTool, storage: &Storage) -> Result<(), RocksdbError>
                 println!("Key: {:?}\nValue: {:?}\n", key, value);
             }
             RocksdbCommand::Iterator => {
-                let iterator = AsIterator::<Unspent, ()>::iter_op(storage)?;
+                let iterator = storage.iter::<Unspent, ()>()?;
 
                 for result in iterator {
                     let (key, value) = result?;
@@ -201,7 +200,7 @@ fn exec_inner(tool: &RocksdbTool, storage: &Storage) -> Result<(), RocksdbError>
                 println!("Key: {:?}\nValue: {:?}\n", key, value);
             }
             RocksdbCommand::Iterator => {
-                let iterator = AsIterator::<(Ed25519Address, OutputId), ()>::iter_op(storage)?;
+                let iterator = storage.iter::<(Ed25519Address, OutputId), ()>()?;
 
                 for result in iterator {
                     let (key, value) = result?;
@@ -212,7 +211,7 @@ fn exec_inner(tool: &RocksdbTool, storage: &Storage) -> Result<(), RocksdbError>
         CF_LEDGER_INDEX => match &tool.command {
             RocksdbCommand::Fetch { key: _key } => return Err(RocksdbError::UnsupportedCommand),
             RocksdbCommand::Iterator => {
-                let iterator = AsIterator::<(), LedgerIndex>::iter_op(storage)?;
+                let iterator = storage.iter::<(), LedgerIndex>()?;
 
                 for result in iterator {
                     let (key, value) = result?;
@@ -228,7 +227,7 @@ fn exec_inner(tool: &RocksdbTool, storage: &Storage) -> Result<(), RocksdbError>
                 println!("Key: {:?}\nValue: {:?}\n", key, value);
             }
             RocksdbCommand::Iterator => {
-                let iterator = AsIterator::<MilestoneIndex, Milestone>::iter_op(storage)?;
+                let iterator = storage.iter::<MilestoneIndex, Milestone>()?;
 
                 for result in iterator {
                     let (key, value) = result?;
@@ -239,7 +238,7 @@ fn exec_inner(tool: &RocksdbTool, storage: &Storage) -> Result<(), RocksdbError>
         CF_SNAPSHOT_INFO => match &tool.command {
             RocksdbCommand::Fetch { key: _key } => return Err(RocksdbError::UnsupportedCommand),
             RocksdbCommand::Iterator => {
-                let iterator = AsIterator::<(), SnapshotInfo>::iter_op(storage)?;
+                let iterator = storage.iter::<(), SnapshotInfo>()?;
 
                 for result in iterator {
                     let (key, value) = result?;
@@ -256,7 +255,7 @@ fn exec_inner(tool: &RocksdbTool, storage: &Storage) -> Result<(), RocksdbError>
                 println!("Key: {:?}\nValue: {:?}\n", key, value);
             }
             RocksdbCommand::Iterator => {
-                let iterator = AsIterator::<SolidEntryPoint, MilestoneIndex>::iter_op(storage)?;
+                let iterator = storage.iter::<SolidEntryPoint, MilestoneIndex>()?;
 
                 for result in iterator {
                     let (key, value) = result?;
@@ -272,7 +271,7 @@ fn exec_inner(tool: &RocksdbTool, storage: &Storage) -> Result<(), RocksdbError>
                 println!("Key: {:?}\nValue: {:?}\n", key, value);
             }
             RocksdbCommand::Iterator => {
-                let iterator = AsIterator::<MilestoneIndex, OutputDiff>::iter_op(storage)?;
+                let iterator = storage.iter::<MilestoneIndex, OutputDiff>()?;
 
                 for result in iterator {
                     let (key, value) = result?;
@@ -289,7 +288,7 @@ fn exec_inner(tool: &RocksdbTool, storage: &Storage) -> Result<(), RocksdbError>
                 println!("Key: {:?}\nValue: {:?}\n", key, value);
             }
             RocksdbCommand::Iterator => {
-                let iterator = AsIterator::<Address, Balance>::iter_op(storage)?;
+                let iterator = storage.iter::<Address, Balance>()?;
 
                 for result in iterator {
                     let (key, value) = result?;
@@ -305,7 +304,7 @@ fn exec_inner(tool: &RocksdbTool, storage: &Storage) -> Result<(), RocksdbError>
                 println!("Key: {:?}\nValue: {:?}\n", key, value);
             }
             RocksdbCommand::Iterator => {
-                let iterator = AsIterator::<(MilestoneIndex, UnreferencedMessage), ()>::iter_op(storage)?;
+                let iterator = storage.iter::<(MilestoneIndex, UnreferencedMessage), ()>()?;
 
                 for result in iterator {
                     let (key, value) = result?;
@@ -321,7 +320,7 @@ fn exec_inner(tool: &RocksdbTool, storage: &Storage) -> Result<(), RocksdbError>
                 println!("Key: {:?}\nValue: {:?}\n", key, value);
             }
             RocksdbCommand::Iterator => {
-                let iterator = AsIterator::<(MilestoneIndex, Receipt), ()>::iter_op(storage)?;
+                let iterator = storage.iter::<(MilestoneIndex, Receipt), ()>()?;
 
                 for result in iterator {
                     let (key, value) = result?;
@@ -337,7 +336,7 @@ fn exec_inner(tool: &RocksdbTool, storage: &Storage) -> Result<(), RocksdbError>
                 println!("Key: {:?}\nValue: {:?}\n", key, value);
             }
             RocksdbCommand::Iterator => {
-                let iterator = AsIterator::<(bool, TreasuryOutput), ()>::iter_op(storage)?;
+                let iterator = storage.iter::<(bool, TreasuryOutput), ()>()?;
 
                 for result in iterator {
                     let (key, value) = result?;

--- a/bee-node/bee-node/src/tools/rocksdb.rs
+++ b/bee-node/bee-node/src/tools/rocksdb.rs
@@ -68,7 +68,7 @@ fn exec_inner(tool: &RocksdbTool, storage: &Storage) -> Result<(), RocksdbError>
                 println!("Key: {:?}\nValue: {:?}\n", key, value);
             }
             RocksdbCommand::Iterator => {
-                let iterator = AsIterator::<u8, System>::iter(storage)?;
+                let iterator = AsIterator::<u8, System>::iter_op(storage)?;
 
                 for result in iterator {
                     let (key, value) = result?;
@@ -84,7 +84,7 @@ fn exec_inner(tool: &RocksdbTool, storage: &Storage) -> Result<(), RocksdbError>
                 println!("Key: {:?}\nValue: {:?}\n", key, value);
             }
             RocksdbCommand::Iterator => {
-                let iterator = AsIterator::<MessageId, Message>::iter(storage)?;
+                let iterator = AsIterator::<MessageId, Message>::iter_op(storage)?;
 
                 for result in iterator {
                     let (key, value) = result?;
@@ -100,7 +100,7 @@ fn exec_inner(tool: &RocksdbTool, storage: &Storage) -> Result<(), RocksdbError>
                 println!("Key: {:?}\nValue: {:?}\n", key, value);
             }
             RocksdbCommand::Iterator => {
-                let iterator = AsIterator::<MessageId, MessageMetadata>::iter(storage)?;
+                let iterator = AsIterator::<MessageId, MessageMetadata>::iter_op(storage)?;
 
                 for result in iterator {
                     let (key, value) = result?;
@@ -116,7 +116,7 @@ fn exec_inner(tool: &RocksdbTool, storage: &Storage) -> Result<(), RocksdbError>
                 println!("Key: {:?}\nValue: {:?}\n", key, value);
             }
             RocksdbCommand::Iterator => {
-                let iterator = AsIterator::<(MessageId, MessageId), ()>::iter(storage)?;
+                let iterator = AsIterator::<(MessageId, MessageId), ()>::iter_op(storage)?;
 
                 for result in iterator {
                     let (key, value) = result?;
@@ -137,7 +137,7 @@ fn exec_inner(tool: &RocksdbTool, storage: &Storage) -> Result<(), RocksdbError>
                 println!("Key: {:?}\nValue: {:?}\n", key, value);
             }
             RocksdbCommand::Iterator => {
-                let iterator = AsIterator::<(PaddedIndex, MessageId), ()>::iter(storage)?;
+                let iterator = AsIterator::<(PaddedIndex, MessageId), ()>::iter_op(storage)?;
 
                 for result in iterator {
                     let (key, value) = result?;
@@ -153,7 +153,7 @@ fn exec_inner(tool: &RocksdbTool, storage: &Storage) -> Result<(), RocksdbError>
                 println!("Key: {:?}\nValue: {:?}\n", key, value);
             }
             RocksdbCommand::Iterator => {
-                let iterator = AsIterator::<OutputId, CreatedOutput>::iter(storage)?;
+                let iterator = AsIterator::<OutputId, CreatedOutput>::iter_op(storage)?;
 
                 for result in iterator {
                     let (key, value) = result?;
@@ -169,7 +169,7 @@ fn exec_inner(tool: &RocksdbTool, storage: &Storage) -> Result<(), RocksdbError>
                 println!("Key: {:?}\nValue: {:?}\n", key, value);
             }
             RocksdbCommand::Iterator => {
-                let iterator = AsIterator::<OutputId, ConsumedOutput>::iter(storage)?;
+                let iterator = AsIterator::<OutputId, ConsumedOutput>::iter_op(storage)?;
 
                 for result in iterator {
                     let (key, value) = result?;
@@ -180,12 +180,12 @@ fn exec_inner(tool: &RocksdbTool, storage: &Storage) -> Result<(), RocksdbError>
         CF_OUTPUT_ID_UNSPENT => match &tool.command {
             RocksdbCommand::Fetch { key } => {
                 let key = Unspent::from(OutputId::from_str(key).map_err(|_| RocksdbError::InvalidKey(key.clone()))?);
-                let value = Exist::<Unspent, ()>::exist(storage, &key)?;
+                let value = Exist::<Unspent, ()>::exist_op(storage, &key)?;
 
                 println!("Key: {:?}\nValue: {:?}\n", key, value);
             }
             RocksdbCommand::Iterator => {
-                let iterator = AsIterator::<Unspent, ()>::iter(storage)?;
+                let iterator = AsIterator::<Unspent, ()>::iter_op(storage)?;
 
                 for result in iterator {
                     let (key, value) = result?;
@@ -201,7 +201,7 @@ fn exec_inner(tool: &RocksdbTool, storage: &Storage) -> Result<(), RocksdbError>
                 println!("Key: {:?}\nValue: {:?}\n", key, value);
             }
             RocksdbCommand::Iterator => {
-                let iterator = AsIterator::<(Ed25519Address, OutputId), ()>::iter(storage)?;
+                let iterator = AsIterator::<(Ed25519Address, OutputId), ()>::iter_op(storage)?;
 
                 for result in iterator {
                     let (key, value) = result?;
@@ -212,7 +212,7 @@ fn exec_inner(tool: &RocksdbTool, storage: &Storage) -> Result<(), RocksdbError>
         CF_LEDGER_INDEX => match &tool.command {
             RocksdbCommand::Fetch { key: _key } => return Err(RocksdbError::UnsupportedCommand),
             RocksdbCommand::Iterator => {
-                let iterator = AsIterator::<(), LedgerIndex>::iter(storage)?;
+                let iterator = AsIterator::<(), LedgerIndex>::iter_op(storage)?;
 
                 for result in iterator {
                     let (key, value) = result?;
@@ -228,7 +228,7 @@ fn exec_inner(tool: &RocksdbTool, storage: &Storage) -> Result<(), RocksdbError>
                 println!("Key: {:?}\nValue: {:?}\n", key, value);
             }
             RocksdbCommand::Iterator => {
-                let iterator = AsIterator::<MilestoneIndex, Milestone>::iter(storage)?;
+                let iterator = AsIterator::<MilestoneIndex, Milestone>::iter_op(storage)?;
 
                 for result in iterator {
                     let (key, value) = result?;
@@ -239,7 +239,7 @@ fn exec_inner(tool: &RocksdbTool, storage: &Storage) -> Result<(), RocksdbError>
         CF_SNAPSHOT_INFO => match &tool.command {
             RocksdbCommand::Fetch { key: _key } => return Err(RocksdbError::UnsupportedCommand),
             RocksdbCommand::Iterator => {
-                let iterator = AsIterator::<(), SnapshotInfo>::iter(storage)?;
+                let iterator = AsIterator::<(), SnapshotInfo>::iter_op(storage)?;
 
                 for result in iterator {
                     let (key, value) = result?;
@@ -256,7 +256,7 @@ fn exec_inner(tool: &RocksdbTool, storage: &Storage) -> Result<(), RocksdbError>
                 println!("Key: {:?}\nValue: {:?}\n", key, value);
             }
             RocksdbCommand::Iterator => {
-                let iterator = AsIterator::<SolidEntryPoint, MilestoneIndex>::iter(storage)?;
+                let iterator = AsIterator::<SolidEntryPoint, MilestoneIndex>::iter_op(storage)?;
 
                 for result in iterator {
                     let (key, value) = result?;
@@ -272,7 +272,7 @@ fn exec_inner(tool: &RocksdbTool, storage: &Storage) -> Result<(), RocksdbError>
                 println!("Key: {:?}\nValue: {:?}\n", key, value);
             }
             RocksdbCommand::Iterator => {
-                let iterator = AsIterator::<MilestoneIndex, OutputDiff>::iter(storage)?;
+                let iterator = AsIterator::<MilestoneIndex, OutputDiff>::iter_op(storage)?;
 
                 for result in iterator {
                     let (key, value) = result?;
@@ -289,7 +289,7 @@ fn exec_inner(tool: &RocksdbTool, storage: &Storage) -> Result<(), RocksdbError>
                 println!("Key: {:?}\nValue: {:?}\n", key, value);
             }
             RocksdbCommand::Iterator => {
-                let iterator = AsIterator::<Address, Balance>::iter(storage)?;
+                let iterator = AsIterator::<Address, Balance>::iter_op(storage)?;
 
                 for result in iterator {
                     let (key, value) = result?;
@@ -305,7 +305,7 @@ fn exec_inner(tool: &RocksdbTool, storage: &Storage) -> Result<(), RocksdbError>
                 println!("Key: {:?}\nValue: {:?}\n", key, value);
             }
             RocksdbCommand::Iterator => {
-                let iterator = AsIterator::<(MilestoneIndex, UnreferencedMessage), ()>::iter(storage)?;
+                let iterator = AsIterator::<(MilestoneIndex, UnreferencedMessage), ()>::iter_op(storage)?;
 
                 for result in iterator {
                     let (key, value) = result?;
@@ -321,7 +321,7 @@ fn exec_inner(tool: &RocksdbTool, storage: &Storage) -> Result<(), RocksdbError>
                 println!("Key: {:?}\nValue: {:?}\n", key, value);
             }
             RocksdbCommand::Iterator => {
-                let iterator = AsIterator::<(MilestoneIndex, Receipt), ()>::iter(storage)?;
+                let iterator = AsIterator::<(MilestoneIndex, Receipt), ()>::iter_op(storage)?;
 
                 for result in iterator {
                     let (key, value) = result?;
@@ -337,7 +337,7 @@ fn exec_inner(tool: &RocksdbTool, storage: &Storage) -> Result<(), RocksdbError>
                 println!("Key: {:?}\nValue: {:?}\n", key, value);
             }
             RocksdbCommand::Iterator => {
-                let iterator = AsIterator::<(bool, TreasuryOutput), ()>::iter(storage)?;
+                let iterator = AsIterator::<(bool, TreasuryOutput), ()>::iter_op(storage)?;
 
                 for result in iterator {
                     let (key, value) = result?;

--- a/bee-node/bee-node/src/tools/sled.rs
+++ b/bee-node/bee-node/src/tools/sled.rs
@@ -67,7 +67,7 @@ fn exec_inner(tool: &SledTool, storage: &Storage) -> Result<(), SledError> {
                 println!("Key: {:?}\nValue: {:?}\n", key, value);
             }
             SledCommand::Iterator => {
-                let iterator = AsIterator::<MessageId, Message>::iter(storage)?;
+                let iterator = AsIterator::<MessageId, Message>::iter_op(storage)?;
 
                 for result in iterator {
                     let (key, value) = result?;
@@ -83,7 +83,7 @@ fn exec_inner(tool: &SledTool, storage: &Storage) -> Result<(), SledError> {
                 println!("Key: {:?}\nValue: {:?}\n", key, value);
             }
             SledCommand::Iterator => {
-                let iterator = AsIterator::<MessageId, MessageMetadata>::iter(storage)?;
+                let iterator = AsIterator::<MessageId, MessageMetadata>::iter_op(storage)?;
 
                 for result in iterator {
                     let (key, value) = result?;
@@ -99,7 +99,7 @@ fn exec_inner(tool: &SledTool, storage: &Storage) -> Result<(), SledError> {
                 println!("Key: {:?}\nValue: {:?}\n", key, value);
             }
             SledCommand::Iterator => {
-                let iterator = AsIterator::<(MessageId, MessageId), ()>::iter(storage)?;
+                let iterator = AsIterator::<(MessageId, MessageId), ()>::iter_op(storage)?;
 
                 for result in iterator {
                     let (key, value) = result?;
@@ -120,7 +120,7 @@ fn exec_inner(tool: &SledTool, storage: &Storage) -> Result<(), SledError> {
                 println!("Key: {:?}\nValue: {:?}\n", key, value);
             }
             SledCommand::Iterator => {
-                let iterator = AsIterator::<(PaddedIndex, MessageId), ()>::iter(storage)?;
+                let iterator = AsIterator::<(PaddedIndex, MessageId), ()>::iter_op(storage)?;
 
                 for result in iterator {
                     let (key, value) = result?;
@@ -136,7 +136,7 @@ fn exec_inner(tool: &SledTool, storage: &Storage) -> Result<(), SledError> {
                 println!("Key: {:?}\nValue: {:?}\n", key, value);
             }
             SledCommand::Iterator => {
-                let iterator = AsIterator::<OutputId, CreatedOutput>::iter(storage)?;
+                let iterator = AsIterator::<OutputId, CreatedOutput>::iter_op(storage)?;
 
                 for result in iterator {
                     let (key, value) = result?;
@@ -152,7 +152,7 @@ fn exec_inner(tool: &SledTool, storage: &Storage) -> Result<(), SledError> {
                 println!("Key: {:?}\nValue: {:?}\n", key, value);
             }
             SledCommand::Iterator => {
-                let iterator = AsIterator::<OutputId, ConsumedOutput>::iter(storage)?;
+                let iterator = AsIterator::<OutputId, ConsumedOutput>::iter_op(storage)?;
 
                 for result in iterator {
                     let (key, value) = result?;
@@ -163,12 +163,12 @@ fn exec_inner(tool: &SledTool, storage: &Storage) -> Result<(), SledError> {
         TREE_OUTPUT_ID_UNSPENT => match &tool.command {
             SledCommand::Fetch { key } => {
                 let key = Unspent::from(OutputId::from_str(key).map_err(|_| SledError::InvalidKey(key.clone()))?);
-                let value = Exist::<Unspent, ()>::exist(storage, &key)?;
+                let value = Exist::<Unspent, ()>::exist_op(storage, &key)?;
 
                 println!("Key: {:?}\nValue: {:?}\n", key, value);
             }
             SledCommand::Iterator => {
-                let iterator = AsIterator::<Unspent, ()>::iter(storage)?;
+                let iterator = AsIterator::<Unspent, ()>::iter_op(storage)?;
 
                 for result in iterator {
                     let (key, value) = result?;
@@ -184,7 +184,7 @@ fn exec_inner(tool: &SledTool, storage: &Storage) -> Result<(), SledError> {
                 println!("Key: {:?}\nValue: {:?}\n", key, value);
             }
             SledCommand::Iterator => {
-                let iterator = AsIterator::<(Ed25519Address, OutputId), ()>::iter(storage)?;
+                let iterator = AsIterator::<(Ed25519Address, OutputId), ()>::iter_op(storage)?;
 
                 for result in iterator {
                     let (key, value) = result?;
@@ -195,7 +195,7 @@ fn exec_inner(tool: &SledTool, storage: &Storage) -> Result<(), SledError> {
         TREE_LEDGER_INDEX => match &tool.command {
             SledCommand::Fetch { key: _key } => return Err(SledError::UnsupportedCommand),
             SledCommand::Iterator => {
-                let iterator = AsIterator::<(), LedgerIndex>::iter(storage)?;
+                let iterator = AsIterator::<(), LedgerIndex>::iter_op(storage)?;
 
                 for result in iterator {
                     let (key, value) = result?;
@@ -211,7 +211,7 @@ fn exec_inner(tool: &SledTool, storage: &Storage) -> Result<(), SledError> {
                 println!("Key: {:?}\nValue: {:?}\n", key, value);
             }
             SledCommand::Iterator => {
-                let iterator = AsIterator::<MilestoneIndex, Milestone>::iter(storage)?;
+                let iterator = AsIterator::<MilestoneIndex, Milestone>::iter_op(storage)?;
 
                 for result in iterator {
                     let (key, value) = result?;
@@ -222,7 +222,7 @@ fn exec_inner(tool: &SledTool, storage: &Storage) -> Result<(), SledError> {
         TREE_SNAPSHOT_INFO => match &tool.command {
             SledCommand::Fetch { key: _key } => return Err(SledError::UnsupportedCommand),
             SledCommand::Iterator => {
-                let iterator = AsIterator::<(), SnapshotInfo>::iter(storage)?;
+                let iterator = AsIterator::<(), SnapshotInfo>::iter_op(storage)?;
 
                 for result in iterator {
                     let (key, value) = result?;
@@ -239,7 +239,7 @@ fn exec_inner(tool: &SledTool, storage: &Storage) -> Result<(), SledError> {
                 println!("Key: {:?}\nValue: {:?}\n", key, value);
             }
             SledCommand::Iterator => {
-                let iterator = AsIterator::<SolidEntryPoint, MilestoneIndex>::iter(storage)?;
+                let iterator = AsIterator::<SolidEntryPoint, MilestoneIndex>::iter_op(storage)?;
 
                 for result in iterator {
                     let (key, value) = result?;
@@ -255,7 +255,7 @@ fn exec_inner(tool: &SledTool, storage: &Storage) -> Result<(), SledError> {
                 println!("Key: {:?}\nValue: {:?}\n", key, value);
             }
             SledCommand::Iterator => {
-                let iterator = AsIterator::<MilestoneIndex, OutputDiff>::iter(storage)?;
+                let iterator = AsIterator::<MilestoneIndex, OutputDiff>::iter_op(storage)?;
 
                 for result in iterator {
                     let (key, value) = result?;
@@ -271,7 +271,7 @@ fn exec_inner(tool: &SledTool, storage: &Storage) -> Result<(), SledError> {
                 println!("Key: {:?}\nValue: {:?}\n", key, value);
             }
             SledCommand::Iterator => {
-                let iterator = AsIterator::<Address, Balance>::iter(storage)?;
+                let iterator = AsIterator::<Address, Balance>::iter_op(storage)?;
 
                 for result in iterator {
                     let (key, value) = result?;
@@ -287,7 +287,7 @@ fn exec_inner(tool: &SledTool, storage: &Storage) -> Result<(), SledError> {
                 println!("Key: {:?}\nValue: {:?}\n", key, value);
             }
             SledCommand::Iterator => {
-                let iterator = AsIterator::<(MilestoneIndex, UnreferencedMessage), ()>::iter(storage)?;
+                let iterator = AsIterator::<(MilestoneIndex, UnreferencedMessage), ()>::iter_op(storage)?;
 
                 for result in iterator {
                     let (key, value) = result?;
@@ -303,7 +303,7 @@ fn exec_inner(tool: &SledTool, storage: &Storage) -> Result<(), SledError> {
                 println!("Key: {:?}\nValue: {:?}\n", key, value);
             }
             SledCommand::Iterator => {
-                let iterator = AsIterator::<(MilestoneIndex, Receipt), ()>::iter(storage)?;
+                let iterator = AsIterator::<(MilestoneIndex, Receipt), ()>::iter_op(storage)?;
 
                 for result in iterator {
                     let (key, value) = result?;
@@ -319,7 +319,7 @@ fn exec_inner(tool: &SledTool, storage: &Storage) -> Result<(), SledError> {
                 println!("Key: {:?}\nValue: {:?}\n", key, value);
             }
             SledCommand::Iterator => {
-                let iterator = AsIterator::<(bool, TreasuryOutput), ()>::iter(storage)?;
+                let iterator = AsIterator::<(bool, TreasuryOutput), ()>::iter_op(storage)?;
 
                 for result in iterator {
                     let (key, value) = result?;

--- a/bee-node/bee-node/src/tools/sled.rs
+++ b/bee-node/bee-node/src/tools/sled.rs
@@ -15,7 +15,7 @@ use bee_message::{
     Message, MessageId,
 };
 use bee_storage::{
-    access::{AsIterator},
+    access::AsIterator,
     backend::{StorageBackend, StorageBackendExt},
 };
 use bee_storage_sled::{

--- a/bee-node/bee-node/src/tools/sled.rs
+++ b/bee-node/bee-node/src/tools/sled.rs
@@ -15,7 +15,7 @@ use bee_message::{
     Message, MessageId,
 };
 use bee_storage::{
-    access::{AsIterator, Exist},
+    access::{AsIterator},
     backend::{StorageBackend, StorageBackendExt},
 };
 use bee_storage_sled::{
@@ -163,7 +163,7 @@ fn exec_inner(tool: &SledTool, storage: &Storage) -> Result<(), SledError> {
         TREE_OUTPUT_ID_UNSPENT => match &tool.command {
             SledCommand::Fetch { key } => {
                 let key = Unspent::from(OutputId::from_str(key).map_err(|_| SledError::InvalidKey(key.clone()))?);
-                let value = Exist::<Unspent, ()>::exist_op(storage, &key)?;
+                let value = storage.exist::<Unspent, ()>(&key)?;
 
                 println!("Key: {:?}\nValue: {:?}\n", key, value);
             }

--- a/bee-node/bee-node/src/tools/sled.rs
+++ b/bee-node/bee-node/src/tools/sled.rs
@@ -15,7 +15,6 @@ use bee_message::{
     Message, MessageId,
 };
 use bee_storage::{
-    access::AsIterator,
     backend::{StorageBackend, StorageBackendExt},
 };
 use bee_storage_sled::{
@@ -67,7 +66,7 @@ fn exec_inner(tool: &SledTool, storage: &Storage) -> Result<(), SledError> {
                 println!("Key: {:?}\nValue: {:?}\n", key, value);
             }
             SledCommand::Iterator => {
-                let iterator = AsIterator::<MessageId, Message>::iter_op(storage)?;
+                let iterator = storage.iter::<MessageId, Message>()?;
 
                 for result in iterator {
                     let (key, value) = result?;
@@ -83,7 +82,7 @@ fn exec_inner(tool: &SledTool, storage: &Storage) -> Result<(), SledError> {
                 println!("Key: {:?}\nValue: {:?}\n", key, value);
             }
             SledCommand::Iterator => {
-                let iterator = AsIterator::<MessageId, MessageMetadata>::iter_op(storage)?;
+                let iterator = storage.iter::<MessageId, MessageMetadata>()?;
 
                 for result in iterator {
                     let (key, value) = result?;
@@ -99,7 +98,7 @@ fn exec_inner(tool: &SledTool, storage: &Storage) -> Result<(), SledError> {
                 println!("Key: {:?}\nValue: {:?}\n", key, value);
             }
             SledCommand::Iterator => {
-                let iterator = AsIterator::<(MessageId, MessageId), ()>::iter_op(storage)?;
+                let iterator = storage.iter::<(MessageId, MessageId), ()>()?;
 
                 for result in iterator {
                     let (key, value) = result?;
@@ -120,7 +119,7 @@ fn exec_inner(tool: &SledTool, storage: &Storage) -> Result<(), SledError> {
                 println!("Key: {:?}\nValue: {:?}\n", key, value);
             }
             SledCommand::Iterator => {
-                let iterator = AsIterator::<(PaddedIndex, MessageId), ()>::iter_op(storage)?;
+                let iterator = storage.iter::<(PaddedIndex, MessageId), ()>()?;
 
                 for result in iterator {
                     let (key, value) = result?;
@@ -136,7 +135,7 @@ fn exec_inner(tool: &SledTool, storage: &Storage) -> Result<(), SledError> {
                 println!("Key: {:?}\nValue: {:?}\n", key, value);
             }
             SledCommand::Iterator => {
-                let iterator = AsIterator::<OutputId, CreatedOutput>::iter_op(storage)?;
+                let iterator = storage.iter::<OutputId, CreatedOutput>()?;
 
                 for result in iterator {
                     let (key, value) = result?;
@@ -152,7 +151,7 @@ fn exec_inner(tool: &SledTool, storage: &Storage) -> Result<(), SledError> {
                 println!("Key: {:?}\nValue: {:?}\n", key, value);
             }
             SledCommand::Iterator => {
-                let iterator = AsIterator::<OutputId, ConsumedOutput>::iter_op(storage)?;
+                let iterator = storage.iter::<OutputId, ConsumedOutput>()?;
 
                 for result in iterator {
                     let (key, value) = result?;
@@ -168,7 +167,7 @@ fn exec_inner(tool: &SledTool, storage: &Storage) -> Result<(), SledError> {
                 println!("Key: {:?}\nValue: {:?}\n", key, value);
             }
             SledCommand::Iterator => {
-                let iterator = AsIterator::<Unspent, ()>::iter_op(storage)?;
+                let iterator = storage.iter::<Unspent, ()>()?;
 
                 for result in iterator {
                     let (key, value) = result?;
@@ -184,7 +183,7 @@ fn exec_inner(tool: &SledTool, storage: &Storage) -> Result<(), SledError> {
                 println!("Key: {:?}\nValue: {:?}\n", key, value);
             }
             SledCommand::Iterator => {
-                let iterator = AsIterator::<(Ed25519Address, OutputId), ()>::iter_op(storage)?;
+                let iterator = storage.iter::<(Ed25519Address, OutputId), ()>()?;
 
                 for result in iterator {
                     let (key, value) = result?;
@@ -195,7 +194,7 @@ fn exec_inner(tool: &SledTool, storage: &Storage) -> Result<(), SledError> {
         TREE_LEDGER_INDEX => match &tool.command {
             SledCommand::Fetch { key: _key } => return Err(SledError::UnsupportedCommand),
             SledCommand::Iterator => {
-                let iterator = AsIterator::<(), LedgerIndex>::iter_op(storage)?;
+                let iterator = storage.iter::<(), LedgerIndex>()?;
 
                 for result in iterator {
                     let (key, value) = result?;
@@ -211,7 +210,7 @@ fn exec_inner(tool: &SledTool, storage: &Storage) -> Result<(), SledError> {
                 println!("Key: {:?}\nValue: {:?}\n", key, value);
             }
             SledCommand::Iterator => {
-                let iterator = AsIterator::<MilestoneIndex, Milestone>::iter_op(storage)?;
+                let iterator = storage.iter::<MilestoneIndex, Milestone>()?;
 
                 for result in iterator {
                     let (key, value) = result?;
@@ -222,7 +221,7 @@ fn exec_inner(tool: &SledTool, storage: &Storage) -> Result<(), SledError> {
         TREE_SNAPSHOT_INFO => match &tool.command {
             SledCommand::Fetch { key: _key } => return Err(SledError::UnsupportedCommand),
             SledCommand::Iterator => {
-                let iterator = AsIterator::<(), SnapshotInfo>::iter_op(storage)?;
+                let iterator = storage.iter::<(), SnapshotInfo>()?;
 
                 for result in iterator {
                     let (key, value) = result?;
@@ -239,7 +238,7 @@ fn exec_inner(tool: &SledTool, storage: &Storage) -> Result<(), SledError> {
                 println!("Key: {:?}\nValue: {:?}\n", key, value);
             }
             SledCommand::Iterator => {
-                let iterator = AsIterator::<SolidEntryPoint, MilestoneIndex>::iter_op(storage)?;
+                let iterator = storage.iter::<SolidEntryPoint, MilestoneIndex>()?;
 
                 for result in iterator {
                     let (key, value) = result?;
@@ -255,7 +254,7 @@ fn exec_inner(tool: &SledTool, storage: &Storage) -> Result<(), SledError> {
                 println!("Key: {:?}\nValue: {:?}\n", key, value);
             }
             SledCommand::Iterator => {
-                let iterator = AsIterator::<MilestoneIndex, OutputDiff>::iter_op(storage)?;
+                let iterator = storage.iter::<MilestoneIndex, OutputDiff>()?;
 
                 for result in iterator {
                     let (key, value) = result?;
@@ -271,7 +270,7 @@ fn exec_inner(tool: &SledTool, storage: &Storage) -> Result<(), SledError> {
                 println!("Key: {:?}\nValue: {:?}\n", key, value);
             }
             SledCommand::Iterator => {
-                let iterator = AsIterator::<Address, Balance>::iter_op(storage)?;
+                let iterator = storage.iter::<Address, Balance>()?;
 
                 for result in iterator {
                     let (key, value) = result?;
@@ -287,7 +286,7 @@ fn exec_inner(tool: &SledTool, storage: &Storage) -> Result<(), SledError> {
                 println!("Key: {:?}\nValue: {:?}\n", key, value);
             }
             SledCommand::Iterator => {
-                let iterator = AsIterator::<(MilestoneIndex, UnreferencedMessage), ()>::iter_op(storage)?;
+                let iterator = storage.iter::<(MilestoneIndex, UnreferencedMessage), ()>()?;
 
                 for result in iterator {
                     let (key, value) = result?;
@@ -303,7 +302,7 @@ fn exec_inner(tool: &SledTool, storage: &Storage) -> Result<(), SledError> {
                 println!("Key: {:?}\nValue: {:?}\n", key, value);
             }
             SledCommand::Iterator => {
-                let iterator = AsIterator::<(MilestoneIndex, Receipt), ()>::iter_op(storage)?;
+                let iterator = storage.iter::<(MilestoneIndex, Receipt), ()>()?;
 
                 for result in iterator {
                     let (key, value) = result?;
@@ -319,7 +318,7 @@ fn exec_inner(tool: &SledTool, storage: &Storage) -> Result<(), SledError> {
                 println!("Key: {:?}\nValue: {:?}\n", key, value);
             }
             SledCommand::Iterator => {
-                let iterator = AsIterator::<(bool, TreasuryOutput), ()>::iter_op(storage)?;
+                let iterator = storage.iter::<(bool, TreasuryOutput), ()>()?;
 
                 for result in iterator {
                     let (key, value) = result?;

--- a/bee-node/bee-node/src/tools/sled.rs
+++ b/bee-node/bee-node/src/tools/sled.rs
@@ -15,8 +15,8 @@ use bee_message::{
     Message, MessageId,
 };
 use bee_storage::{
-    access::{AsIterator, Exist, Fetch},
-    backend::StorageBackend,
+    access::{AsIterator, Exist},
+    backend::{StorageBackend, StorageBackendExt},
 };
 use bee_storage_sled::{
     config::SledConfigBuilder,
@@ -62,7 +62,7 @@ fn exec_inner(tool: &SledTool, storage: &Storage) -> Result<(), SledError> {
         TREE_MESSAGE_ID_TO_MESSAGE => match &tool.command {
             SledCommand::Fetch { key } => {
                 let key = MessageId::from_str(key).map_err(|_| SledError::InvalidKey(key.clone()))?;
-                let value = Fetch::<MessageId, Message>::fetch(storage, &key)?;
+                let value = storage.fetch_access::<MessageId, Message>(&key)?;
 
                 println!("Key: {:?}\nValue: {:?}\n", key, value);
             }
@@ -78,7 +78,7 @@ fn exec_inner(tool: &SledTool, storage: &Storage) -> Result<(), SledError> {
         TREE_MESSAGE_ID_TO_METADATA => match &tool.command {
             SledCommand::Fetch { key } => {
                 let key = MessageId::from_str(key).map_err(|_| SledError::InvalidKey(key.clone()))?;
-                let value = Fetch::<MessageId, MessageMetadata>::fetch(storage, &key)?;
+                let value = storage.fetch_access::<MessageId, MessageMetadata>(&key)?;
 
                 println!("Key: {:?}\nValue: {:?}\n", key, value);
             }
@@ -94,7 +94,7 @@ fn exec_inner(tool: &SledTool, storage: &Storage) -> Result<(), SledError> {
         TREE_MESSAGE_ID_TO_MESSAGE_ID => match &tool.command {
             SledCommand::Fetch { key } => {
                 let key = MessageId::from_str(key).map_err(|_| SledError::InvalidKey(key.clone()))?;
-                let value = Fetch::<MessageId, Vec<MessageId>>::fetch(storage, &key)?;
+                let value = storage.fetch_access::<MessageId, Vec<MessageId>>(&key)?;
 
                 println!("Key: {:?}\nValue: {:?}\n", key, value);
             }
@@ -115,7 +115,7 @@ fn exec_inner(tool: &SledTool, storage: &Storage) -> Result<(), SledError> {
                 )
                 .map_err(|_| SledError::InvalidKey(key.clone()))?
                 .padded_index();
-                let value = Fetch::<PaddedIndex, Vec<MessageId>>::fetch(storage, &key)?;
+                let value = storage.fetch_access::<PaddedIndex, Vec<MessageId>>(&key)?;
 
                 println!("Key: {:?}\nValue: {:?}\n", key, value);
             }
@@ -131,7 +131,7 @@ fn exec_inner(tool: &SledTool, storage: &Storage) -> Result<(), SledError> {
         TREE_OUTPUT_ID_TO_CREATED_OUTPUT => match &tool.command {
             SledCommand::Fetch { key } => {
                 let key = OutputId::from_str(key).map_err(|_| SledError::InvalidKey(key.clone()))?;
-                let value = Fetch::<OutputId, CreatedOutput>::fetch(storage, &key)?;
+                let value = storage.fetch_access::<OutputId, CreatedOutput>(&key)?;
 
                 println!("Key: {:?}\nValue: {:?}\n", key, value);
             }
@@ -147,7 +147,7 @@ fn exec_inner(tool: &SledTool, storage: &Storage) -> Result<(), SledError> {
         TREE_OUTPUT_ID_TO_CONSUMED_OUTPUT => match &tool.command {
             SledCommand::Fetch { key } => {
                 let key = OutputId::from_str(key).map_err(|_| SledError::InvalidKey(key.clone()))?;
-                let value = Fetch::<OutputId, ConsumedOutput>::fetch(storage, &key)?;
+                let value = storage.fetch_access::<OutputId, ConsumedOutput>(&key)?;
 
                 println!("Key: {:?}\nValue: {:?}\n", key, value);
             }
@@ -179,7 +179,7 @@ fn exec_inner(tool: &SledTool, storage: &Storage) -> Result<(), SledError> {
         TREE_ED25519_ADDRESS_TO_OUTPUT_ID => match &tool.command {
             SledCommand::Fetch { key } => {
                 let key = Ed25519Address::from_str(key).map_err(|_| SledError::InvalidKey(key.clone()))?;
-                let value = Fetch::<Ed25519Address, Vec<OutputId>>::fetch(storage, &key)?;
+                let value = storage.fetch_access::<Ed25519Address, Vec<OutputId>>(&key)?;
 
                 println!("Key: {:?}\nValue: {:?}\n", key, value);
             }
@@ -206,7 +206,7 @@ fn exec_inner(tool: &SledTool, storage: &Storage) -> Result<(), SledError> {
         TREE_MILESTONE_INDEX_TO_MILESTONE => match &tool.command {
             SledCommand::Fetch { key } => {
                 let key = MilestoneIndex(u32::from_str(key).map_err(|_| SledError::InvalidKey(key.clone()))?);
-                let value = Fetch::<MilestoneIndex, Milestone>::fetch(storage, &key)?;
+                let value = storage.fetch_access::<MilestoneIndex, Milestone>(&key)?;
 
                 println!("Key: {:?}\nValue: {:?}\n", key, value);
             }
@@ -234,7 +234,7 @@ fn exec_inner(tool: &SledTool, storage: &Storage) -> Result<(), SledError> {
             SledCommand::Fetch { key } => {
                 let key =
                     SolidEntryPoint::from(MessageId::from_str(key).map_err(|_| SledError::InvalidKey(key.clone()))?);
-                let value = Fetch::<SolidEntryPoint, MilestoneIndex>::fetch(storage, &key)?;
+                let value = storage.fetch_access::<SolidEntryPoint, MilestoneIndex>(&key)?;
 
                 println!("Key: {:?}\nValue: {:?}\n", key, value);
             }
@@ -250,7 +250,7 @@ fn exec_inner(tool: &SledTool, storage: &Storage) -> Result<(), SledError> {
         TREE_MILESTONE_INDEX_TO_OUTPUT_DIFF => match &tool.command {
             SledCommand::Fetch { key } => {
                 let key = MilestoneIndex(u32::from_str(key).map_err(|_| SledError::InvalidKey(key.clone()))?);
-                let value = Fetch::<MilestoneIndex, OutputDiff>::fetch(storage, &key)?;
+                let value = storage.fetch_access::<MilestoneIndex, OutputDiff>(&key)?;
 
                 println!("Key: {:?}\nValue: {:?}\n", key, value);
             }
@@ -266,7 +266,7 @@ fn exec_inner(tool: &SledTool, storage: &Storage) -> Result<(), SledError> {
         TREE_ADDRESS_TO_BALANCE => match &tool.command {
             SledCommand::Fetch { key } => {
                 let key = Address::from(Ed25519Address::from_str(key).map_err(|_| SledError::InvalidKey(key.clone()))?);
-                let value = Fetch::<Address, Balance>::fetch(storage, &key)?;
+                let value = storage.fetch_access::<Address, Balance>(&key)?;
 
                 println!("Key: {:?}\nValue: {:?}\n", key, value);
             }
@@ -282,7 +282,7 @@ fn exec_inner(tool: &SledTool, storage: &Storage) -> Result<(), SledError> {
         TREE_MILESTONE_INDEX_TO_UNREFERENCED_MESSAGE => match &tool.command {
             SledCommand::Fetch { key } => {
                 let key = MilestoneIndex(u32::from_str(key).map_err(|_| SledError::InvalidKey(key.clone()))?);
-                let value = Fetch::<MilestoneIndex, Vec<UnreferencedMessage>>::fetch(storage, &key)?;
+                let value = storage.fetch_access::<MilestoneIndex, Vec<UnreferencedMessage>>(&key)?;
 
                 println!("Key: {:?}\nValue: {:?}\n", key, value);
             }
@@ -298,7 +298,7 @@ fn exec_inner(tool: &SledTool, storage: &Storage) -> Result<(), SledError> {
         TREE_MILESTONE_INDEX_TO_RECEIPT => match &tool.command {
             SledCommand::Fetch { key } => {
                 let key = MilestoneIndex(u32::from_str(key).map_err(|_| SledError::InvalidKey(key.clone()))?);
-                let value = Fetch::<MilestoneIndex, Vec<Receipt>>::fetch(storage, &key)?;
+                let value = storage.fetch_access::<MilestoneIndex, Vec<Receipt>>(&key)?;
 
                 println!("Key: {:?}\nValue: {:?}\n", key, value);
             }
@@ -314,7 +314,7 @@ fn exec_inner(tool: &SledTool, storage: &Storage) -> Result<(), SledError> {
         TREE_SPENT_TO_TREASURY_OUTPUT => match &tool.command {
             SledCommand::Fetch { key } => {
                 let key = bool::from_str(key).map_err(|_| SledError::InvalidKey(key.clone()))?;
-                let value = Fetch::<bool, Vec<TreasuryOutput>>::fetch(storage, &key)?;
+                let value = storage.fetch_access::<bool, Vec<TreasuryOutput>>(&key)?;
 
                 println!("Key: {:?}\nValue: {:?}\n", key, value);
             }

--- a/bee-node/bee-node/src/tools/sled.rs
+++ b/bee-node/bee-node/src/tools/sled.rs
@@ -14,9 +14,7 @@ use bee_message::{
     payload::indexation::{IndexationPayload, PaddedIndex},
     Message, MessageId,
 };
-use bee_storage::{
-    backend::{StorageBackend, StorageBackendExt},
-};
+use bee_storage::backend::{StorageBackend, StorageBackendExt};
 use bee_storage_sled::{
     config::SledConfigBuilder,
     storage::{Error as BackendError, Storage},

--- a/bee-node/bee-node/src/tools/sled.rs
+++ b/bee-node/bee-node/src/tools/sled.rs
@@ -62,7 +62,7 @@ fn exec_inner(tool: &SledTool, storage: &Storage) -> Result<(), SledError> {
         TREE_MESSAGE_ID_TO_MESSAGE => match &tool.command {
             SledCommand::Fetch { key } => {
                 let key = MessageId::from_str(key).map_err(|_| SledError::InvalidKey(key.clone()))?;
-                let value = storage.fetch_access::<MessageId, Message>(&key)?;
+                let value = storage.fetch::<MessageId, Message>(&key)?;
 
                 println!("Key: {:?}\nValue: {:?}\n", key, value);
             }
@@ -78,7 +78,7 @@ fn exec_inner(tool: &SledTool, storage: &Storage) -> Result<(), SledError> {
         TREE_MESSAGE_ID_TO_METADATA => match &tool.command {
             SledCommand::Fetch { key } => {
                 let key = MessageId::from_str(key).map_err(|_| SledError::InvalidKey(key.clone()))?;
-                let value = storage.fetch_access::<MessageId, MessageMetadata>(&key)?;
+                let value = storage.fetch::<MessageId, MessageMetadata>(&key)?;
 
                 println!("Key: {:?}\nValue: {:?}\n", key, value);
             }
@@ -94,7 +94,7 @@ fn exec_inner(tool: &SledTool, storage: &Storage) -> Result<(), SledError> {
         TREE_MESSAGE_ID_TO_MESSAGE_ID => match &tool.command {
             SledCommand::Fetch { key } => {
                 let key = MessageId::from_str(key).map_err(|_| SledError::InvalidKey(key.clone()))?;
-                let value = storage.fetch_access::<MessageId, Vec<MessageId>>(&key)?;
+                let value = storage.fetch::<MessageId, Vec<MessageId>>(&key)?;
 
                 println!("Key: {:?}\nValue: {:?}\n", key, value);
             }
@@ -115,7 +115,7 @@ fn exec_inner(tool: &SledTool, storage: &Storage) -> Result<(), SledError> {
                 )
                 .map_err(|_| SledError::InvalidKey(key.clone()))?
                 .padded_index();
-                let value = storage.fetch_access::<PaddedIndex, Vec<MessageId>>(&key)?;
+                let value = storage.fetch::<PaddedIndex, Vec<MessageId>>(&key)?;
 
                 println!("Key: {:?}\nValue: {:?}\n", key, value);
             }
@@ -131,7 +131,7 @@ fn exec_inner(tool: &SledTool, storage: &Storage) -> Result<(), SledError> {
         TREE_OUTPUT_ID_TO_CREATED_OUTPUT => match &tool.command {
             SledCommand::Fetch { key } => {
                 let key = OutputId::from_str(key).map_err(|_| SledError::InvalidKey(key.clone()))?;
-                let value = storage.fetch_access::<OutputId, CreatedOutput>(&key)?;
+                let value = storage.fetch::<OutputId, CreatedOutput>(&key)?;
 
                 println!("Key: {:?}\nValue: {:?}\n", key, value);
             }
@@ -147,7 +147,7 @@ fn exec_inner(tool: &SledTool, storage: &Storage) -> Result<(), SledError> {
         TREE_OUTPUT_ID_TO_CONSUMED_OUTPUT => match &tool.command {
             SledCommand::Fetch { key } => {
                 let key = OutputId::from_str(key).map_err(|_| SledError::InvalidKey(key.clone()))?;
-                let value = storage.fetch_access::<OutputId, ConsumedOutput>(&key)?;
+                let value = storage.fetch::<OutputId, ConsumedOutput>(&key)?;
 
                 println!("Key: {:?}\nValue: {:?}\n", key, value);
             }
@@ -179,7 +179,7 @@ fn exec_inner(tool: &SledTool, storage: &Storage) -> Result<(), SledError> {
         TREE_ED25519_ADDRESS_TO_OUTPUT_ID => match &tool.command {
             SledCommand::Fetch { key } => {
                 let key = Ed25519Address::from_str(key).map_err(|_| SledError::InvalidKey(key.clone()))?;
-                let value = storage.fetch_access::<Ed25519Address, Vec<OutputId>>(&key)?;
+                let value = storage.fetch::<Ed25519Address, Vec<OutputId>>(&key)?;
 
                 println!("Key: {:?}\nValue: {:?}\n", key, value);
             }
@@ -206,7 +206,7 @@ fn exec_inner(tool: &SledTool, storage: &Storage) -> Result<(), SledError> {
         TREE_MILESTONE_INDEX_TO_MILESTONE => match &tool.command {
             SledCommand::Fetch { key } => {
                 let key = MilestoneIndex(u32::from_str(key).map_err(|_| SledError::InvalidKey(key.clone()))?);
-                let value = storage.fetch_access::<MilestoneIndex, Milestone>(&key)?;
+                let value = storage.fetch::<MilestoneIndex, Milestone>(&key)?;
 
                 println!("Key: {:?}\nValue: {:?}\n", key, value);
             }
@@ -234,7 +234,7 @@ fn exec_inner(tool: &SledTool, storage: &Storage) -> Result<(), SledError> {
             SledCommand::Fetch { key } => {
                 let key =
                     SolidEntryPoint::from(MessageId::from_str(key).map_err(|_| SledError::InvalidKey(key.clone()))?);
-                let value = storage.fetch_access::<SolidEntryPoint, MilestoneIndex>(&key)?;
+                let value = storage.fetch::<SolidEntryPoint, MilestoneIndex>(&key)?;
 
                 println!("Key: {:?}\nValue: {:?}\n", key, value);
             }
@@ -250,7 +250,7 @@ fn exec_inner(tool: &SledTool, storage: &Storage) -> Result<(), SledError> {
         TREE_MILESTONE_INDEX_TO_OUTPUT_DIFF => match &tool.command {
             SledCommand::Fetch { key } => {
                 let key = MilestoneIndex(u32::from_str(key).map_err(|_| SledError::InvalidKey(key.clone()))?);
-                let value = storage.fetch_access::<MilestoneIndex, OutputDiff>(&key)?;
+                let value = storage.fetch::<MilestoneIndex, OutputDiff>(&key)?;
 
                 println!("Key: {:?}\nValue: {:?}\n", key, value);
             }
@@ -266,7 +266,7 @@ fn exec_inner(tool: &SledTool, storage: &Storage) -> Result<(), SledError> {
         TREE_ADDRESS_TO_BALANCE => match &tool.command {
             SledCommand::Fetch { key } => {
                 let key = Address::from(Ed25519Address::from_str(key).map_err(|_| SledError::InvalidKey(key.clone()))?);
-                let value = storage.fetch_access::<Address, Balance>(&key)?;
+                let value = storage.fetch::<Address, Balance>(&key)?;
 
                 println!("Key: {:?}\nValue: {:?}\n", key, value);
             }
@@ -282,7 +282,7 @@ fn exec_inner(tool: &SledTool, storage: &Storage) -> Result<(), SledError> {
         TREE_MILESTONE_INDEX_TO_UNREFERENCED_MESSAGE => match &tool.command {
             SledCommand::Fetch { key } => {
                 let key = MilestoneIndex(u32::from_str(key).map_err(|_| SledError::InvalidKey(key.clone()))?);
-                let value = storage.fetch_access::<MilestoneIndex, Vec<UnreferencedMessage>>(&key)?;
+                let value = storage.fetch::<MilestoneIndex, Vec<UnreferencedMessage>>(&key)?;
 
                 println!("Key: {:?}\nValue: {:?}\n", key, value);
             }
@@ -298,7 +298,7 @@ fn exec_inner(tool: &SledTool, storage: &Storage) -> Result<(), SledError> {
         TREE_MILESTONE_INDEX_TO_RECEIPT => match &tool.command {
             SledCommand::Fetch { key } => {
                 let key = MilestoneIndex(u32::from_str(key).map_err(|_| SledError::InvalidKey(key.clone()))?);
-                let value = storage.fetch_access::<MilestoneIndex, Vec<Receipt>>(&key)?;
+                let value = storage.fetch::<MilestoneIndex, Vec<Receipt>>(&key)?;
 
                 println!("Key: {:?}\nValue: {:?}\n", key, value);
             }
@@ -314,7 +314,7 @@ fn exec_inner(tool: &SledTool, storage: &Storage) -> Result<(), SledError> {
         TREE_SPENT_TO_TREASURY_OUTPUT => match &tool.command {
             SledCommand::Fetch { key } => {
                 let key = bool::from_str(key).map_err(|_| SledError::InvalidKey(key.clone()))?;
-                let value = storage.fetch_access::<bool, Vec<TreasuryOutput>>(&key)?;
+                let value = storage.fetch::<bool, Vec<TreasuryOutput>>(&key)?;
 
                 println!("Key: {:?}\nValue: {:?}\n", key, value);
             }

--- a/bee-protocol/src/workers/message/payload/indexation.rs
+++ b/bee-protocol/src/workers/message/payload/indexation.rs
@@ -58,7 +58,7 @@ fn process<B: StorageBackend>(storage: &B, metrics: &NodeMetrics, message_id: Me
     metrics.indexation_payloads_inc(1);
 
     if let Err(e) =
-        Insert::<(PaddedIndex, MessageId), ()>::insert(&*storage, &(indexation.padded_index(), message_id), &())
+        Insert::<(PaddedIndex, MessageId), ()>::insert_op(&*storage, &(indexation.padded_index(), message_id), &())
     {
         error!(
             "Inserting indexation payload for message {} failed: {:?}.",

--- a/bee-protocol/src/workers/message/payload/indexation.rs
+++ b/bee-protocol/src/workers/message/payload/indexation.rs
@@ -9,7 +9,7 @@ use bee_message::{
     Message, MessageId,
 };
 use bee_runtime::{node::Node, shutdown_stream::ShutdownStream, worker::Worker};
-use bee_storage::access::Insert;
+use bee_storage::backend::StorageBackendExt;
 use futures::{future::FutureExt, stream::StreamExt};
 use log::{debug, error, info};
 use tokio::sync::mpsc;
@@ -57,9 +57,7 @@ fn process<B: StorageBackend>(storage: &B, metrics: &NodeMetrics, message_id: Me
 
     metrics.indexation_payloads_inc(1);
 
-    if let Err(e) =
-        Insert::<(PaddedIndex, MessageId), ()>::insert_op(&*storage, &(indexation.padded_index(), message_id), &())
-    {
+    if let Err(e) = storage.insert::<(PaddedIndex, MessageId), ()>(&(indexation.padded_index(), message_id), &()) {
         error!(
             "Inserting indexation payload for message {} failed: {:?}.",
             message_id, e

--- a/bee-protocol/src/workers/message/payload/indexation.rs
+++ b/bee-protocol/src/workers/message/payload/indexation.rs
@@ -5,7 +5,7 @@ use std::{any::TypeId, convert::Infallible};
 
 use async_trait::async_trait;
 use bee_message::{
-    payload::{indexation::PaddedIndex, transaction::Essence, Payload},
+    payload::{transaction::Essence, Payload},
     Message, MessageId,
 };
 use bee_runtime::{node::Node, shutdown_stream::ShutdownStream, worker::Worker};
@@ -57,7 +57,7 @@ fn process<B: StorageBackend>(storage: &B, metrics: &NodeMetrics, message_id: Me
 
     metrics.indexation_payloads_inc(1);
 
-    if let Err(e) = storage.insert::<(PaddedIndex, MessageId), ()>(&(indexation.padded_index(), message_id), &()) {
+    if let Err(e) = storage.insert(&(indexation.padded_index(), message_id), &()) {
         error!(
             "Inserting indexation payload for message {} failed: {:?}.",
             message_id, e

--- a/bee-protocol/src/workers/message/unreferenced_inserter.rs
+++ b/bee-protocol/src/workers/message/unreferenced_inserter.rs
@@ -47,11 +47,7 @@ where
             let mut receiver = ShutdownStream::new(shutdown, UnboundedReceiverStream::new(rx));
 
             while let Some(UnreferencedMessageInserterWorkerEvent(message_id, index)) = receiver.next().await {
-                if let Err(e) = storage.batch_insert::<(MilestoneIndex, UnreferencedMessage), ()>(
-                    &mut batch,
-                    &(index, UnreferencedMessage::from(message_id)),
-                    &(),
-                ) {
+                if let Err(e) = storage.batch_insert(&mut batch, &(index, UnreferencedMessage::from(message_id)), &()) {
                     error!("Batch inserting unreferenced message failed: {:?}.", e);
                 }
 
@@ -78,10 +74,7 @@ where
             while let Some(Some(UnreferencedMessageInserterWorkerEvent(message_id, index))) =
                 receiver.next().now_or_never()
             {
-                if let Err(e) = storage.insert::<(MilestoneIndex, UnreferencedMessage), ()>(
-                    &(index, UnreferencedMessage::from(message_id)),
-                    &(),
-                ) {
+                if let Err(e) = storage.insert(&(index, UnreferencedMessage::from(message_id)), &()) {
                     error!("Inserting unreferenced message failed: {:?}.", e);
                 }
                 counter += 1;

--- a/bee-storage/bee-storage-memory/src/access/batch.rs
+++ b/bee-storage/bee-storage-memory/src/access/batch.rs
@@ -87,7 +87,7 @@ impl BatchBuilder for Storage {
 macro_rules! impl_batch {
     ($key:ty, $value:ty, $field:ident) => {
         impl Batch<$key, $value> for Storage {
-            fn batch_insert(
+            fn batch_insert_op(
                 &self,
                 batch: &mut Self::Batch,
                 key: &$key,
@@ -98,7 +98,11 @@ macro_rules! impl_batch {
                 Ok(())
             }
 
-            fn batch_delete(&self, batch: &mut Self::Batch, key: &$key) -> Result<(), <Self as StorageBackend>::Error> {
+            fn batch_delete_op(
+                &self,
+                batch: &mut Self::Batch,
+                key: &$key,
+            ) -> Result<(), <Self as StorageBackend>::Error> {
                 batch.$field.delete(key);
 
                 Ok(())

--- a/bee-storage/bee-storage-memory/src/access/delete.rs
+++ b/bee-storage/bee-storage-memory/src/access/delete.rs
@@ -24,7 +24,7 @@ use crate::storage::Storage;
 macro_rules! impl_delete {
     ($key:ty, $value:ty, $field:ident) => {
         impl Delete<$key, $value> for Storage {
-            fn delete(&self, k: &$key) -> Result<(), <Self as StorageBackend>::Error> {
+            fn delete_op(&self, k: &$key) -> Result<(), <Self as StorageBackend>::Error> {
                 self.inner.write()?.$field.delete(k);
 
                 Ok(())

--- a/bee-storage/bee-storage-memory/src/access/exist.rs
+++ b/bee-storage/bee-storage-memory/src/access/exist.rs
@@ -24,7 +24,7 @@ use crate::storage::Storage;
 macro_rules! impl_exist {
     ($key:ty, $value:ty, $field:ident) => {
         impl Exist<$key, $value> for Storage {
-            fn exist(&self, k: &$key) -> Result<bool, <Self as StorageBackend>::Error> {
+            fn exist_op(&self, k: &$key) -> Result<bool, <Self as StorageBackend>::Error> {
                 Ok(self.inner.read()?.$field.exist(k))
             }
         }

--- a/bee-storage/bee-storage-memory/src/access/fetch.rs
+++ b/bee-storage/bee-storage-memory/src/access/fetch.rs
@@ -24,7 +24,7 @@ use crate::storage::Storage;
 macro_rules! impl_fetch {
     ($key:ty, $value:ty, $field:ident) => {
         impl Fetch<$key, $value> for Storage {
-            fn fetch(&self, k: &$key) -> Result<Option<$value>, <Self as StorageBackend>::Error> {
+            fn fetch_op(&self, k: &$key) -> Result<Option<$value>, <Self as StorageBackend>::Error> {
                 Ok(self.inner.read()?.$field.fetch(k))
             }
         }

--- a/bee-storage/bee-storage-memory/src/access/insert.rs
+++ b/bee-storage/bee-storage-memory/src/access/insert.rs
@@ -28,7 +28,7 @@ use crate::storage::Storage;
 macro_rules! impl_insert {
     ($key:ty, $value:ty, $field:ident) => {
         impl Insert<$key, $value> for Storage {
-            fn insert(&self, k: &$key, v: &$value) -> Result<(), <Self as StorageBackend>::Error> {
+            fn insert_op(&self, k: &$key, v: &$value) -> Result<(), <Self as StorageBackend>::Error> {
                 self.inner.write()?.$field.insert(k, v);
 
                 Ok(())
@@ -60,7 +60,7 @@ impl_insert!((MilestoneIndex, Receipt), (), milestone_index_to_receipt);
 impl_insert!((bool, TreasuryOutput), (), spent_to_treasury_output);
 
 impl InsertStrict<MessageId, MessageMetadata> for Storage {
-    fn insert_strict(&self, k: &MessageId, v: &MessageMetadata) -> Result<(), <Self as StorageBackend>::Error> {
+    fn insert_strict_op(&self, k: &MessageId, v: &MessageMetadata) -> Result<(), <Self as StorageBackend>::Error> {
         let mut guard = self.inner.write()?;
 
         if !guard.message_id_to_metadata.exist(k) {

--- a/bee-storage/bee-storage-memory/src/access/iter.rs
+++ b/bee-storage/bee-storage-memory/src/access/iter.rs
@@ -29,7 +29,7 @@ macro_rules! impl_iter {
         impl<'a> AsIterator<'a, ($key, $value), ()> for Storage {
             type AsIter = VecTableIter<$key, $value>;
 
-            fn iter(&'a self) -> Result<Self::AsIter, <Self as StorageBackend>::Error> {
+            fn iter_op(&'a self) -> Result<Self::AsIter, <Self as StorageBackend>::Error> {
                 Ok(self.inner.read()?.$field.iter())
             }
         }
@@ -39,7 +39,7 @@ macro_rules! impl_iter {
         impl<'a> AsIterator<'a, (), $value> for Storage {
             type AsIter = SingletonTableIter<$value>;
 
-            fn iter(&'a self) -> Result<Self::AsIter, <Self as StorageBackend>::Error> {
+            fn iter_op(&'a self) -> Result<Self::AsIter, <Self as StorageBackend>::Error> {
                 Ok(self.inner.read()?.$field.iter())
             }
         }
@@ -48,7 +48,7 @@ macro_rules! impl_iter {
         impl<'a> AsIterator<'a, $key, $value> for Storage {
             type AsIter = TableIter<$key, $value>;
 
-            fn iter(&'a self) -> Result<Self::AsIter, <Self as StorageBackend>::Error> {
+            fn iter_op(&'a self) -> Result<Self::AsIter, <Self as StorageBackend>::Error> {
                 Ok(self.inner.read()?.$field.iter())
             }
         }

--- a/bee-storage/bee-storage-memory/src/access/multi_fetch.rs
+++ b/bee-storage/bee-storage-memory/src/access/multi_fetch.rs
@@ -25,7 +25,7 @@ macro_rules! impl_multi_fetch {
                 fn(Option<$value>) -> Result<Option<$value>, <Self as StorageBackend>::Error>,
             >;
 
-            fn multi_fetch(&'a self, keys: &'a [$key]) -> Result<Self::Iter, <Self as StorageBackend>::Error> {
+            fn multi_fetch_op(&'a self, keys: &'a [$key]) -> Result<Self::Iter, <Self as StorageBackend>::Error> {
                 Ok(self.inner.read()?.$field.multi_fetch(keys))
             }
         }

--- a/bee-storage/bee-storage-memory/src/access/truncate.rs
+++ b/bee-storage/bee-storage-memory/src/access/truncate.rs
@@ -24,7 +24,7 @@ use crate::storage::Storage;
 macro_rules! impl_truncate {
     ($key:ty, $value:ty, $field:ident) => {
         impl Truncate<$key, $value> for Storage {
-            fn truncate(&self) -> Result<(), <Self as StorageBackend>::Error> {
+            fn truncate_op(&self) -> Result<(), <Self as StorageBackend>::Error> {
                 self.inner.write()?.$field.truncate();
 
                 Ok(())

--- a/bee-storage/bee-storage-memory/src/access/update.rs
+++ b/bee-storage/bee-storage-memory/src/access/update.rs
@@ -12,7 +12,7 @@ use crate::storage::Storage;
 macro_rules! impl_update {
     ($key:ty, $value:ty, $field:ident) => {
         impl Update<$key, $value> for Storage {
-            fn update(&self, k: &$key, f: impl FnMut(&mut $value)) -> Result<(), <Self as StorageBackend>::Error> {
+            fn update_op(&self, k: &$key, f: impl FnMut(&mut $value)) -> Result<(), <Self as StorageBackend>::Error> {
                 Ok(self.inner.write()?.$field.update(k, f))
             }
         }

--- a/bee-storage/bee-storage-memory/src/storage.rs
+++ b/bee-storage/bee-storage-memory/src/storage.rs
@@ -16,8 +16,8 @@ use bee_message::{
     Message, MessageId,
 };
 use bee_storage::{
-    access::{Fetch, Insert},
-    backend::StorageBackend,
+    access::Insert,
+    backend::{StorageBackend, StorageBackendExt},
     system::{StorageHealth, StorageVersion, System, SYSTEM_HEALTH_KEY, SYSTEM_VERSION_KEY},
 };
 use bee_tangle::{
@@ -92,7 +92,7 @@ impl StorageBackend for Storage {
     fn start(_: Self::Config) -> Result<Self, Self::Error> {
         let storage = Self::new();
 
-        match Fetch::<u8, System>::fetch(&storage, &SYSTEM_VERSION_KEY)? {
+        match storage.fetch_access::<u8, System>(&SYSTEM_VERSION_KEY)? {
             Some(System::Version(version)) => {
                 if version != STORAGE_VERSION {
                     return Err(Error::VersionMismatch(version, STORAGE_VERSION));
@@ -123,7 +123,7 @@ impl StorageBackend for Storage {
     }
 
     fn get_health(&self) -> Result<Option<StorageHealth>, Self::Error> {
-        Ok(match Fetch::<u8, System>::fetch(self, &SYSTEM_HEALTH_KEY)? {
+        Ok(match self.fetch_access::<u8, System>(&SYSTEM_HEALTH_KEY)? {
             Some(System::Health(health)) => Some(health),
             None => None,
             _ => panic!("Another system value was inserted on the health key."),

--- a/bee-storage/bee-storage-memory/src/storage.rs
+++ b/bee-storage/bee-storage-memory/src/storage.rs
@@ -92,7 +92,7 @@ impl StorageBackend for Storage {
     fn start(_: Self::Config) -> Result<Self, Self::Error> {
         let storage = Self::new();
 
-        match storage.fetch_access::<u8, System>(&SYSTEM_VERSION_KEY)? {
+        match storage.fetch::<u8, System>(&SYSTEM_VERSION_KEY)? {
             Some(System::Version(version)) => {
                 if version != STORAGE_VERSION {
                     return Err(Error::VersionMismatch(version, STORAGE_VERSION));
@@ -123,7 +123,7 @@ impl StorageBackend for Storage {
     }
 
     fn get_health(&self) -> Result<Option<StorageHealth>, Self::Error> {
-        Ok(match self.fetch_access::<u8, System>(&SYSTEM_HEALTH_KEY)? {
+        Ok(match self.fetch::<u8, System>(&SYSTEM_HEALTH_KEY)? {
             Some(System::Health(health)) => Some(health),
             None => None,
             _ => panic!("Another system value was inserted on the health key."),

--- a/bee-storage/bee-storage-memory/src/storage.rs
+++ b/bee-storage/bee-storage-memory/src/storage.rs
@@ -98,7 +98,7 @@ impl StorageBackend for Storage {
                     return Err(Error::VersionMismatch(version, STORAGE_VERSION));
                 }
             }
-            None => Insert::<u8, System>::insert(&storage, &SYSTEM_VERSION_KEY, &System::Version(STORAGE_VERSION))?,
+            None => Insert::<u8, System>::insert_op(&storage, &SYSTEM_VERSION_KEY, &System::Version(STORAGE_VERSION))?,
             _ => panic!("Another system value was inserted on the version key."),
         }
 
@@ -131,6 +131,6 @@ impl StorageBackend for Storage {
     }
 
     fn set_health(&self, health: StorageHealth) -> Result<(), Self::Error> {
-        Insert::<u8, System>::insert(self, &SYSTEM_HEALTH_KEY, &System::Health(health))
+        Insert::<u8, System>::insert_op(self, &SYSTEM_HEALTH_KEY, &System::Health(health))
     }
 }

--- a/bee-storage/bee-storage-memory/src/storage.rs
+++ b/bee-storage/bee-storage-memory/src/storage.rs
@@ -97,7 +97,7 @@ impl StorageBackend for Storage {
                     return Err(Error::VersionMismatch(version, STORAGE_VERSION));
                 }
             }
-            None => storage.insert::<u8, System>(&SYSTEM_VERSION_KEY, &System::Version(STORAGE_VERSION))?,
+            None => storage.insert(&SYSTEM_VERSION_KEY, &System::Version(STORAGE_VERSION))?,
             _ => panic!("Another system value was inserted on the version key."),
         }
 
@@ -130,6 +130,6 @@ impl StorageBackend for Storage {
     }
 
     fn set_health(&self, health: StorageHealth) -> Result<(), Self::Error> {
-        self.insert::<u8, System>(&SYSTEM_HEALTH_KEY, &System::Health(health))
+        self.insert(&SYSTEM_HEALTH_KEY, &System::Health(health))
     }
 }

--- a/bee-storage/bee-storage-memory/src/storage.rs
+++ b/bee-storage/bee-storage-memory/src/storage.rs
@@ -16,7 +16,6 @@ use bee_message::{
     Message, MessageId,
 };
 use bee_storage::{
-    access::Insert,
     backend::{StorageBackend, StorageBackendExt},
     system::{StorageHealth, StorageVersion, System, SYSTEM_HEALTH_KEY, SYSTEM_VERSION_KEY},
 };
@@ -98,7 +97,7 @@ impl StorageBackend for Storage {
                     return Err(Error::VersionMismatch(version, STORAGE_VERSION));
                 }
             }
-            None => Insert::<u8, System>::insert_op(&storage, &SYSTEM_VERSION_KEY, &System::Version(STORAGE_VERSION))?,
+            None => storage.insert::<u8, System>(&SYSTEM_VERSION_KEY, &System::Version(STORAGE_VERSION))?,
             _ => panic!("Another system value was inserted on the version key."),
         }
 
@@ -131,6 +130,6 @@ impl StorageBackend for Storage {
     }
 
     fn set_health(&self, health: StorageHealth) -> Result<(), Self::Error> {
-        Insert::<u8, System>::insert_op(self, &SYSTEM_HEALTH_KEY, &System::Health(health))
+        self.insert::<u8, System>(&SYSTEM_HEALTH_KEY, &System::Health(health))
     }
 }

--- a/bee-storage/bee-storage-null/src/access/batch.rs
+++ b/bee-storage/bee-storage-null/src/access/batch.rs
@@ -17,11 +17,11 @@ impl BatchBuilder for Storage {
 }
 
 impl<K, V> Batch<K, V> for Storage {
-    fn batch_insert(&self, _batch: &mut Self::Batch, _key: &K, _value: &V) -> Result<(), Self::Error> {
+    fn batch_insert_op(&self, _batch: &mut Self::Batch, _key: &K, _value: &V) -> Result<(), Self::Error> {
         Ok(())
     }
 
-    fn batch_delete(&self, _batch: &mut Self::Batch, _key: &K) -> Result<(), Self::Error> {
+    fn batch_delete_op(&self, _batch: &mut Self::Batch, _key: &K) -> Result<(), Self::Error> {
         Ok(())
     }
 }

--- a/bee-storage/bee-storage-null/src/access/delete.rs
+++ b/bee-storage/bee-storage-null/src/access/delete.rs
@@ -6,7 +6,7 @@ use bee_storage::access::Delete;
 use crate::Storage;
 
 impl<K, V> Delete<K, V> for Storage {
-    fn delete(&self, _key: &K) -> Result<(), Self::Error> {
+    fn delete_op(&self, _key: &K) -> Result<(), Self::Error> {
         Ok(())
     }
 }

--- a/bee-storage/bee-storage-null/src/access/exist.rs
+++ b/bee-storage/bee-storage-null/src/access/exist.rs
@@ -6,7 +6,7 @@ use bee_storage::access::Exist;
 use crate::Storage;
 
 impl<K, V> Exist<K, V> for Storage {
-    fn exist(&self, _key: &K) -> Result<bool, Self::Error> {
+    fn exist_op(&self, _key: &K) -> Result<bool, Self::Error> {
         Ok(false)
     }
 }

--- a/bee-storage/bee-storage-null/src/access/fetch.rs
+++ b/bee-storage/bee-storage-null/src/access/fetch.rs
@@ -6,7 +6,7 @@ use bee_storage::access::Fetch;
 use crate::Storage;
 
 impl<K, V> Fetch<K, V> for Storage {
-    fn fetch(&self, _key: &K) -> Result<Option<V>, Self::Error> {
+    fn fetch_op(&self, _key: &K) -> Result<Option<V>, Self::Error> {
         Ok(None)
     }
 }

--- a/bee-storage/bee-storage-null/src/access/insert.rs
+++ b/bee-storage/bee-storage-null/src/access/insert.rs
@@ -6,13 +6,13 @@ use bee_storage::access::{Insert, InsertStrict};
 use crate::Storage;
 
 impl<K, V> Insert<K, V> for Storage {
-    fn insert(&self, _key: &K, _value: &V) -> Result<(), Self::Error> {
+    fn insert_op(&self, _key: &K, _value: &V) -> Result<(), Self::Error> {
         Ok(())
     }
 }
 
 impl<K, V> InsertStrict<K, V> for Storage {
-    fn insert_strict(&self, _key: &K, _value: &V) -> Result<(), Self::Error> {
+    fn insert_strict_op(&self, _key: &K, _value: &V) -> Result<(), Self::Error> {
         Ok(())
     }
 }

--- a/bee-storage/bee-storage-null/src/access/iter.rs
+++ b/bee-storage/bee-storage-null/src/access/iter.rs
@@ -28,7 +28,7 @@ impl<K, V> Iterator for StorageIterator<K, V> {
 impl<'a, K, V> AsIterator<'a, K, V> for Storage {
     type AsIter = StorageIterator<K, V>;
 
-    fn iter(&'a self) -> Result<Self::AsIter, Self::Error> {
+    fn iter_op(&'a self) -> Result<Self::AsIter, Self::Error> {
         Ok(StorageIterator::new())
     }
 }

--- a/bee-storage/bee-storage-null/src/access/multi_fetch.rs
+++ b/bee-storage/bee-storage-null/src/access/multi_fetch.rs
@@ -29,7 +29,7 @@ impl<K, V> Iterator for MultiIter<K, V> {
 impl<'a, K: 'a, V: 'a> MultiFetch<'a, K, V> for Storage {
     type Iter = MultiIter<K, V>;
 
-    fn multi_fetch(&'a self, _keys: &'a [K]) -> Result<Self::Iter, Self::Error> {
+    fn multi_fetch_op(&'a self, _keys: &'a [K]) -> Result<Self::Iter, Self::Error> {
         Ok(MultiIter::new())
     }
 }

--- a/bee-storage/bee-storage-null/src/access/truncate.rs
+++ b/bee-storage/bee-storage-null/src/access/truncate.rs
@@ -6,7 +6,7 @@ use bee_storage::access::Truncate;
 use crate::Storage;
 
 impl<K, V> Truncate<K, V> for Storage {
-    fn truncate(&self) -> Result<(), Self::Error> {
+    fn truncate_op(&self) -> Result<(), Self::Error> {
         Ok(())
     }
 }

--- a/bee-storage/bee-storage-null/src/access/update.rs
+++ b/bee-storage/bee-storage-null/src/access/update.rs
@@ -6,7 +6,7 @@ use bee_storage::access::Update;
 use crate::Storage;
 
 impl<K, V> Update<K, V> for Storage {
-    fn update(&self, _key: &K, _f: impl FnMut(&mut V)) -> Result<(), Self::Error> {
+    fn update_op(&self, _key: &K, _f: impl FnMut(&mut V)) -> Result<(), Self::Error> {
         Ok(())
     }
 }

--- a/bee-storage/bee-storage-rocksdb/src/access/batch.rs
+++ b/bee-storage/bee-storage-rocksdb/src/access/batch.rs
@@ -51,7 +51,7 @@ impl BatchBuilder for Storage {
 }
 
 impl Batch<MessageId, Message> for Storage {
-    fn batch_insert(
+    fn batch_insert_op(
         &self,
         batch: &mut Self::Batch,
         message_id: &MessageId,
@@ -68,7 +68,7 @@ impl Batch<MessageId, Message> for Storage {
         Ok(())
     }
 
-    fn batch_delete(
+    fn batch_delete_op(
         &self,
         batch: &mut Self::Batch,
         message_id: &MessageId,
@@ -82,7 +82,7 @@ impl Batch<MessageId, Message> for Storage {
 }
 
 impl Batch<MessageId, MessageMetadata> for Storage {
-    fn batch_insert(
+    fn batch_insert_op(
         &self,
         batch: &mut Self::Batch,
         message_id: &MessageId,
@@ -101,7 +101,7 @@ impl Batch<MessageId, MessageMetadata> for Storage {
         Ok(())
     }
 
-    fn batch_delete(
+    fn batch_delete_op(
         &self,
         batch: &mut Self::Batch,
         message_id: &MessageId,
@@ -117,7 +117,7 @@ impl Batch<MessageId, MessageMetadata> for Storage {
 }
 
 impl Batch<(MessageId, MessageId), ()> for Storage {
-    fn batch_insert(
+    fn batch_insert_op(
         &self,
         batch: &mut Self::Batch,
         (parent, child): &(MessageId, MessageId),
@@ -134,7 +134,7 @@ impl Batch<(MessageId, MessageId), ()> for Storage {
         Ok(())
     }
 
-    fn batch_delete(
+    fn batch_delete_op(
         &self,
         batch: &mut Self::Batch,
         (parent, child): &(MessageId, MessageId),
@@ -152,7 +152,7 @@ impl Batch<(MessageId, MessageId), ()> for Storage {
 }
 
 impl Batch<(PaddedIndex, MessageId), ()> for Storage {
-    fn batch_insert(
+    fn batch_insert_op(
         &self,
         batch: &mut Self::Batch,
         (index, message_id): &(PaddedIndex, MessageId),
@@ -169,7 +169,7 @@ impl Batch<(PaddedIndex, MessageId), ()> for Storage {
         Ok(())
     }
 
-    fn batch_delete(
+    fn batch_delete_op(
         &self,
         batch: &mut Self::Batch,
         (index, message_id): &(PaddedIndex, MessageId),
@@ -187,7 +187,7 @@ impl Batch<(PaddedIndex, MessageId), ()> for Storage {
 }
 
 impl Batch<OutputId, CreatedOutput> for Storage {
-    fn batch_insert(
+    fn batch_insert_op(
         &self,
         batch: &mut Self::Batch,
         output_id: &OutputId,
@@ -209,7 +209,7 @@ impl Batch<OutputId, CreatedOutput> for Storage {
         Ok(())
     }
 
-    fn batch_delete(
+    fn batch_delete_op(
         &self,
         batch: &mut Self::Batch,
         output_id: &OutputId,
@@ -227,7 +227,7 @@ impl Batch<OutputId, CreatedOutput> for Storage {
 }
 
 impl Batch<OutputId, ConsumedOutput> for Storage {
-    fn batch_insert(
+    fn batch_insert_op(
         &self,
         batch: &mut Self::Batch,
         output_id: &OutputId,
@@ -249,7 +249,7 @@ impl Batch<OutputId, ConsumedOutput> for Storage {
         Ok(())
     }
 
-    fn batch_delete(
+    fn batch_delete_op(
         &self,
         batch: &mut Self::Batch,
         output_id: &OutputId,
@@ -267,7 +267,7 @@ impl Batch<OutputId, ConsumedOutput> for Storage {
 }
 
 impl Batch<Unspent, ()> for Storage {
-    fn batch_insert(&self, batch: &mut Self::Batch, unspent: &Unspent, (): &()) -> Result<(), Self::Error> {
+    fn batch_insert_op(&self, batch: &mut Self::Batch, unspent: &Unspent, (): &()) -> Result<(), Self::Error> {
         batch.key_buf.clear();
         // Packing to bytes can't fail.
         unspent.pack(&mut batch.key_buf).unwrap();
@@ -279,7 +279,7 @@ impl Batch<Unspent, ()> for Storage {
         Ok(())
     }
 
-    fn batch_delete(&self, batch: &mut Self::Batch, unspent: &Unspent) -> Result<(), Self::Error> {
+    fn batch_delete_op(&self, batch: &mut Self::Batch, unspent: &Unspent) -> Result<(), Self::Error> {
         batch.key_buf.clear();
         // Packing to bytes can't fail.
         unspent.pack(&mut batch.key_buf).unwrap();
@@ -293,7 +293,7 @@ impl Batch<Unspent, ()> for Storage {
 }
 
 impl Batch<(Ed25519Address, OutputId), ()> for Storage {
-    fn batch_insert(
+    fn batch_insert_op(
         &self,
         batch: &mut Self::Batch,
         (address, output_id): &(Ed25519Address, OutputId),
@@ -310,7 +310,7 @@ impl Batch<(Ed25519Address, OutputId), ()> for Storage {
         Ok(())
     }
 
-    fn batch_delete(
+    fn batch_delete_op(
         &self,
         batch: &mut Self::Batch,
         (address, output_id): &(Ed25519Address, OutputId),
@@ -328,7 +328,7 @@ impl Batch<(Ed25519Address, OutputId), ()> for Storage {
 }
 
 impl Batch<(), LedgerIndex> for Storage {
-    fn batch_insert(
+    fn batch_insert_op(
         &self,
         batch: &mut Self::Batch,
         (): &(),
@@ -345,7 +345,7 @@ impl Batch<(), LedgerIndex> for Storage {
         Ok(())
     }
 
-    fn batch_delete(&self, batch: &mut Self::Batch, (): &()) -> Result<(), <Self as StorageBackend>::Error> {
+    fn batch_delete_op(&self, batch: &mut Self::Batch, (): &()) -> Result<(), <Self as StorageBackend>::Error> {
         batch.inner.delete_cf(self.cf_handle(CF_LEDGER_INDEX)?, [0x00u8]);
 
         Ok(())
@@ -353,7 +353,7 @@ impl Batch<(), LedgerIndex> for Storage {
 }
 
 impl Batch<MilestoneIndex, Milestone> for Storage {
-    fn batch_insert(
+    fn batch_insert_op(
         &self,
         batch: &mut Self::Batch,
         index: &MilestoneIndex,
@@ -375,7 +375,7 @@ impl Batch<MilestoneIndex, Milestone> for Storage {
         Ok(())
     }
 
-    fn batch_delete(
+    fn batch_delete_op(
         &self,
         batch: &mut Self::Batch,
         index: &MilestoneIndex,
@@ -393,7 +393,7 @@ impl Batch<MilestoneIndex, Milestone> for Storage {
 }
 
 impl Batch<(), SnapshotInfo> for Storage {
-    fn batch_insert(
+    fn batch_insert_op(
         &self,
         batch: &mut Self::Batch,
         (): &(),
@@ -410,7 +410,7 @@ impl Batch<(), SnapshotInfo> for Storage {
         Ok(())
     }
 
-    fn batch_delete(&self, batch: &mut Self::Batch, (): &()) -> Result<(), <Self as StorageBackend>::Error> {
+    fn batch_delete_op(&self, batch: &mut Self::Batch, (): &()) -> Result<(), <Self as StorageBackend>::Error> {
         batch.inner.delete_cf(self.cf_handle(CF_SNAPSHOT_INFO)?, [0x00u8]);
 
         Ok(())
@@ -418,7 +418,7 @@ impl Batch<(), SnapshotInfo> for Storage {
 }
 
 impl Batch<SolidEntryPoint, MilestoneIndex> for Storage {
-    fn batch_insert(
+    fn batch_insert_op(
         &self,
         batch: &mut Self::Batch,
         sep: &SolidEntryPoint,
@@ -440,7 +440,7 @@ impl Batch<SolidEntryPoint, MilestoneIndex> for Storage {
         Ok(())
     }
 
-    fn batch_delete(&self, batch: &mut Self::Batch, sep: &SolidEntryPoint) -> Result<(), Self::Error> {
+    fn batch_delete_op(&self, batch: &mut Self::Batch, sep: &SolidEntryPoint) -> Result<(), Self::Error> {
         batch.key_buf.clear();
         // Packing to bytes can't fail.
         sep.pack(&mut batch.key_buf).unwrap();
@@ -454,7 +454,7 @@ impl Batch<SolidEntryPoint, MilestoneIndex> for Storage {
 }
 
 impl Batch<MilestoneIndex, OutputDiff> for Storage {
-    fn batch_insert(
+    fn batch_insert_op(
         &self,
         batch: &mut Self::Batch,
         index: &MilestoneIndex,
@@ -476,7 +476,7 @@ impl Batch<MilestoneIndex, OutputDiff> for Storage {
         Ok(())
     }
 
-    fn batch_delete(
+    fn batch_delete_op(
         &self,
         batch: &mut Self::Batch,
         index: &MilestoneIndex,
@@ -494,7 +494,7 @@ impl Batch<MilestoneIndex, OutputDiff> for Storage {
 }
 
 impl Batch<Address, Balance> for Storage {
-    fn batch_insert(
+    fn batch_insert_op(
         &self,
         batch: &mut Self::Batch,
         address: &Address,
@@ -509,7 +509,11 @@ impl Batch<Address, Balance> for Storage {
         Ok(())
     }
 
-    fn batch_delete(&self, batch: &mut Self::Batch, address: &Address) -> Result<(), <Self as StorageBackend>::Error> {
+    fn batch_delete_op(
+        &self,
+        batch: &mut Self::Batch,
+        address: &Address,
+    ) -> Result<(), <Self as StorageBackend>::Error> {
         batch
             .inner
             .delete_cf(self.cf_handle(CF_ADDRESS_TO_BALANCE)?, address.pack_new());
@@ -519,7 +523,7 @@ impl Batch<Address, Balance> for Storage {
 }
 
 impl Batch<(MilestoneIndex, UnreferencedMessage), ()> for Storage {
-    fn batch_insert(
+    fn batch_insert_op(
         &self,
         batch: &mut Self::Batch,
         (index, unreferenced_message): &(MilestoneIndex, UnreferencedMessage),
@@ -538,7 +542,7 @@ impl Batch<(MilestoneIndex, UnreferencedMessage), ()> for Storage {
         Ok(())
     }
 
-    fn batch_delete(
+    fn batch_delete_op(
         &self,
         batch: &mut Self::Batch,
         (index, unreferenced_message): &(MilestoneIndex, UnreferencedMessage),
@@ -557,7 +561,7 @@ impl Batch<(MilestoneIndex, UnreferencedMessage), ()> for Storage {
 }
 
 impl Batch<(MilestoneIndex, Receipt), ()> for Storage {
-    fn batch_insert(
+    fn batch_insert_op(
         &self,
         batch: &mut Self::Batch,
         (index, receipt): &(MilestoneIndex, Receipt),
@@ -574,7 +578,7 @@ impl Batch<(MilestoneIndex, Receipt), ()> for Storage {
         Ok(())
     }
 
-    fn batch_delete(
+    fn batch_delete_op(
         &self,
         batch: &mut Self::Batch,
         (index, receipt): &(MilestoneIndex, Receipt),
@@ -592,7 +596,7 @@ impl Batch<(MilestoneIndex, Receipt), ()> for Storage {
 }
 
 impl Batch<(bool, TreasuryOutput), ()> for Storage {
-    fn batch_insert(
+    fn batch_insert_op(
         &self,
         batch: &mut Self::Batch,
         (spent, output): &(bool, TreasuryOutput),
@@ -609,7 +613,7 @@ impl Batch<(bool, TreasuryOutput), ()> for Storage {
         Ok(())
     }
 
-    fn batch_delete(
+    fn batch_delete_op(
         &self,
         batch: &mut Self::Batch,
         (spent, output): &(bool, TreasuryOutput),

--- a/bee-storage/bee-storage-rocksdb/src/access/delete.rs
+++ b/bee-storage/bee-storage-rocksdb/src/access/delete.rs
@@ -24,7 +24,7 @@ use crate::{
 };
 
 impl Delete<MessageId, Message> for Storage {
-    fn delete(&self, message_id: &MessageId) -> Result<(), <Self as StorageBackend>::Error> {
+    fn delete_op(&self, message_id: &MessageId) -> Result<(), <Self as StorageBackend>::Error> {
         self.inner
             .delete_cf(self.cf_handle(CF_MESSAGE_ID_TO_MESSAGE)?, message_id)?;
 
@@ -33,7 +33,7 @@ impl Delete<MessageId, Message> for Storage {
 }
 
 impl Delete<MessageId, MessageMetadata> for Storage {
-    fn delete(&self, message_id: &MessageId) -> Result<(), <Self as StorageBackend>::Error> {
+    fn delete_op(&self, message_id: &MessageId) -> Result<(), <Self as StorageBackend>::Error> {
         let guard = self.locks.message_id_to_metadata.read();
 
         self.inner
@@ -46,7 +46,7 @@ impl Delete<MessageId, MessageMetadata> for Storage {
 }
 
 impl Delete<(MessageId, MessageId), ()> for Storage {
-    fn delete(&self, (parent, child): &(MessageId, MessageId)) -> Result<(), <Self as StorageBackend>::Error> {
+    fn delete_op(&self, (parent, child): &(MessageId, MessageId)) -> Result<(), <Self as StorageBackend>::Error> {
         let mut key = parent.as_ref().to_vec();
         key.extend_from_slice(child.as_ref());
 
@@ -58,7 +58,7 @@ impl Delete<(MessageId, MessageId), ()> for Storage {
 }
 
 impl Delete<(PaddedIndex, MessageId), ()> for Storage {
-    fn delete(&self, (index, message_id): &(PaddedIndex, MessageId)) -> Result<(), <Self as StorageBackend>::Error> {
+    fn delete_op(&self, (index, message_id): &(PaddedIndex, MessageId)) -> Result<(), <Self as StorageBackend>::Error> {
         let mut key = index.as_ref().to_vec();
         key.extend_from_slice(message_id.as_ref());
 
@@ -69,7 +69,7 @@ impl Delete<(PaddedIndex, MessageId), ()> for Storage {
 }
 
 impl Delete<OutputId, CreatedOutput> for Storage {
-    fn delete(&self, output_id: &OutputId) -> Result<(), <Self as StorageBackend>::Error> {
+    fn delete_op(&self, output_id: &OutputId) -> Result<(), <Self as StorageBackend>::Error> {
         self.inner
             .delete_cf(self.cf_handle(CF_OUTPUT_ID_TO_CREATED_OUTPUT)?, output_id.pack_new())?;
 
@@ -78,7 +78,7 @@ impl Delete<OutputId, CreatedOutput> for Storage {
 }
 
 impl Delete<OutputId, ConsumedOutput> for Storage {
-    fn delete(&self, output_id: &OutputId) -> Result<(), <Self as StorageBackend>::Error> {
+    fn delete_op(&self, output_id: &OutputId) -> Result<(), <Self as StorageBackend>::Error> {
         self.inner
             .delete_cf(self.cf_handle(CF_OUTPUT_ID_TO_CONSUMED_OUTPUT)?, output_id.pack_new())?;
 
@@ -87,7 +87,7 @@ impl Delete<OutputId, ConsumedOutput> for Storage {
 }
 
 impl Delete<Unspent, ()> for Storage {
-    fn delete(&self, unspent: &Unspent) -> Result<(), <Self as StorageBackend>::Error> {
+    fn delete_op(&self, unspent: &Unspent) -> Result<(), <Self as StorageBackend>::Error> {
         self.inner
             .delete_cf(self.cf_handle(CF_OUTPUT_ID_UNSPENT)?, unspent.pack_new())?;
 
@@ -96,7 +96,10 @@ impl Delete<Unspent, ()> for Storage {
 }
 
 impl Delete<(Ed25519Address, OutputId), ()> for Storage {
-    fn delete(&self, (address, output_id): &(Ed25519Address, OutputId)) -> Result<(), <Self as StorageBackend>::Error> {
+    fn delete_op(
+        &self,
+        (address, output_id): &(Ed25519Address, OutputId),
+    ) -> Result<(), <Self as StorageBackend>::Error> {
         let mut key = address.as_ref().to_vec();
         key.extend_from_slice(&output_id.pack_new());
 
@@ -108,7 +111,7 @@ impl Delete<(Ed25519Address, OutputId), ()> for Storage {
 }
 
 impl Delete<(), LedgerIndex> for Storage {
-    fn delete(&self, (): &()) -> Result<(), <Self as StorageBackend>::Error> {
+    fn delete_op(&self, (): &()) -> Result<(), <Self as StorageBackend>::Error> {
         self.inner.delete_cf(self.cf_handle(CF_LEDGER_INDEX)?, [0x00u8])?;
 
         Ok(())
@@ -116,7 +119,7 @@ impl Delete<(), LedgerIndex> for Storage {
 }
 
 impl Delete<MilestoneIndex, Milestone> for Storage {
-    fn delete(&self, index: &MilestoneIndex) -> Result<(), <Self as StorageBackend>::Error> {
+    fn delete_op(&self, index: &MilestoneIndex) -> Result<(), <Self as StorageBackend>::Error> {
         self.inner
             .delete_cf(self.cf_handle(CF_MILESTONE_INDEX_TO_MILESTONE)?, index.pack_new())?;
 
@@ -125,7 +128,7 @@ impl Delete<MilestoneIndex, Milestone> for Storage {
 }
 
 impl Delete<(), SnapshotInfo> for Storage {
-    fn delete(&self, (): &()) -> Result<(), <Self as StorageBackend>::Error> {
+    fn delete_op(&self, (): &()) -> Result<(), <Self as StorageBackend>::Error> {
         self.inner.delete_cf(self.cf_handle(CF_SNAPSHOT_INFO)?, [0x00u8])?;
 
         Ok(())
@@ -133,7 +136,7 @@ impl Delete<(), SnapshotInfo> for Storage {
 }
 
 impl Delete<SolidEntryPoint, MilestoneIndex> for Storage {
-    fn delete(&self, sep: &SolidEntryPoint) -> Result<(), <Self as StorageBackend>::Error> {
+    fn delete_op(&self, sep: &SolidEntryPoint) -> Result<(), <Self as StorageBackend>::Error> {
         self.inner
             .delete_cf(self.cf_handle(CF_SOLID_ENTRY_POINT_TO_MILESTONE_INDEX)?, sep.as_ref())?;
 
@@ -142,7 +145,7 @@ impl Delete<SolidEntryPoint, MilestoneIndex> for Storage {
 }
 
 impl Delete<MilestoneIndex, OutputDiff> for Storage {
-    fn delete(&self, index: &MilestoneIndex) -> Result<(), <Self as StorageBackend>::Error> {
+    fn delete_op(&self, index: &MilestoneIndex) -> Result<(), <Self as StorageBackend>::Error> {
         self.inner
             .delete_cf(self.cf_handle(CF_MILESTONE_INDEX_TO_OUTPUT_DIFF)?, index.pack_new())?;
 
@@ -151,7 +154,7 @@ impl Delete<MilestoneIndex, OutputDiff> for Storage {
 }
 
 impl Delete<Address, Balance> for Storage {
-    fn delete(&self, address: &Address) -> Result<(), <Self as StorageBackend>::Error> {
+    fn delete_op(&self, address: &Address) -> Result<(), <Self as StorageBackend>::Error> {
         self.inner
             .delete_cf(self.cf_handle(CF_ADDRESS_TO_BALANCE)?, address.pack_new())?;
 
@@ -160,7 +163,7 @@ impl Delete<Address, Balance> for Storage {
 }
 
 impl Delete<(MilestoneIndex, UnreferencedMessage), ()> for Storage {
-    fn delete(
+    fn delete_op(
         &self,
         (index, unreferenced_message): &(MilestoneIndex, UnreferencedMessage),
     ) -> Result<(), <Self as StorageBackend>::Error> {
@@ -175,7 +178,7 @@ impl Delete<(MilestoneIndex, UnreferencedMessage), ()> for Storage {
 }
 
 impl Delete<(MilestoneIndex, Receipt), ()> for Storage {
-    fn delete(&self, (index, receipt): &(MilestoneIndex, Receipt)) -> Result<(), <Self as StorageBackend>::Error> {
+    fn delete_op(&self, (index, receipt): &(MilestoneIndex, Receipt)) -> Result<(), <Self as StorageBackend>::Error> {
         let mut key = index.pack_new();
         key.extend_from_slice(&receipt.pack_new());
 
@@ -187,7 +190,7 @@ impl Delete<(MilestoneIndex, Receipt), ()> for Storage {
 }
 
 impl Delete<(bool, TreasuryOutput), ()> for Storage {
-    fn delete(&self, (spent, output): &(bool, TreasuryOutput)) -> Result<(), <Self as StorageBackend>::Error> {
+    fn delete_op(&self, (spent, output): &(bool, TreasuryOutput)) -> Result<(), <Self as StorageBackend>::Error> {
         let mut key = spent.pack_new();
         key.extend_from_slice(&output.pack_new());
 

--- a/bee-storage/bee-storage-rocksdb/src/access/exist.rs
+++ b/bee-storage/bee-storage-rocksdb/src/access/exist.rs
@@ -24,7 +24,7 @@ use crate::{
 };
 
 impl Exist<MessageId, Message> for Storage {
-    fn exist(&self, message_id: &MessageId) -> Result<bool, <Self as StorageBackend>::Error> {
+    fn exist_op(&self, message_id: &MessageId) -> Result<bool, <Self as StorageBackend>::Error> {
         Ok(self
             .inner
             .get_pinned_cf(self.cf_handle(CF_MESSAGE_ID_TO_MESSAGE)?, message_id)?
@@ -33,7 +33,7 @@ impl Exist<MessageId, Message> for Storage {
 }
 
 impl Exist<MessageId, MessageMetadata> for Storage {
-    fn exist(&self, message_id: &MessageId) -> Result<bool, <Self as StorageBackend>::Error> {
+    fn exist_op(&self, message_id: &MessageId) -> Result<bool, <Self as StorageBackend>::Error> {
         let guard = self.locks.message_id_to_metadata.read();
 
         let exists = self
@@ -48,7 +48,7 @@ impl Exist<MessageId, MessageMetadata> for Storage {
 }
 
 impl Exist<(MessageId, MessageId), ()> for Storage {
-    fn exist(&self, (parent, child): &(MessageId, MessageId)) -> Result<bool, <Self as StorageBackend>::Error> {
+    fn exist_op(&self, (parent, child): &(MessageId, MessageId)) -> Result<bool, <Self as StorageBackend>::Error> {
         let mut key = parent.as_ref().to_vec();
         key.extend_from_slice(child.as_ref());
 
@@ -60,7 +60,10 @@ impl Exist<(MessageId, MessageId), ()> for Storage {
 }
 
 impl Exist<(PaddedIndex, MessageId), ()> for Storage {
-    fn exist(&self, (index, message_id): &(PaddedIndex, MessageId)) -> Result<bool, <Self as StorageBackend>::Error> {
+    fn exist_op(
+        &self,
+        (index, message_id): &(PaddedIndex, MessageId),
+    ) -> Result<bool, <Self as StorageBackend>::Error> {
         let mut key = index.as_ref().to_vec();
         key.extend_from_slice(message_id.as_ref());
 
@@ -72,7 +75,7 @@ impl Exist<(PaddedIndex, MessageId), ()> for Storage {
 }
 
 impl Exist<OutputId, CreatedOutput> for Storage {
-    fn exist(&self, output_id: &OutputId) -> Result<bool, <Self as StorageBackend>::Error> {
+    fn exist_op(&self, output_id: &OutputId) -> Result<bool, <Self as StorageBackend>::Error> {
         Ok(self
             .inner
             .get_pinned_cf(self.cf_handle(CF_OUTPUT_ID_TO_CREATED_OUTPUT)?, output_id.pack_new())?
@@ -81,7 +84,7 @@ impl Exist<OutputId, CreatedOutput> for Storage {
 }
 
 impl Exist<OutputId, ConsumedOutput> for Storage {
-    fn exist(&self, output_id: &OutputId) -> Result<bool, <Self as StorageBackend>::Error> {
+    fn exist_op(&self, output_id: &OutputId) -> Result<bool, <Self as StorageBackend>::Error> {
         Ok(self
             .inner
             .get_pinned_cf(self.cf_handle(CF_OUTPUT_ID_TO_CONSUMED_OUTPUT)?, output_id.pack_new())?
@@ -90,7 +93,7 @@ impl Exist<OutputId, ConsumedOutput> for Storage {
 }
 
 impl Exist<Unspent, ()> for Storage {
-    fn exist(&self, unspent: &Unspent) -> Result<bool, <Self as StorageBackend>::Error> {
+    fn exist_op(&self, unspent: &Unspent) -> Result<bool, <Self as StorageBackend>::Error> {
         Ok(self
             .inner
             .get_pinned_cf(self.cf_handle(CF_OUTPUT_ID_UNSPENT)?, unspent.pack_new())?
@@ -99,7 +102,7 @@ impl Exist<Unspent, ()> for Storage {
 }
 
 impl Exist<(Ed25519Address, OutputId), ()> for Storage {
-    fn exist(
+    fn exist_op(
         &self,
         (address, output_id): &(Ed25519Address, OutputId),
     ) -> Result<bool, <Self as StorageBackend>::Error> {
@@ -114,7 +117,7 @@ impl Exist<(Ed25519Address, OutputId), ()> for Storage {
 }
 
 impl Exist<(), LedgerIndex> for Storage {
-    fn exist(&self, (): &()) -> Result<bool, <Self as StorageBackend>::Error> {
+    fn exist_op(&self, (): &()) -> Result<bool, <Self as StorageBackend>::Error> {
         Ok(self
             .inner
             .get_pinned_cf(self.cf_handle(CF_LEDGER_INDEX)?, [0x00u8])?
@@ -123,7 +126,7 @@ impl Exist<(), LedgerIndex> for Storage {
 }
 
 impl Exist<MilestoneIndex, Milestone> for Storage {
-    fn exist(&self, index: &MilestoneIndex) -> Result<bool, <Self as StorageBackend>::Error> {
+    fn exist_op(&self, index: &MilestoneIndex) -> Result<bool, <Self as StorageBackend>::Error> {
         Ok(self
             .inner
             .get_pinned_cf(self.cf_handle(CF_MILESTONE_INDEX_TO_MILESTONE)?, index.pack_new())?
@@ -132,7 +135,7 @@ impl Exist<MilestoneIndex, Milestone> for Storage {
 }
 
 impl Exist<(), SnapshotInfo> for Storage {
-    fn exist(&self, (): &()) -> Result<bool, <Self as StorageBackend>::Error> {
+    fn exist_op(&self, (): &()) -> Result<bool, <Self as StorageBackend>::Error> {
         Ok(self
             .inner
             .get_pinned_cf(self.cf_handle(CF_SNAPSHOT_INFO)?, [0x00u8])?
@@ -141,7 +144,7 @@ impl Exist<(), SnapshotInfo> for Storage {
 }
 
 impl Exist<SolidEntryPoint, MilestoneIndex> for Storage {
-    fn exist(&self, sep: &SolidEntryPoint) -> Result<bool, <Self as StorageBackend>::Error> {
+    fn exist_op(&self, sep: &SolidEntryPoint) -> Result<bool, <Self as StorageBackend>::Error> {
         Ok(self
             .inner
             .get_pinned_cf(self.cf_handle(CF_SOLID_ENTRY_POINT_TO_MILESTONE_INDEX)?, sep.pack_new())?
@@ -150,7 +153,7 @@ impl Exist<SolidEntryPoint, MilestoneIndex> for Storage {
 }
 
 impl Exist<MilestoneIndex, OutputDiff> for Storage {
-    fn exist(&self, index: &MilestoneIndex) -> Result<bool, <Self as StorageBackend>::Error> {
+    fn exist_op(&self, index: &MilestoneIndex) -> Result<bool, <Self as StorageBackend>::Error> {
         Ok(self
             .inner
             .get_pinned_cf(self.cf_handle(CF_MILESTONE_INDEX_TO_OUTPUT_DIFF)?, index.pack_new())?
@@ -159,7 +162,7 @@ impl Exist<MilestoneIndex, OutputDiff> for Storage {
 }
 
 impl Exist<Address, Balance> for Storage {
-    fn exist(&self, address: &Address) -> Result<bool, <Self as StorageBackend>::Error> {
+    fn exist_op(&self, address: &Address) -> Result<bool, <Self as StorageBackend>::Error> {
         Ok(self
             .inner
             .get_pinned_cf(self.cf_handle(CF_ADDRESS_TO_BALANCE)?, address.pack_new())?
@@ -168,7 +171,7 @@ impl Exist<Address, Balance> for Storage {
 }
 
 impl Exist<(MilestoneIndex, UnreferencedMessage), ()> for Storage {
-    fn exist(
+    fn exist_op(
         &self,
         (index, unreferenced_message): &(MilestoneIndex, UnreferencedMessage),
     ) -> Result<bool, <Self as StorageBackend>::Error> {
@@ -183,7 +186,7 @@ impl Exist<(MilestoneIndex, UnreferencedMessage), ()> for Storage {
 }
 
 impl Exist<(MilestoneIndex, Receipt), ()> for Storage {
-    fn exist(&self, (index, receipt): &(MilestoneIndex, Receipt)) -> Result<bool, <Self as StorageBackend>::Error> {
+    fn exist_op(&self, (index, receipt): &(MilestoneIndex, Receipt)) -> Result<bool, <Self as StorageBackend>::Error> {
         let mut key = index.pack_new();
         key.extend_from_slice(&receipt.pack_new());
 
@@ -195,7 +198,7 @@ impl Exist<(MilestoneIndex, Receipt), ()> for Storage {
 }
 
 impl Exist<(bool, TreasuryOutput), ()> for Storage {
-    fn exist(&self, (spent, output): &(bool, TreasuryOutput)) -> Result<bool, <Self as StorageBackend>::Error> {
+    fn exist_op(&self, (spent, output): &(bool, TreasuryOutput)) -> Result<bool, <Self as StorageBackend>::Error> {
         let mut key = spent.pack_new();
         key.extend_from_slice(&output.pack_new());
 

--- a/bee-storage/bee-storage-rocksdb/src/access/fetch.rs
+++ b/bee-storage/bee-storage-rocksdb/src/access/fetch.rs
@@ -24,7 +24,7 @@ use crate::{
 };
 
 impl Fetch<u8, System> for Storage {
-    fn fetch(&self, key: &u8) -> Result<Option<System>, <Self as StorageBackend>::Error> {
+    fn fetch_op(&self, key: &u8) -> Result<Option<System>, <Self as StorageBackend>::Error> {
         Ok(self
             .inner
             .get_pinned_cf(self.cf_handle(CF_SYSTEM)?, [*key])?
@@ -34,7 +34,7 @@ impl Fetch<u8, System> for Storage {
 }
 
 impl Fetch<MessageId, Message> for Storage {
-    fn fetch(&self, message_id: &MessageId) -> Result<Option<Message>, <Self as StorageBackend>::Error> {
+    fn fetch_op(&self, message_id: &MessageId) -> Result<Option<Message>, <Self as StorageBackend>::Error> {
         Ok(self
             .inner
             .get_pinned_cf(self.cf_handle(CF_MESSAGE_ID_TO_MESSAGE)?, message_id)?
@@ -44,7 +44,7 @@ impl Fetch<MessageId, Message> for Storage {
 }
 
 impl Fetch<MessageId, MessageMetadata> for Storage {
-    fn fetch(&self, message_id: &MessageId) -> Result<Option<MessageMetadata>, <Self as StorageBackend>::Error> {
+    fn fetch_op(&self, message_id: &MessageId) -> Result<Option<MessageMetadata>, <Self as StorageBackend>::Error> {
         let guard = self.locks.message_id_to_metadata.read();
 
         let metadata = self
@@ -60,7 +60,7 @@ impl Fetch<MessageId, MessageMetadata> for Storage {
 }
 
 impl Fetch<MessageId, Vec<MessageId>> for Storage {
-    fn fetch(&self, parent: &MessageId) -> Result<Option<Vec<MessageId>>, <Self as StorageBackend>::Error> {
+    fn fetch_op(&self, parent: &MessageId) -> Result<Option<Vec<MessageId>>, <Self as StorageBackend>::Error> {
         Ok(Some(
             self.inner
                 .prefix_iterator_cf(self.cf_handle(CF_MESSAGE_ID_TO_MESSAGE_ID)?, parent)
@@ -77,7 +77,7 @@ impl Fetch<MessageId, Vec<MessageId>> for Storage {
 }
 
 impl Fetch<PaddedIndex, Vec<MessageId>> for Storage {
-    fn fetch(&self, index: &PaddedIndex) -> Result<Option<Vec<MessageId>>, <Self as StorageBackend>::Error> {
+    fn fetch_op(&self, index: &PaddedIndex) -> Result<Option<Vec<MessageId>>, <Self as StorageBackend>::Error> {
         Ok(Some(
             self.inner
                 .prefix_iterator_cf(self.cf_handle(CF_INDEX_TO_MESSAGE_ID)?, index)
@@ -94,7 +94,7 @@ impl Fetch<PaddedIndex, Vec<MessageId>> for Storage {
 }
 
 impl Fetch<OutputId, CreatedOutput> for Storage {
-    fn fetch(&self, output_id: &OutputId) -> Result<Option<CreatedOutput>, <Self as StorageBackend>::Error> {
+    fn fetch_op(&self, output_id: &OutputId) -> Result<Option<CreatedOutput>, <Self as StorageBackend>::Error> {
         Ok(self
             .inner
             .get_pinned_cf(self.cf_handle(CF_OUTPUT_ID_TO_CREATED_OUTPUT)?, output_id.pack_new())?
@@ -104,7 +104,7 @@ impl Fetch<OutputId, CreatedOutput> for Storage {
 }
 
 impl Fetch<OutputId, ConsumedOutput> for Storage {
-    fn fetch(&self, output_id: &OutputId) -> Result<Option<ConsumedOutput>, <Self as StorageBackend>::Error> {
+    fn fetch_op(&self, output_id: &OutputId) -> Result<Option<ConsumedOutput>, <Self as StorageBackend>::Error> {
         Ok(self
             .inner
             .get_pinned_cf(self.cf_handle(CF_OUTPUT_ID_TO_CONSUMED_OUTPUT)?, output_id.pack_new())?
@@ -114,7 +114,7 @@ impl Fetch<OutputId, ConsumedOutput> for Storage {
 }
 
 impl Fetch<Ed25519Address, Vec<OutputId>> for Storage {
-    fn fetch(&self, address: &Ed25519Address) -> Result<Option<Vec<OutputId>>, <Self as StorageBackend>::Error> {
+    fn fetch_op(&self, address: &Ed25519Address) -> Result<Option<Vec<OutputId>>, <Self as StorageBackend>::Error> {
         Ok(Some(
             self.inner
                 .prefix_iterator_cf(self.cf_handle(CF_ED25519_ADDRESS_TO_OUTPUT_ID)?, address)
@@ -130,7 +130,7 @@ impl Fetch<Ed25519Address, Vec<OutputId>> for Storage {
 }
 
 impl Fetch<(), LedgerIndex> for Storage {
-    fn fetch(&self, (): &()) -> Result<Option<LedgerIndex>, <Self as StorageBackend>::Error> {
+    fn fetch_op(&self, (): &()) -> Result<Option<LedgerIndex>, <Self as StorageBackend>::Error> {
         Ok(self
             .inner
             .get_pinned_cf(self.cf_handle(CF_LEDGER_INDEX)?, [0x00u8])?
@@ -140,7 +140,7 @@ impl Fetch<(), LedgerIndex> for Storage {
 }
 
 impl Fetch<MilestoneIndex, Milestone> for Storage {
-    fn fetch(&self, index: &MilestoneIndex) -> Result<Option<Milestone>, <Self as StorageBackend>::Error> {
+    fn fetch_op(&self, index: &MilestoneIndex) -> Result<Option<Milestone>, <Self as StorageBackend>::Error> {
         Ok(self
             .inner
             .get_pinned_cf(self.cf_handle(CF_MILESTONE_INDEX_TO_MILESTONE)?, index.pack_new())?
@@ -150,7 +150,7 @@ impl Fetch<MilestoneIndex, Milestone> for Storage {
 }
 
 impl Fetch<(), SnapshotInfo> for Storage {
-    fn fetch(&self, (): &()) -> Result<Option<SnapshotInfo>, <Self as StorageBackend>::Error> {
+    fn fetch_op(&self, (): &()) -> Result<Option<SnapshotInfo>, <Self as StorageBackend>::Error> {
         Ok(self
             .inner
             .get_pinned_cf(self.cf_handle(CF_SNAPSHOT_INFO)?, [0x00u8])?
@@ -160,7 +160,7 @@ impl Fetch<(), SnapshotInfo> for Storage {
 }
 
 impl Fetch<SolidEntryPoint, MilestoneIndex> for Storage {
-    fn fetch(&self, sep: &SolidEntryPoint) -> Result<Option<MilestoneIndex>, <Self as StorageBackend>::Error> {
+    fn fetch_op(&self, sep: &SolidEntryPoint) -> Result<Option<MilestoneIndex>, <Self as StorageBackend>::Error> {
         Ok(self
             .inner
             .get_pinned_cf(self.cf_handle(CF_SOLID_ENTRY_POINT_TO_MILESTONE_INDEX)?, sep.as_ref())?
@@ -170,7 +170,7 @@ impl Fetch<SolidEntryPoint, MilestoneIndex> for Storage {
 }
 
 impl Fetch<MilestoneIndex, OutputDiff> for Storage {
-    fn fetch(&self, index: &MilestoneIndex) -> Result<Option<OutputDiff>, <Self as StorageBackend>::Error> {
+    fn fetch_op(&self, index: &MilestoneIndex) -> Result<Option<OutputDiff>, <Self as StorageBackend>::Error> {
         Ok(self
             .inner
             .get_pinned_cf(self.cf_handle(CF_MILESTONE_INDEX_TO_OUTPUT_DIFF)?, index.pack_new())?
@@ -180,7 +180,7 @@ impl Fetch<MilestoneIndex, OutputDiff> for Storage {
 }
 
 impl Fetch<Address, Balance> for Storage {
-    fn fetch(&self, address: &Address) -> Result<Option<Balance>, <Self as StorageBackend>::Error> {
+    fn fetch_op(&self, address: &Address) -> Result<Option<Balance>, <Self as StorageBackend>::Error> {
         Ok(self
             .inner
             .get_pinned_cf(self.cf_handle(CF_ADDRESS_TO_BALANCE)?, address.pack_new())?
@@ -190,7 +190,7 @@ impl Fetch<Address, Balance> for Storage {
 }
 
 impl Fetch<MilestoneIndex, Vec<UnreferencedMessage>> for Storage {
-    fn fetch(
+    fn fetch_op(
         &self,
         index: &MilestoneIndex,
     ) -> Result<Option<Vec<UnreferencedMessage>>, <Self as StorageBackend>::Error> {
@@ -212,7 +212,7 @@ impl Fetch<MilestoneIndex, Vec<UnreferencedMessage>> for Storage {
 }
 
 impl Fetch<MilestoneIndex, Vec<Receipt>> for Storage {
-    fn fetch(&self, index: &MilestoneIndex) -> Result<Option<Vec<Receipt>>, <Self as StorageBackend>::Error> {
+    fn fetch_op(&self, index: &MilestoneIndex) -> Result<Option<Vec<Receipt>>, <Self as StorageBackend>::Error> {
         Ok(Some(
             self.inner
                 .prefix_iterator_cf(self.cf_handle(CF_MILESTONE_INDEX_TO_RECEIPT)?, index.pack_new())
@@ -228,7 +228,7 @@ impl Fetch<MilestoneIndex, Vec<Receipt>> for Storage {
 }
 
 impl Fetch<bool, Vec<TreasuryOutput>> for Storage {
-    fn fetch(&self, spent: &bool) -> Result<Option<Vec<TreasuryOutput>>, <Self as StorageBackend>::Error> {
+    fn fetch_op(&self, spent: &bool) -> Result<Option<Vec<TreasuryOutput>>, <Self as StorageBackend>::Error> {
         Ok(Some(
             self.inner
                 .prefix_iterator_cf(self.cf_handle(CF_SPENT_TO_TREASURY_OUTPUT)?, spent.pack_new())

--- a/bee-storage/bee-storage-rocksdb/src/access/insert.rs
+++ b/bee-storage/bee-storage-rocksdb/src/access/insert.rs
@@ -27,7 +27,7 @@ use crate::{
 };
 
 impl Insert<u8, System> for Storage {
-    fn insert(&self, key: &u8, value: &System) -> Result<(), <Self as StorageBackend>::Error> {
+    fn insert_op(&self, key: &u8, value: &System) -> Result<(), <Self as StorageBackend>::Error> {
         self.inner
             .put_cf(self.cf_handle(CF_SYSTEM)?, [*key], value.pack_new())?;
 
@@ -36,7 +36,7 @@ impl Insert<u8, System> for Storage {
 }
 
 impl Insert<MessageId, Message> for Storage {
-    fn insert(&self, message_id: &MessageId, message: &Message) -> Result<(), <Self as StorageBackend>::Error> {
+    fn insert_op(&self, message_id: &MessageId, message: &Message) -> Result<(), <Self as StorageBackend>::Error> {
         self.inner.put_cf(
             self.cf_handle(CF_MESSAGE_ID_TO_MESSAGE)?,
             message_id,
@@ -48,7 +48,7 @@ impl Insert<MessageId, Message> for Storage {
 }
 
 impl InsertStrict<MessageId, MessageMetadata> for Storage {
-    fn insert_strict(
+    fn insert_strict_op(
         &self,
         message_id: &MessageId,
         metadata: &MessageMetadata,
@@ -68,7 +68,11 @@ impl InsertStrict<MessageId, MessageMetadata> for Storage {
 }
 
 impl Insert<(MessageId, MessageId), ()> for Storage {
-    fn insert(&self, (parent, child): &(MessageId, MessageId), (): &()) -> Result<(), <Self as StorageBackend>::Error> {
+    fn insert_op(
+        &self,
+        (parent, child): &(MessageId, MessageId),
+        (): &(),
+    ) -> Result<(), <Self as StorageBackend>::Error> {
         let mut key = parent.as_ref().to_vec();
         key.extend_from_slice(child.as_ref());
 
@@ -80,7 +84,7 @@ impl Insert<(MessageId, MessageId), ()> for Storage {
 }
 
 impl Insert<(PaddedIndex, MessageId), ()> for Storage {
-    fn insert(
+    fn insert_op(
         &self,
         (index, message_id): &(PaddedIndex, MessageId),
         (): &(),
@@ -95,7 +99,7 @@ impl Insert<(PaddedIndex, MessageId), ()> for Storage {
 }
 
 impl Insert<OutputId, CreatedOutput> for Storage {
-    fn insert(&self, output_id: &OutputId, output: &CreatedOutput) -> Result<(), <Self as StorageBackend>::Error> {
+    fn insert_op(&self, output_id: &OutputId, output: &CreatedOutput) -> Result<(), <Self as StorageBackend>::Error> {
         self.inner.put_cf(
             self.cf_handle(CF_OUTPUT_ID_TO_CREATED_OUTPUT)?,
             output_id.pack_new(),
@@ -107,7 +111,7 @@ impl Insert<OutputId, CreatedOutput> for Storage {
 }
 
 impl Insert<OutputId, ConsumedOutput> for Storage {
-    fn insert(&self, output_id: &OutputId, output: &ConsumedOutput) -> Result<(), <Self as StorageBackend>::Error> {
+    fn insert_op(&self, output_id: &OutputId, output: &ConsumedOutput) -> Result<(), <Self as StorageBackend>::Error> {
         self.inner.put_cf(
             self.cf_handle(CF_OUTPUT_ID_TO_CONSUMED_OUTPUT)?,
             output_id.pack_new(),
@@ -119,7 +123,7 @@ impl Insert<OutputId, ConsumedOutput> for Storage {
 }
 
 impl Insert<Unspent, ()> for Storage {
-    fn insert(&self, unspent: &Unspent, (): &()) -> Result<(), <Self as StorageBackend>::Error> {
+    fn insert_op(&self, unspent: &Unspent, (): &()) -> Result<(), <Self as StorageBackend>::Error> {
         self.inner
             .put_cf(self.cf_handle(CF_OUTPUT_ID_UNSPENT)?, unspent.pack_new(), [])?;
 
@@ -128,7 +132,7 @@ impl Insert<Unspent, ()> for Storage {
 }
 
 impl Insert<(Ed25519Address, OutputId), ()> for Storage {
-    fn insert(
+    fn insert_op(
         &self,
         (address, output_id): &(Ed25519Address, OutputId),
         (): &(),
@@ -144,7 +148,7 @@ impl Insert<(Ed25519Address, OutputId), ()> for Storage {
 }
 
 impl Insert<(), LedgerIndex> for Storage {
-    fn insert(&self, (): &(), index: &LedgerIndex) -> Result<(), <Self as StorageBackend>::Error> {
+    fn insert_op(&self, (): &(), index: &LedgerIndex) -> Result<(), <Self as StorageBackend>::Error> {
         self.inner
             .put_cf(self.cf_handle(CF_LEDGER_INDEX)?, [0x00u8], index.pack_new())?;
 
@@ -153,7 +157,7 @@ impl Insert<(), LedgerIndex> for Storage {
 }
 
 impl Insert<MilestoneIndex, Milestone> for Storage {
-    fn insert(&self, index: &MilestoneIndex, milestone: &Milestone) -> Result<(), <Self as StorageBackend>::Error> {
+    fn insert_op(&self, index: &MilestoneIndex, milestone: &Milestone) -> Result<(), <Self as StorageBackend>::Error> {
         self.inner.put_cf(
             self.cf_handle(CF_MILESTONE_INDEX_TO_MILESTONE)?,
             index.pack_new(),
@@ -165,7 +169,7 @@ impl Insert<MilestoneIndex, Milestone> for Storage {
 }
 
 impl Insert<(), SnapshotInfo> for Storage {
-    fn insert(&self, (): &(), info: &SnapshotInfo) -> Result<(), <Self as StorageBackend>::Error> {
+    fn insert_op(&self, (): &(), info: &SnapshotInfo) -> Result<(), <Self as StorageBackend>::Error> {
         self.inner
             .put_cf(self.cf_handle(CF_SNAPSHOT_INFO)?, [0x00u8], info.pack_new())?;
 
@@ -174,7 +178,7 @@ impl Insert<(), SnapshotInfo> for Storage {
 }
 
 impl Insert<SolidEntryPoint, MilestoneIndex> for Storage {
-    fn insert(&self, sep: &SolidEntryPoint, index: &MilestoneIndex) -> Result<(), <Self as StorageBackend>::Error> {
+    fn insert_op(&self, sep: &SolidEntryPoint, index: &MilestoneIndex) -> Result<(), <Self as StorageBackend>::Error> {
         self.inner.put_cf(
             self.cf_handle(CF_SOLID_ENTRY_POINT_TO_MILESTONE_INDEX)?,
             sep.as_ref(),
@@ -186,7 +190,7 @@ impl Insert<SolidEntryPoint, MilestoneIndex> for Storage {
 }
 
 impl Insert<MilestoneIndex, OutputDiff> for Storage {
-    fn insert(&self, index: &MilestoneIndex, diff: &OutputDiff) -> Result<(), <Self as StorageBackend>::Error> {
+    fn insert_op(&self, index: &MilestoneIndex, diff: &OutputDiff) -> Result<(), <Self as StorageBackend>::Error> {
         self.inner.put_cf(
             self.cf_handle(CF_MILESTONE_INDEX_TO_OUTPUT_DIFF)?,
             index.pack_new(),
@@ -198,7 +202,7 @@ impl Insert<MilestoneIndex, OutputDiff> for Storage {
 }
 
 impl Insert<Address, Balance> for Storage {
-    fn insert(&self, address: &Address, balance: &Balance) -> Result<(), <Self as StorageBackend>::Error> {
+    fn insert_op(&self, address: &Address, balance: &Balance) -> Result<(), <Self as StorageBackend>::Error> {
         self.inner.put_cf(
             self.cf_handle(CF_ADDRESS_TO_BALANCE)?,
             address.pack_new(),
@@ -210,7 +214,7 @@ impl Insert<Address, Balance> for Storage {
 }
 
 impl Insert<(MilestoneIndex, UnreferencedMessage), ()> for Storage {
-    fn insert(
+    fn insert_op(
         &self,
         (index, unreferenced_message): &(MilestoneIndex, UnreferencedMessage),
         (): &(),
@@ -226,7 +230,7 @@ impl Insert<(MilestoneIndex, UnreferencedMessage), ()> for Storage {
 }
 
 impl Insert<(MilestoneIndex, Receipt), ()> for Storage {
-    fn insert(
+    fn insert_op(
         &self,
         (index, receipt): &(MilestoneIndex, Receipt),
         (): &(),
@@ -242,7 +246,11 @@ impl Insert<(MilestoneIndex, Receipt), ()> for Storage {
 }
 
 impl Insert<(bool, TreasuryOutput), ()> for Storage {
-    fn insert(&self, (spent, output): &(bool, TreasuryOutput), (): &()) -> Result<(), <Self as StorageBackend>::Error> {
+    fn insert_op(
+        &self,
+        (spent, output): &(bool, TreasuryOutput),
+        (): &(),
+    ) -> Result<(), <Self as StorageBackend>::Error> {
         let mut key = spent.pack_new();
         key.extend_from_slice(&output.pack_new());
 

--- a/bee-storage/bee-storage-rocksdb/src/access/iter.rs
+++ b/bee-storage/bee-storage-rocksdb/src/access/iter.rs
@@ -48,7 +48,7 @@ macro_rules! impl_iter {
         impl<'a> AsIterator<'a, $key, $value> for Storage {
             type AsIter = StorageIterator<'a, $key, $value>;
 
-            fn iter(&'a self) -> Result<Self::AsIter, <Self as StorageBackend>::Error> {
+            fn iter_op(&'a self) -> Result<Self::AsIter, <Self as StorageBackend>::Error> {
                 Ok(StorageIterator::new(
                     self.inner.iterator_cf(self.cf_handle($cf)?, IteratorMode::Start),
                     None,
@@ -328,7 +328,7 @@ impl_iter!((bool, TreasuryOutput), (), CF_SPENT_TO_TREASURY_OUTPUT);
 impl<'a> AsIterator<'a, MessageId, MessageMetadata> for Storage {
     type AsIter = StorageIterator<'a, MessageId, MessageMetadata>;
 
-    fn iter(&'a self) -> Result<Self::AsIter, <Self as StorageBackend>::Error> {
+    fn iter_op(&'a self) -> Result<Self::AsIter, <Self as StorageBackend>::Error> {
         Ok(StorageIterator::new(
             self.inner
                 .iterator_cf(self.cf_handle(CF_MESSAGE_ID_TO_METADATA)?, IteratorMode::Start),

--- a/bee-storage/bee-storage-rocksdb/src/access/multi_fetch.rs
+++ b/bee-storage/bee-storage-rocksdb/src/access/multi_fetch.rs
@@ -44,7 +44,7 @@ macro_rules! impl_multi_fetch {
         impl<'a> MultiFetch<'a, $key, $value> for Storage {
             type Iter = MultiIter<'a, $value, <Self as StorageBackend>::Error>;
 
-            fn multi_fetch(&'a self, keys: &[$key]) -> Result<Self::Iter, <Self as StorageBackend>::Error> {
+            fn multi_fetch_op(&'a self, keys: &[$key]) -> Result<Self::Iter, <Self as StorageBackend>::Error> {
                 let cf = self.cf_handle($cf)?;
 
                 Ok(MultiIter {
@@ -72,7 +72,7 @@ impl_multi_fetch!(Address, Balance, CF_ADDRESS_TO_BALANCE);
 impl<'a> MultiFetch<'a, MessageId, MessageMetadata> for Storage {
     type Iter = MultiIter<'a, MessageMetadata, <Self as StorageBackend>::Error>;
 
-    fn multi_fetch(&'a self, keys: &[MessageId]) -> Result<Self::Iter, <Self as StorageBackend>::Error> {
+    fn multi_fetch_op(&'a self, keys: &[MessageId]) -> Result<Self::Iter, <Self as StorageBackend>::Error> {
         let cf = self.cf_handle(CF_MESSAGE_ID_TO_METADATA)?;
 
         Ok(MultiIter {

--- a/bee-storage/bee-storage-rocksdb/src/access/truncate.rs
+++ b/bee-storage/bee-storage-rocksdb/src/access/truncate.rs
@@ -25,7 +25,7 @@ use crate::{
 macro_rules! impl_truncate {
     ($key:ty, $value:ty, $cf:expr) => {
         impl Truncate<$key, $value> for Storage {
-            fn truncate(&self) -> Result<(), <Self as StorageBackend>::Error> {
+            fn truncate_op(&self) -> Result<(), <Self as StorageBackend>::Error> {
                 let cf_handle = self.cf_handle($cf)?;
 
                 let mut iter = self.inner.raw_iterator_cf(cf_handle);
@@ -83,7 +83,7 @@ impl_truncate!((MilestoneIndex, Receipt), (), CF_MILESTONE_INDEX_TO_RECEIPT);
 impl_truncate!((bool, TreasuryOutput), (), CF_SPENT_TO_TREASURY_OUTPUT);
 
 impl Truncate<MessageId, MessageMetadata> for Storage {
-    fn truncate(&self) -> Result<(), <Self as StorageBackend>::Error> {
+    fn truncate_op(&self) -> Result<(), <Self as StorageBackend>::Error> {
         let guard = self.locks.message_id_to_metadata.read();
 
         let cf_handle = self.cf_handle(CF_MESSAGE_ID_TO_METADATA)?;

--- a/bee-storage/bee-storage-rocksdb/src/access/update.rs
+++ b/bee-storage/bee-storage-rocksdb/src/access/update.rs
@@ -9,7 +9,7 @@ use bee_tangle::metadata::MessageMetadata;
 use crate::{column_families::*, storage::Storage};
 
 impl Update<MessageId, MessageMetadata> for Storage {
-    fn update(&self, message_id: &MessageId, mut f: impl FnMut(&mut MessageMetadata)) -> Result<(), Self::Error> {
+    fn update_op(&self, message_id: &MessageId, mut f: impl FnMut(&mut MessageMetadata)) -> Result<(), Self::Error> {
         let cf_handle = self.cf_handle(CF_MESSAGE_ID_TO_METADATA)?;
 
         let guard = self.locks.message_id_to_metadata.write();

--- a/bee-storage/bee-storage-rocksdb/src/storage.rs
+++ b/bee-storage/bee-storage-rocksdb/src/storage.rs
@@ -184,7 +184,7 @@ impl StorageBackend for Storage {
     fn start(config: Self::Config) -> Result<Self, Self::Error> {
         let storage = Self::new(config)?;
 
-        match storage.fetch_access::<u8, System>(&SYSTEM_VERSION_KEY)? {
+        match storage.fetch::<u8, System>(&SYSTEM_VERSION_KEY)? {
             Some(System::Version(version)) => {
                 if version != STORAGE_VERSION {
                     return Err(Error::VersionMismatch(version, STORAGE_VERSION));
@@ -218,7 +218,7 @@ impl StorageBackend for Storage {
     }
 
     fn get_health(&self) -> Result<Option<StorageHealth>, Self::Error> {
-        Ok(match self.fetch_access::<u8, System>(&SYSTEM_HEALTH_KEY)? {
+        Ok(match self.fetch::<u8, System>(&SYSTEM_HEALTH_KEY)? {
             Some(System::Health(health)) => Some(health),
             None => None,
             _ => panic!("Another system value was inserted on the health key."),

--- a/bee-storage/bee-storage-rocksdb/src/storage.rs
+++ b/bee-storage/bee-storage-rocksdb/src/storage.rs
@@ -190,7 +190,7 @@ impl StorageBackend for Storage {
                     return Err(Error::VersionMismatch(version, STORAGE_VERSION));
                 }
             }
-            None => Insert::<u8, System>::insert(&storage, &SYSTEM_VERSION_KEY, &System::Version(STORAGE_VERSION))?,
+            None => Insert::<u8, System>::insert_op(&storage, &SYSTEM_VERSION_KEY, &System::Version(STORAGE_VERSION))?,
             _ => panic!("Another system value was inserted on the version key."),
         }
 
@@ -226,6 +226,6 @@ impl StorageBackend for Storage {
     }
 
     fn set_health(&self, health: StorageHealth) -> Result<(), Self::Error> {
-        Insert::<u8, System>::insert(self, &SYSTEM_HEALTH_KEY, &System::Health(health))
+        Insert::<u8, System>::insert_op(self, &SYSTEM_HEALTH_KEY, &System::Health(health))
     }
 }

--- a/bee-storage/bee-storage-rocksdb/src/storage.rs
+++ b/bee-storage/bee-storage-rocksdb/src/storage.rs
@@ -190,7 +190,7 @@ impl StorageBackend for Storage {
                     return Err(Error::VersionMismatch(version, STORAGE_VERSION));
                 }
             }
-            None => Insert::<u8, System>::insert_op(&storage, &SYSTEM_VERSION_KEY, &System::Version(STORAGE_VERSION))?,
+            None => storage.insert::<u8, System>(&SYSTEM_VERSION_KEY, &System::Version(STORAGE_VERSION))?,
             _ => panic!("Another system value was inserted on the version key."),
         }
 
@@ -226,6 +226,6 @@ impl StorageBackend for Storage {
     }
 
     fn set_health(&self, health: StorageHealth) -> Result<(), Self::Error> {
-        Insert::<u8, System>::insert_op(self, &SYSTEM_HEALTH_KEY, &System::Health(health))
+        self.insert::<u8, System>(&SYSTEM_HEALTH_KEY, &System::Health(health))
     }
 }

--- a/bee-storage/bee-storage-rocksdb/src/storage.rs
+++ b/bee-storage/bee-storage-rocksdb/src/storage.rs
@@ -190,7 +190,7 @@ impl StorageBackend for Storage {
                     return Err(Error::VersionMismatch(version, STORAGE_VERSION));
                 }
             }
-            None => storage.insert::<u8, System>(&SYSTEM_VERSION_KEY, &System::Version(STORAGE_VERSION))?,
+            None => storage.insert(&SYSTEM_VERSION_KEY, &System::Version(STORAGE_VERSION))?,
             _ => panic!("Another system value was inserted on the version key."),
         }
 
@@ -226,6 +226,6 @@ impl StorageBackend for Storage {
     }
 
     fn set_health(&self, health: StorageHealth) -> Result<(), Self::Error> {
-        self.insert::<u8, System>(&SYSTEM_HEALTH_KEY, &System::Health(health))
+        self.insert(&SYSTEM_HEALTH_KEY, &System::Health(health))
     }
 }

--- a/bee-storage/bee-storage-rocksdb/src/storage.rs
+++ b/bee-storage/bee-storage-rocksdb/src/storage.rs
@@ -6,8 +6,8 @@ use bee_message::{
     MESSAGE_ID_LENGTH,
 };
 pub use bee_storage::{
-    access::{Fetch, Insert},
-    backend::StorageBackend,
+    access::Insert,
+    backend::{StorageBackend, StorageBackendExt},
     system::{StorageHealth, StorageVersion, System, SYSTEM_HEALTH_KEY, SYSTEM_VERSION_KEY},
 };
 use parking_lot::RwLock;
@@ -184,7 +184,7 @@ impl StorageBackend for Storage {
     fn start(config: Self::Config) -> Result<Self, Self::Error> {
         let storage = Self::new(config)?;
 
-        match Fetch::<u8, System>::fetch(&storage, &SYSTEM_VERSION_KEY)? {
+        match storage.fetch_access::<u8, System>(&SYSTEM_VERSION_KEY)? {
             Some(System::Version(version)) => {
                 if version != STORAGE_VERSION {
                     return Err(Error::VersionMismatch(version, STORAGE_VERSION));
@@ -218,7 +218,7 @@ impl StorageBackend for Storage {
     }
 
     fn get_health(&self) -> Result<Option<StorageHealth>, Self::Error> {
-        Ok(match Fetch::<u8, System>::fetch(self, &SYSTEM_HEALTH_KEY)? {
+        Ok(match self.fetch_access::<u8, System>(&SYSTEM_HEALTH_KEY)? {
             Some(System::Health(health)) => Some(health),
             None => None,
             _ => panic!("Another system value was inserted on the health key."),

--- a/bee-storage/bee-storage-sled/src/access/batch.rs
+++ b/bee-storage/bee-storage-sled/src/access/batch.rs
@@ -68,7 +68,7 @@ impl BatchBuilder for Storage {
 }
 
 impl Batch<MessageId, Message> for Storage {
-    fn batch_insert(
+    fn batch_insert_op(
         &self,
         batch: &mut Self::Batch,
         message_id: &MessageId,
@@ -87,7 +87,7 @@ impl Batch<MessageId, Message> for Storage {
         Ok(())
     }
 
-    fn batch_delete(
+    fn batch_delete_op(
         &self,
         batch: &mut Self::Batch,
         message_id: &MessageId,
@@ -103,7 +103,7 @@ impl Batch<MessageId, Message> for Storage {
 }
 
 impl Batch<MessageId, MessageMetadata> for Storage {
-    fn batch_insert(
+    fn batch_insert_op(
         &self,
         batch: &mut Self::Batch,
         message_id: &MessageId,
@@ -122,7 +122,7 @@ impl Batch<MessageId, MessageMetadata> for Storage {
         Ok(())
     }
 
-    fn batch_delete(
+    fn batch_delete_op(
         &self,
         batch: &mut Self::Batch,
         message_id: &MessageId,
@@ -138,7 +138,7 @@ impl Batch<MessageId, MessageMetadata> for Storage {
 }
 
 impl Batch<(MessageId, MessageId), ()> for Storage {
-    fn batch_insert(
+    fn batch_insert_op(
         &self,
         batch: &mut Self::Batch,
         (parent, child): &(MessageId, MessageId),
@@ -157,7 +157,7 @@ impl Batch<(MessageId, MessageId), ()> for Storage {
         Ok(())
     }
 
-    fn batch_delete(
+    fn batch_delete_op(
         &self,
         batch: &mut Self::Batch,
         (parent, child): &(MessageId, MessageId),
@@ -177,7 +177,7 @@ impl Batch<(MessageId, MessageId), ()> for Storage {
 }
 
 impl Batch<(PaddedIndex, MessageId), ()> for Storage {
-    fn batch_insert(
+    fn batch_insert_op(
         &self,
         batch: &mut Self::Batch,
         (index, message_id): &(PaddedIndex, MessageId),
@@ -196,7 +196,7 @@ impl Batch<(PaddedIndex, MessageId), ()> for Storage {
         Ok(())
     }
 
-    fn batch_delete(
+    fn batch_delete_op(
         &self,
         batch: &mut Self::Batch,
         (index, message_id): &(PaddedIndex, MessageId),
@@ -216,7 +216,7 @@ impl Batch<(PaddedIndex, MessageId), ()> for Storage {
 }
 
 impl Batch<OutputId, CreatedOutput> for Storage {
-    fn batch_insert(
+    fn batch_insert_op(
         &self,
         batch: &mut Self::Batch,
         output_id: &OutputId,
@@ -238,7 +238,7 @@ impl Batch<OutputId, CreatedOutput> for Storage {
         Ok(())
     }
 
-    fn batch_delete(
+    fn batch_delete_op(
         &self,
         batch: &mut Self::Batch,
         output_id: &OutputId,
@@ -258,7 +258,7 @@ impl Batch<OutputId, CreatedOutput> for Storage {
 }
 
 impl Batch<OutputId, ConsumedOutput> for Storage {
-    fn batch_insert(
+    fn batch_insert_op(
         &self,
         batch: &mut Self::Batch,
         output_id: &OutputId,
@@ -280,7 +280,7 @@ impl Batch<OutputId, ConsumedOutput> for Storage {
         Ok(())
     }
 
-    fn batch_delete(
+    fn batch_delete_op(
         &self,
         batch: &mut Self::Batch,
         output_id: &OutputId,
@@ -300,7 +300,7 @@ impl Batch<OutputId, ConsumedOutput> for Storage {
 }
 
 impl Batch<Unspent, ()> for Storage {
-    fn batch_insert(&self, batch: &mut Self::Batch, unspent: &Unspent, (): &()) -> Result<(), Self::Error> {
+    fn batch_insert_op(&self, batch: &mut Self::Batch, unspent: &Unspent, (): &()) -> Result<(), Self::Error> {
         batch.key_buf.clear();
         // Packing to bytes can't fail.
         unspent.pack(&mut batch.key_buf).unwrap();
@@ -314,7 +314,7 @@ impl Batch<Unspent, ()> for Storage {
         Ok(())
     }
 
-    fn batch_delete(&self, batch: &mut Self::Batch, unspent: &Unspent) -> Result<(), Self::Error> {
+    fn batch_delete_op(&self, batch: &mut Self::Batch, unspent: &Unspent) -> Result<(), Self::Error> {
         batch.key_buf.clear();
         // Packing to bytes can't fail.
         unspent.pack(&mut batch.key_buf).unwrap();
@@ -330,7 +330,7 @@ impl Batch<Unspent, ()> for Storage {
 }
 
 impl Batch<(Ed25519Address, OutputId), ()> for Storage {
-    fn batch_insert(
+    fn batch_insert_op(
         &self,
         batch: &mut Self::Batch,
         (address, output_id): &(Ed25519Address, OutputId),
@@ -349,7 +349,7 @@ impl Batch<(Ed25519Address, OutputId), ()> for Storage {
         Ok(())
     }
 
-    fn batch_delete(
+    fn batch_delete_op(
         &self,
         batch: &mut Self::Batch,
         (address, output_id): &(Ed25519Address, OutputId),
@@ -369,7 +369,7 @@ impl Batch<(Ed25519Address, OutputId), ()> for Storage {
 }
 
 impl Batch<(), LedgerIndex> for Storage {
-    fn batch_insert(
+    fn batch_insert_op(
         &self,
         batch: &mut Self::Batch,
         (): &(),
@@ -388,7 +388,7 @@ impl Batch<(), LedgerIndex> for Storage {
         Ok(())
     }
 
-    fn batch_delete(&self, batch: &mut Self::Batch, (): &()) -> Result<(), <Self as StorageBackend>::Error> {
+    fn batch_delete_op(&self, batch: &mut Self::Batch, (): &()) -> Result<(), <Self as StorageBackend>::Error> {
         batch.inner.entry(TREE_LEDGER_INDEX).or_default().remove(&[0x00u8]);
 
         Ok(())
@@ -396,7 +396,7 @@ impl Batch<(), LedgerIndex> for Storage {
 }
 
 impl Batch<MilestoneIndex, Milestone> for Storage {
-    fn batch_insert(
+    fn batch_insert_op(
         &self,
         batch: &mut Self::Batch,
         index: &MilestoneIndex,
@@ -418,7 +418,7 @@ impl Batch<MilestoneIndex, Milestone> for Storage {
         Ok(())
     }
 
-    fn batch_delete(
+    fn batch_delete_op(
         &self,
         batch: &mut Self::Batch,
         index: &MilestoneIndex,
@@ -438,7 +438,7 @@ impl Batch<MilestoneIndex, Milestone> for Storage {
 }
 
 impl Batch<(), SnapshotInfo> for Storage {
-    fn batch_insert(
+    fn batch_insert_op(
         &self,
         batch: &mut Self::Batch,
         (): &(),
@@ -457,7 +457,7 @@ impl Batch<(), SnapshotInfo> for Storage {
         Ok(())
     }
 
-    fn batch_delete(&self, batch: &mut Self::Batch, (): &()) -> Result<(), <Self as StorageBackend>::Error> {
+    fn batch_delete_op(&self, batch: &mut Self::Batch, (): &()) -> Result<(), <Self as StorageBackend>::Error> {
         batch.inner.entry(TREE_SNAPSHOT_INFO).or_default().remove(&[0x00u8]);
 
         Ok(())
@@ -465,7 +465,7 @@ impl Batch<(), SnapshotInfo> for Storage {
 }
 
 impl Batch<SolidEntryPoint, MilestoneIndex> for Storage {
-    fn batch_insert(
+    fn batch_insert_op(
         &self,
         batch: &mut Self::Batch,
         sep: &SolidEntryPoint,
@@ -487,7 +487,7 @@ impl Batch<SolidEntryPoint, MilestoneIndex> for Storage {
         Ok(())
     }
 
-    fn batch_delete(&self, batch: &mut Self::Batch, sep: &SolidEntryPoint) -> Result<(), Self::Error> {
+    fn batch_delete_op(&self, batch: &mut Self::Batch, sep: &SolidEntryPoint) -> Result<(), Self::Error> {
         batch.key_buf.clear();
         // Packing to bytes can't fail.
         sep.pack(&mut batch.key_buf).unwrap();
@@ -503,7 +503,7 @@ impl Batch<SolidEntryPoint, MilestoneIndex> for Storage {
 }
 
 impl Batch<MilestoneIndex, OutputDiff> for Storage {
-    fn batch_insert(
+    fn batch_insert_op(
         &self,
         batch: &mut Self::Batch,
         index: &MilestoneIndex,
@@ -525,7 +525,7 @@ impl Batch<MilestoneIndex, OutputDiff> for Storage {
         Ok(())
     }
 
-    fn batch_delete(
+    fn batch_delete_op(
         &self,
         batch: &mut Self::Batch,
         index: &MilestoneIndex,
@@ -545,7 +545,7 @@ impl Batch<MilestoneIndex, OutputDiff> for Storage {
 }
 
 impl Batch<Address, Balance> for Storage {
-    fn batch_insert(
+    fn batch_insert_op(
         &self,
         batch: &mut Self::Batch,
         address: &Address,
@@ -560,7 +560,11 @@ impl Batch<Address, Balance> for Storage {
         Ok(())
     }
 
-    fn batch_delete(&self, batch: &mut Self::Batch, address: &Address) -> Result<(), <Self as StorageBackend>::Error> {
+    fn batch_delete_op(
+        &self,
+        batch: &mut Self::Batch,
+        address: &Address,
+    ) -> Result<(), <Self as StorageBackend>::Error> {
         batch
             .inner
             .entry(TREE_ADDRESS_TO_BALANCE)
@@ -572,7 +576,7 @@ impl Batch<Address, Balance> for Storage {
 }
 
 impl Batch<(MilestoneIndex, UnreferencedMessage), ()> for Storage {
-    fn batch_insert(
+    fn batch_insert_op(
         &self,
         batch: &mut Self::Batch,
         (index, unreferenced_message): &(MilestoneIndex, UnreferencedMessage),
@@ -591,7 +595,7 @@ impl Batch<(MilestoneIndex, UnreferencedMessage), ()> for Storage {
         Ok(())
     }
 
-    fn batch_delete(
+    fn batch_delete_op(
         &self,
         batch: &mut Self::Batch,
         (index, unreferenced_message): &(MilestoneIndex, UnreferencedMessage),
@@ -611,7 +615,7 @@ impl Batch<(MilestoneIndex, UnreferencedMessage), ()> for Storage {
 }
 
 impl Batch<(MilestoneIndex, Receipt), ()> for Storage {
-    fn batch_insert(
+    fn batch_insert_op(
         &self,
         batch: &mut Self::Batch,
         (index, receipt): &(MilestoneIndex, Receipt),
@@ -630,7 +634,7 @@ impl Batch<(MilestoneIndex, Receipt), ()> for Storage {
         Ok(())
     }
 
-    fn batch_delete(
+    fn batch_delete_op(
         &self,
         batch: &mut Self::Batch,
         (index, receipt): &(MilestoneIndex, Receipt),
@@ -650,7 +654,7 @@ impl Batch<(MilestoneIndex, Receipt), ()> for Storage {
 }
 
 impl Batch<(bool, TreasuryOutput), ()> for Storage {
-    fn batch_insert(
+    fn batch_insert_op(
         &self,
         batch: &mut Self::Batch,
         (spent, output): &(bool, TreasuryOutput),
@@ -669,7 +673,7 @@ impl Batch<(bool, TreasuryOutput), ()> for Storage {
         Ok(())
     }
 
-    fn batch_delete(
+    fn batch_delete_op(
         &self,
         batch: &mut Self::Batch,
         (spent, output): &(bool, TreasuryOutput),

--- a/bee-storage/bee-storage-sled/src/access/delete.rs
+++ b/bee-storage/bee-storage-sled/src/access/delete.rs
@@ -23,7 +23,7 @@ use bee_tangle::{
 use crate::{storage::Storage, trees::*};
 
 impl Delete<MessageId, Message> for Storage {
-    fn delete(&self, message_id: &MessageId) -> Result<(), <Self as StorageBackend>::Error> {
+    fn delete_op(&self, message_id: &MessageId) -> Result<(), <Self as StorageBackend>::Error> {
         self.inner.open_tree(TREE_MESSAGE_ID_TO_MESSAGE)?.remove(message_id)?;
 
         Ok(())
@@ -31,7 +31,7 @@ impl Delete<MessageId, Message> for Storage {
 }
 
 impl Delete<MessageId, MessageMetadata> for Storage {
-    fn delete(&self, message_id: &MessageId) -> Result<(), <Self as StorageBackend>::Error> {
+    fn delete_op(&self, message_id: &MessageId) -> Result<(), <Self as StorageBackend>::Error> {
         self.inner.open_tree(TREE_MESSAGE_ID_TO_METADATA)?.remove(message_id)?;
 
         Ok(())
@@ -39,7 +39,7 @@ impl Delete<MessageId, MessageMetadata> for Storage {
 }
 
 impl Delete<(MessageId, MessageId), ()> for Storage {
-    fn delete(&self, (parent, child): &(MessageId, MessageId)) -> Result<(), <Self as StorageBackend>::Error> {
+    fn delete_op(&self, (parent, child): &(MessageId, MessageId)) -> Result<(), <Self as StorageBackend>::Error> {
         let mut key = parent.as_ref().to_vec();
         key.extend_from_slice(child.as_ref());
 
@@ -50,7 +50,7 @@ impl Delete<(MessageId, MessageId), ()> for Storage {
 }
 
 impl Delete<(PaddedIndex, MessageId), ()> for Storage {
-    fn delete(&self, (index, message_id): &(PaddedIndex, MessageId)) -> Result<(), <Self as StorageBackend>::Error> {
+    fn delete_op(&self, (index, message_id): &(PaddedIndex, MessageId)) -> Result<(), <Self as StorageBackend>::Error> {
         let mut key = index.as_ref().to_vec();
         key.extend_from_slice(message_id.as_ref());
 
@@ -61,7 +61,7 @@ impl Delete<(PaddedIndex, MessageId), ()> for Storage {
 }
 
 impl Delete<OutputId, CreatedOutput> for Storage {
-    fn delete(&self, output_id: &OutputId) -> Result<(), <Self as StorageBackend>::Error> {
+    fn delete_op(&self, output_id: &OutputId) -> Result<(), <Self as StorageBackend>::Error> {
         self.inner
             .open_tree(TREE_OUTPUT_ID_TO_CREATED_OUTPUT)?
             .remove(output_id.pack_new())?;
@@ -71,7 +71,7 @@ impl Delete<OutputId, CreatedOutput> for Storage {
 }
 
 impl Delete<OutputId, ConsumedOutput> for Storage {
-    fn delete(&self, output_id: &OutputId) -> Result<(), <Self as StorageBackend>::Error> {
+    fn delete_op(&self, output_id: &OutputId) -> Result<(), <Self as StorageBackend>::Error> {
         self.inner
             .open_tree(TREE_OUTPUT_ID_TO_CONSUMED_OUTPUT)?
             .remove(output_id.pack_new())?;
@@ -81,7 +81,7 @@ impl Delete<OutputId, ConsumedOutput> for Storage {
 }
 
 impl Delete<Unspent, ()> for Storage {
-    fn delete(&self, unspent: &Unspent) -> Result<(), <Self as StorageBackend>::Error> {
+    fn delete_op(&self, unspent: &Unspent) -> Result<(), <Self as StorageBackend>::Error> {
         self.inner
             .open_tree(TREE_OUTPUT_ID_UNSPENT)?
             .remove(unspent.pack_new())?;
@@ -91,7 +91,10 @@ impl Delete<Unspent, ()> for Storage {
 }
 
 impl Delete<(Ed25519Address, OutputId), ()> for Storage {
-    fn delete(&self, (address, output_id): &(Ed25519Address, OutputId)) -> Result<(), <Self as StorageBackend>::Error> {
+    fn delete_op(
+        &self,
+        (address, output_id): &(Ed25519Address, OutputId),
+    ) -> Result<(), <Self as StorageBackend>::Error> {
         let mut key = address.as_ref().to_vec();
         key.extend_from_slice(&output_id.pack_new());
 
@@ -102,7 +105,7 @@ impl Delete<(Ed25519Address, OutputId), ()> for Storage {
 }
 
 impl Delete<(), LedgerIndex> for Storage {
-    fn delete(&self, (): &()) -> Result<(), <Self as StorageBackend>::Error> {
+    fn delete_op(&self, (): &()) -> Result<(), <Self as StorageBackend>::Error> {
         self.inner.open_tree(TREE_LEDGER_INDEX)?.remove([0x00u8])?;
 
         Ok(())
@@ -110,7 +113,7 @@ impl Delete<(), LedgerIndex> for Storage {
 }
 
 impl Delete<MilestoneIndex, Milestone> for Storage {
-    fn delete(&self, index: &MilestoneIndex) -> Result<(), <Self as StorageBackend>::Error> {
+    fn delete_op(&self, index: &MilestoneIndex) -> Result<(), <Self as StorageBackend>::Error> {
         self.inner
             .open_tree(TREE_MILESTONE_INDEX_TO_MILESTONE)?
             .remove(index.pack_new())?;
@@ -120,7 +123,7 @@ impl Delete<MilestoneIndex, Milestone> for Storage {
 }
 
 impl Delete<(), SnapshotInfo> for Storage {
-    fn delete(&self, (): &()) -> Result<(), <Self as StorageBackend>::Error> {
+    fn delete_op(&self, (): &()) -> Result<(), <Self as StorageBackend>::Error> {
         self.inner.open_tree(TREE_SNAPSHOT_INFO)?.remove([0x00u8])?;
 
         Ok(())
@@ -128,7 +131,7 @@ impl Delete<(), SnapshotInfo> for Storage {
 }
 
 impl Delete<SolidEntryPoint, MilestoneIndex> for Storage {
-    fn delete(&self, sep: &SolidEntryPoint) -> Result<(), <Self as StorageBackend>::Error> {
+    fn delete_op(&self, sep: &SolidEntryPoint) -> Result<(), <Self as StorageBackend>::Error> {
         self.inner
             .open_tree(TREE_SOLID_ENTRY_POINT_TO_MILESTONE_INDEX)?
             .remove(sep.as_ref())?;
@@ -138,7 +141,7 @@ impl Delete<SolidEntryPoint, MilestoneIndex> for Storage {
 }
 
 impl Delete<MilestoneIndex, OutputDiff> for Storage {
-    fn delete(&self, index: &MilestoneIndex) -> Result<(), <Self as StorageBackend>::Error> {
+    fn delete_op(&self, index: &MilestoneIndex) -> Result<(), <Self as StorageBackend>::Error> {
         self.inner
             .open_tree(TREE_MILESTONE_INDEX_TO_OUTPUT_DIFF)?
             .remove(index.pack_new())?;
@@ -148,7 +151,7 @@ impl Delete<MilestoneIndex, OutputDiff> for Storage {
 }
 
 impl Delete<Address, Balance> for Storage {
-    fn delete(&self, address: &Address) -> Result<(), <Self as StorageBackend>::Error> {
+    fn delete_op(&self, address: &Address) -> Result<(), <Self as StorageBackend>::Error> {
         self.inner
             .open_tree(TREE_ADDRESS_TO_BALANCE)?
             .remove(address.pack_new())?;
@@ -158,7 +161,7 @@ impl Delete<Address, Balance> for Storage {
 }
 
 impl Delete<(MilestoneIndex, UnreferencedMessage), ()> for Storage {
-    fn delete(
+    fn delete_op(
         &self,
         (index, unreferenced_message): &(MilestoneIndex, UnreferencedMessage),
     ) -> Result<(), <Self as StorageBackend>::Error> {
@@ -174,7 +177,7 @@ impl Delete<(MilestoneIndex, UnreferencedMessage), ()> for Storage {
 }
 
 impl Delete<(MilestoneIndex, Receipt), ()> for Storage {
-    fn delete(&self, (index, receipt): &(MilestoneIndex, Receipt)) -> Result<(), <Self as StorageBackend>::Error> {
+    fn delete_op(&self, (index, receipt): &(MilestoneIndex, Receipt)) -> Result<(), <Self as StorageBackend>::Error> {
         let mut key = index.pack_new();
         key.extend_from_slice(&receipt.pack_new());
 
@@ -185,7 +188,7 @@ impl Delete<(MilestoneIndex, Receipt), ()> for Storage {
 }
 
 impl Delete<(bool, TreasuryOutput), ()> for Storage {
-    fn delete(&self, (spent, output): &(bool, TreasuryOutput)) -> Result<(), <Self as StorageBackend>::Error> {
+    fn delete_op(&self, (spent, output): &(bool, TreasuryOutput)) -> Result<(), <Self as StorageBackend>::Error> {
         let mut key = spent.pack_new();
         key.extend_from_slice(&output.pack_new());
 

--- a/bee-storage/bee-storage-sled/src/access/exist.rs
+++ b/bee-storage/bee-storage-sled/src/access/exist.rs
@@ -23,7 +23,7 @@ use bee_tangle::{
 use crate::{storage::Storage, trees::*};
 
 impl Exist<MessageId, Message> for Storage {
-    fn exist(&self, message_id: &MessageId) -> Result<bool, <Self as StorageBackend>::Error> {
+    fn exist_op(&self, message_id: &MessageId) -> Result<bool, <Self as StorageBackend>::Error> {
         Ok(self
             .inner
             .open_tree(TREE_MESSAGE_ID_TO_MESSAGE)?
@@ -32,7 +32,7 @@ impl Exist<MessageId, Message> for Storage {
 }
 
 impl Exist<MessageId, MessageMetadata> for Storage {
-    fn exist(&self, message_id: &MessageId) -> Result<bool, <Self as StorageBackend>::Error> {
+    fn exist_op(&self, message_id: &MessageId) -> Result<bool, <Self as StorageBackend>::Error> {
         Ok(self
             .inner
             .open_tree(TREE_MESSAGE_ID_TO_METADATA)?
@@ -41,7 +41,7 @@ impl Exist<MessageId, MessageMetadata> for Storage {
 }
 
 impl Exist<(MessageId, MessageId), ()> for Storage {
-    fn exist(&self, (parent, child): &(MessageId, MessageId)) -> Result<bool, <Self as StorageBackend>::Error> {
+    fn exist_op(&self, (parent, child): &(MessageId, MessageId)) -> Result<bool, <Self as StorageBackend>::Error> {
         let mut key = parent.as_ref().to_vec();
         key.extend_from_slice(child.as_ref());
 
@@ -50,7 +50,10 @@ impl Exist<(MessageId, MessageId), ()> for Storage {
 }
 
 impl Exist<(PaddedIndex, MessageId), ()> for Storage {
-    fn exist(&self, (index, message_id): &(PaddedIndex, MessageId)) -> Result<bool, <Self as StorageBackend>::Error> {
+    fn exist_op(
+        &self,
+        (index, message_id): &(PaddedIndex, MessageId),
+    ) -> Result<bool, <Self as StorageBackend>::Error> {
         let mut key = index.as_ref().to_vec();
         key.extend_from_slice(message_id.as_ref());
 
@@ -59,7 +62,7 @@ impl Exist<(PaddedIndex, MessageId), ()> for Storage {
 }
 
 impl Exist<OutputId, CreatedOutput> for Storage {
-    fn exist(&self, output_id: &OutputId) -> Result<bool, <Self as StorageBackend>::Error> {
+    fn exist_op(&self, output_id: &OutputId) -> Result<bool, <Self as StorageBackend>::Error> {
         Ok(self
             .inner
             .open_tree(TREE_OUTPUT_ID_TO_CREATED_OUTPUT)?
@@ -68,7 +71,7 @@ impl Exist<OutputId, CreatedOutput> for Storage {
 }
 
 impl Exist<OutputId, ConsumedOutput> for Storage {
-    fn exist(&self, output_id: &OutputId) -> Result<bool, <Self as StorageBackend>::Error> {
+    fn exist_op(&self, output_id: &OutputId) -> Result<bool, <Self as StorageBackend>::Error> {
         Ok(self
             .inner
             .open_tree(TREE_OUTPUT_ID_TO_CONSUMED_OUTPUT)?
@@ -77,7 +80,7 @@ impl Exist<OutputId, ConsumedOutput> for Storage {
 }
 
 impl Exist<Unspent, ()> for Storage {
-    fn exist(&self, unspent: &Unspent) -> Result<bool, <Self as StorageBackend>::Error> {
+    fn exist_op(&self, unspent: &Unspent) -> Result<bool, <Self as StorageBackend>::Error> {
         Ok(self
             .inner
             .open_tree(TREE_OUTPUT_ID_UNSPENT)?
@@ -86,7 +89,7 @@ impl Exist<Unspent, ()> for Storage {
 }
 
 impl Exist<(Ed25519Address, OutputId), ()> for Storage {
-    fn exist(
+    fn exist_op(
         &self,
         (address, output_id): &(Ed25519Address, OutputId),
     ) -> Result<bool, <Self as StorageBackend>::Error> {
@@ -101,13 +104,13 @@ impl Exist<(Ed25519Address, OutputId), ()> for Storage {
 }
 
 impl Exist<(), LedgerIndex> for Storage {
-    fn exist(&self, (): &()) -> Result<bool, <Self as StorageBackend>::Error> {
+    fn exist_op(&self, (): &()) -> Result<bool, <Self as StorageBackend>::Error> {
         Ok(self.inner.open_tree(TREE_LEDGER_INDEX)?.contains_key([0x00u8])?)
     }
 }
 
 impl Exist<MilestoneIndex, Milestone> for Storage {
-    fn exist(&self, index: &MilestoneIndex) -> Result<bool, <Self as StorageBackend>::Error> {
+    fn exist_op(&self, index: &MilestoneIndex) -> Result<bool, <Self as StorageBackend>::Error> {
         Ok(self
             .inner
             .open_tree(TREE_MILESTONE_INDEX_TO_MILESTONE)?
@@ -116,13 +119,13 @@ impl Exist<MilestoneIndex, Milestone> for Storage {
 }
 
 impl Exist<(), SnapshotInfo> for Storage {
-    fn exist(&self, (): &()) -> Result<bool, <Self as StorageBackend>::Error> {
+    fn exist_op(&self, (): &()) -> Result<bool, <Self as StorageBackend>::Error> {
         Ok(self.inner.open_tree(TREE_SNAPSHOT_INFO)?.contains_key([0x00u8])?)
     }
 }
 
 impl Exist<SolidEntryPoint, MilestoneIndex> for Storage {
-    fn exist(&self, sep: &SolidEntryPoint) -> Result<bool, <Self as StorageBackend>::Error> {
+    fn exist_op(&self, sep: &SolidEntryPoint) -> Result<bool, <Self as StorageBackend>::Error> {
         Ok(self
             .inner
             .open_tree(TREE_SOLID_ENTRY_POINT_TO_MILESTONE_INDEX)?
@@ -131,7 +134,7 @@ impl Exist<SolidEntryPoint, MilestoneIndex> for Storage {
 }
 
 impl Exist<MilestoneIndex, OutputDiff> for Storage {
-    fn exist(&self, index: &MilestoneIndex) -> Result<bool, <Self as StorageBackend>::Error> {
+    fn exist_op(&self, index: &MilestoneIndex) -> Result<bool, <Self as StorageBackend>::Error> {
         Ok(self
             .inner
             .open_tree(TREE_MILESTONE_INDEX_TO_OUTPUT_DIFF)?
@@ -140,7 +143,7 @@ impl Exist<MilestoneIndex, OutputDiff> for Storage {
 }
 
 impl Exist<Address, Balance> for Storage {
-    fn exist(&self, address: &Address) -> Result<bool, <Self as StorageBackend>::Error> {
+    fn exist_op(&self, address: &Address) -> Result<bool, <Self as StorageBackend>::Error> {
         Ok(self
             .inner
             .open_tree(TREE_ADDRESS_TO_BALANCE)?
@@ -149,7 +152,7 @@ impl Exist<Address, Balance> for Storage {
 }
 
 impl Exist<(MilestoneIndex, UnreferencedMessage), ()> for Storage {
-    fn exist(
+    fn exist_op(
         &self,
         (index, unreferenced_message): &(MilestoneIndex, UnreferencedMessage),
     ) -> Result<bool, <Self as StorageBackend>::Error> {
@@ -164,7 +167,7 @@ impl Exist<(MilestoneIndex, UnreferencedMessage), ()> for Storage {
 }
 
 impl Exist<(MilestoneIndex, Receipt), ()> for Storage {
-    fn exist(&self, (index, receipt): &(MilestoneIndex, Receipt)) -> Result<bool, <Self as StorageBackend>::Error> {
+    fn exist_op(&self, (index, receipt): &(MilestoneIndex, Receipt)) -> Result<bool, <Self as StorageBackend>::Error> {
         let mut key = index.pack_new();
         key.extend_from_slice(&receipt.pack_new());
 
@@ -176,7 +179,7 @@ impl Exist<(MilestoneIndex, Receipt), ()> for Storage {
 }
 
 impl Exist<(bool, TreasuryOutput), ()> for Storage {
-    fn exist(&self, (spent, output): &(bool, TreasuryOutput)) -> Result<bool, <Self as StorageBackend>::Error> {
+    fn exist_op(&self, (spent, output): &(bool, TreasuryOutput)) -> Result<bool, <Self as StorageBackend>::Error> {
         let mut key = spent.pack_new();
         key.extend_from_slice(&output.pack_new());
 

--- a/bee-storage/bee-storage-sled/src/access/fetch.rs
+++ b/bee-storage/bee-storage-sled/src/access/fetch.rs
@@ -23,7 +23,7 @@ use bee_tangle::{
 use crate::{storage::Storage, trees::*};
 
 impl Fetch<u8, System> for Storage {
-    fn fetch(&self, &key: &u8) -> Result<Option<System>, <Self as StorageBackend>::Error> {
+    fn fetch_op(&self, &key: &u8) -> Result<Option<System>, <Self as StorageBackend>::Error> {
         Ok(self
             .inner
             .get(&[key])?
@@ -33,7 +33,7 @@ impl Fetch<u8, System> for Storage {
 }
 
 impl Fetch<MessageId, Message> for Storage {
-    fn fetch(&self, message_id: &MessageId) -> Result<Option<Message>, <Self as StorageBackend>::Error> {
+    fn fetch_op(&self, message_id: &MessageId) -> Result<Option<Message>, <Self as StorageBackend>::Error> {
         Ok(self
             .inner
             .open_tree(TREE_MESSAGE_ID_TO_MESSAGE)?
@@ -44,7 +44,7 @@ impl Fetch<MessageId, Message> for Storage {
 }
 
 impl Fetch<MessageId, MessageMetadata> for Storage {
-    fn fetch(&self, message_id: &MessageId) -> Result<Option<MessageMetadata>, <Self as StorageBackend>::Error> {
+    fn fetch_op(&self, message_id: &MessageId) -> Result<Option<MessageMetadata>, <Self as StorageBackend>::Error> {
         Ok(self
             .inner
             .open_tree(TREE_MESSAGE_ID_TO_METADATA)?
@@ -55,7 +55,7 @@ impl Fetch<MessageId, MessageMetadata> for Storage {
 }
 
 impl Fetch<MessageId, Vec<MessageId>> for Storage {
-    fn fetch(&self, parent: &MessageId) -> Result<Option<Vec<MessageId>>, <Self as StorageBackend>::Error> {
+    fn fetch_op(&self, parent: &MessageId) -> Result<Option<Vec<MessageId>>, <Self as StorageBackend>::Error> {
         Ok(Some(
             self.inner
                 .open_tree(TREE_MESSAGE_ID_TO_MESSAGE_ID)?
@@ -74,7 +74,7 @@ impl Fetch<MessageId, Vec<MessageId>> for Storage {
 }
 
 impl Fetch<PaddedIndex, Vec<MessageId>> for Storage {
-    fn fetch(&self, index: &PaddedIndex) -> Result<Option<Vec<MessageId>>, <Self as StorageBackend>::Error> {
+    fn fetch_op(&self, index: &PaddedIndex) -> Result<Option<Vec<MessageId>>, <Self as StorageBackend>::Error> {
         Ok(Some(
             self.inner
                 .open_tree(TREE_INDEX_TO_MESSAGE_ID)?
@@ -93,7 +93,7 @@ impl Fetch<PaddedIndex, Vec<MessageId>> for Storage {
 }
 
 impl Fetch<OutputId, CreatedOutput> for Storage {
-    fn fetch(&self, output_id: &OutputId) -> Result<Option<CreatedOutput>, <Self as StorageBackend>::Error> {
+    fn fetch_op(&self, output_id: &OutputId) -> Result<Option<CreatedOutput>, <Self as StorageBackend>::Error> {
         Ok(self
             .inner
             .open_tree(TREE_OUTPUT_ID_TO_CREATED_OUTPUT)?
@@ -104,7 +104,7 @@ impl Fetch<OutputId, CreatedOutput> for Storage {
 }
 
 impl Fetch<OutputId, ConsumedOutput> for Storage {
-    fn fetch(&self, output_id: &OutputId) -> Result<Option<ConsumedOutput>, <Self as StorageBackend>::Error> {
+    fn fetch_op(&self, output_id: &OutputId) -> Result<Option<ConsumedOutput>, <Self as StorageBackend>::Error> {
         Ok(self
             .inner
             .open_tree(TREE_OUTPUT_ID_TO_CONSUMED_OUTPUT)?
@@ -115,7 +115,7 @@ impl Fetch<OutputId, ConsumedOutput> for Storage {
 }
 
 impl Fetch<Ed25519Address, Vec<OutputId>> for Storage {
-    fn fetch(&self, address: &Ed25519Address) -> Result<Option<Vec<OutputId>>, <Self as StorageBackend>::Error> {
+    fn fetch_op(&self, address: &Ed25519Address) -> Result<Option<Vec<OutputId>>, <Self as StorageBackend>::Error> {
         Ok(Some(
             self.inner
                 .open_tree(TREE_ED25519_ADDRESS_TO_OUTPUT_ID)?
@@ -135,7 +135,7 @@ impl Fetch<Ed25519Address, Vec<OutputId>> for Storage {
 }
 
 impl Fetch<(), LedgerIndex> for Storage {
-    fn fetch(&self, (): &()) -> Result<Option<LedgerIndex>, <Self as StorageBackend>::Error> {
+    fn fetch_op(&self, (): &()) -> Result<Option<LedgerIndex>, <Self as StorageBackend>::Error> {
         Ok(self
             .inner
             .open_tree(TREE_LEDGER_INDEX)?
@@ -146,7 +146,7 @@ impl Fetch<(), LedgerIndex> for Storage {
 }
 
 impl Fetch<MilestoneIndex, Milestone> for Storage {
-    fn fetch(&self, index: &MilestoneIndex) -> Result<Option<Milestone>, <Self as StorageBackend>::Error> {
+    fn fetch_op(&self, index: &MilestoneIndex) -> Result<Option<Milestone>, <Self as StorageBackend>::Error> {
         Ok(self
             .inner
             .open_tree(TREE_MILESTONE_INDEX_TO_MILESTONE)?
@@ -157,7 +157,7 @@ impl Fetch<MilestoneIndex, Milestone> for Storage {
 }
 
 impl Fetch<(), SnapshotInfo> for Storage {
-    fn fetch(&self, (): &()) -> Result<Option<SnapshotInfo>, <Self as StorageBackend>::Error> {
+    fn fetch_op(&self, (): &()) -> Result<Option<SnapshotInfo>, <Self as StorageBackend>::Error> {
         Ok(self
             .inner
             .open_tree(TREE_SNAPSHOT_INFO)?
@@ -168,7 +168,7 @@ impl Fetch<(), SnapshotInfo> for Storage {
 }
 
 impl Fetch<SolidEntryPoint, MilestoneIndex> for Storage {
-    fn fetch(&self, sep: &SolidEntryPoint) -> Result<Option<MilestoneIndex>, <Self as StorageBackend>::Error> {
+    fn fetch_op(&self, sep: &SolidEntryPoint) -> Result<Option<MilestoneIndex>, <Self as StorageBackend>::Error> {
         Ok(self
             .inner
             .open_tree(TREE_SOLID_ENTRY_POINT_TO_MILESTONE_INDEX)?
@@ -179,7 +179,7 @@ impl Fetch<SolidEntryPoint, MilestoneIndex> for Storage {
 }
 
 impl Fetch<MilestoneIndex, OutputDiff> for Storage {
-    fn fetch(&self, index: &MilestoneIndex) -> Result<Option<OutputDiff>, <Self as StorageBackend>::Error> {
+    fn fetch_op(&self, index: &MilestoneIndex) -> Result<Option<OutputDiff>, <Self as StorageBackend>::Error> {
         Ok(self
             .inner
             .open_tree(TREE_MILESTONE_INDEX_TO_OUTPUT_DIFF)?
@@ -190,7 +190,7 @@ impl Fetch<MilestoneIndex, OutputDiff> for Storage {
 }
 
 impl Fetch<Address, Balance> for Storage {
-    fn fetch(&self, address: &Address) -> Result<Option<Balance>, <Self as StorageBackend>::Error> {
+    fn fetch_op(&self, address: &Address) -> Result<Option<Balance>, <Self as StorageBackend>::Error> {
         Ok(self
             .inner
             .open_tree(TREE_ADDRESS_TO_BALANCE)?
@@ -201,7 +201,7 @@ impl Fetch<Address, Balance> for Storage {
 }
 
 impl Fetch<MilestoneIndex, Vec<UnreferencedMessage>> for Storage {
-    fn fetch(
+    fn fetch_op(
         &self,
         index: &MilestoneIndex,
     ) -> Result<Option<Vec<UnreferencedMessage>>, <Self as StorageBackend>::Error> {
@@ -222,7 +222,7 @@ impl Fetch<MilestoneIndex, Vec<UnreferencedMessage>> for Storage {
 }
 
 impl Fetch<MilestoneIndex, Vec<Receipt>> for Storage {
-    fn fetch(&self, index: &MilestoneIndex) -> Result<Option<Vec<Receipt>>, <Self as StorageBackend>::Error> {
+    fn fetch_op(&self, index: &MilestoneIndex) -> Result<Option<Vec<Receipt>>, <Self as StorageBackend>::Error> {
         Ok(Some(
             self.inner
                 .open_tree(TREE_MILESTONE_INDEX_TO_RECEIPT)?
@@ -240,7 +240,7 @@ impl Fetch<MilestoneIndex, Vec<Receipt>> for Storage {
 }
 
 impl Fetch<bool, Vec<TreasuryOutput>> for Storage {
-    fn fetch(&self, spent: &bool) -> Result<Option<Vec<TreasuryOutput>>, <Self as StorageBackend>::Error> {
+    fn fetch_op(&self, spent: &bool) -> Result<Option<Vec<TreasuryOutput>>, <Self as StorageBackend>::Error> {
         Ok(Some(
             self.inner
                 .open_tree(TREE_SPENT_TO_TREASURY_OUTPUT)?

--- a/bee-storage/bee-storage-sled/src/access/insert.rs
+++ b/bee-storage/bee-storage-sled/src/access/insert.rs
@@ -27,7 +27,7 @@ use bee_tangle::{
 use crate::{storage::Storage, trees::*};
 
 impl Insert<u8, System> for Storage {
-    fn insert(&self, key: &u8, value: &System) -> Result<(), <Self as StorageBackend>::Error> {
+    fn insert_op(&self, key: &u8, value: &System) -> Result<(), <Self as StorageBackend>::Error> {
         self.inner.insert(&[*key], value.pack_new())?;
 
         Ok(())
@@ -35,7 +35,7 @@ impl Insert<u8, System> for Storage {
 }
 
 impl Insert<MessageId, Message> for Storage {
-    fn insert(&self, message_id: &MessageId, message: &Message) -> Result<(), <Self as StorageBackend>::Error> {
+    fn insert_op(&self, message_id: &MessageId, message: &Message) -> Result<(), <Self as StorageBackend>::Error> {
         self.inner
             .open_tree(TREE_MESSAGE_ID_TO_MESSAGE)?
             .insert(message_id, message.pack_new())?;
@@ -45,7 +45,7 @@ impl Insert<MessageId, Message> for Storage {
 }
 
 impl InsertStrict<MessageId, MessageMetadata> for Storage {
-    fn insert_strict(
+    fn insert_strict_op(
         &self,
         message_id: &MessageId,
         metadata: &MessageMetadata,
@@ -61,7 +61,11 @@ impl InsertStrict<MessageId, MessageMetadata> for Storage {
 }
 
 impl Insert<(MessageId, MessageId), ()> for Storage {
-    fn insert(&self, (parent, child): &(MessageId, MessageId), (): &()) -> Result<(), <Self as StorageBackend>::Error> {
+    fn insert_op(
+        &self,
+        (parent, child): &(MessageId, MessageId),
+        (): &(),
+    ) -> Result<(), <Self as StorageBackend>::Error> {
         let mut key = parent.as_ref().to_vec();
         key.extend_from_slice(child.as_ref());
 
@@ -72,7 +76,7 @@ impl Insert<(MessageId, MessageId), ()> for Storage {
 }
 
 impl Insert<(PaddedIndex, MessageId), ()> for Storage {
-    fn insert(
+    fn insert_op(
         &self,
         (index, message_id): &(PaddedIndex, MessageId),
         (): &(),
@@ -87,7 +91,7 @@ impl Insert<(PaddedIndex, MessageId), ()> for Storage {
 }
 
 impl Insert<OutputId, CreatedOutput> for Storage {
-    fn insert(&self, output_id: &OutputId, output: &CreatedOutput) -> Result<(), <Self as StorageBackend>::Error> {
+    fn insert_op(&self, output_id: &OutputId, output: &CreatedOutput) -> Result<(), <Self as StorageBackend>::Error> {
         self.inner
             .open_tree(TREE_OUTPUT_ID_TO_CREATED_OUTPUT)?
             .insert(output_id.pack_new(), output.pack_new())?;
@@ -97,7 +101,7 @@ impl Insert<OutputId, CreatedOutput> for Storage {
 }
 
 impl Insert<OutputId, ConsumedOutput> for Storage {
-    fn insert(&self, output_id: &OutputId, output: &ConsumedOutput) -> Result<(), <Self as StorageBackend>::Error> {
+    fn insert_op(&self, output_id: &OutputId, output: &ConsumedOutput) -> Result<(), <Self as StorageBackend>::Error> {
         self.inner
             .open_tree(TREE_OUTPUT_ID_TO_CONSUMED_OUTPUT)?
             .insert(output_id.pack_new(), output.pack_new())?;
@@ -107,7 +111,7 @@ impl Insert<OutputId, ConsumedOutput> for Storage {
 }
 
 impl Insert<Unspent, ()> for Storage {
-    fn insert(&self, unspent: &Unspent, (): &()) -> Result<(), <Self as StorageBackend>::Error> {
+    fn insert_op(&self, unspent: &Unspent, (): &()) -> Result<(), <Self as StorageBackend>::Error> {
         self.inner
             .open_tree(TREE_OUTPUT_ID_UNSPENT)?
             .insert(unspent.pack_new(), &[])?;
@@ -117,7 +121,7 @@ impl Insert<Unspent, ()> for Storage {
 }
 
 impl Insert<(Ed25519Address, OutputId), ()> for Storage {
-    fn insert(
+    fn insert_op(
         &self,
         (address, output_id): &(Ed25519Address, OutputId),
         (): &(),
@@ -134,7 +138,7 @@ impl Insert<(Ed25519Address, OutputId), ()> for Storage {
 }
 
 impl Insert<(), LedgerIndex> for Storage {
-    fn insert(&self, (): &(), index: &LedgerIndex) -> Result<(), <Self as StorageBackend>::Error> {
+    fn insert_op(&self, (): &(), index: &LedgerIndex) -> Result<(), <Self as StorageBackend>::Error> {
         self.inner
             .open_tree(TREE_LEDGER_INDEX)?
             .insert([0x00u8], index.pack_new())?;
@@ -144,7 +148,7 @@ impl Insert<(), LedgerIndex> for Storage {
 }
 
 impl Insert<MilestoneIndex, Milestone> for Storage {
-    fn insert(&self, index: &MilestoneIndex, milestone: &Milestone) -> Result<(), <Self as StorageBackend>::Error> {
+    fn insert_op(&self, index: &MilestoneIndex, milestone: &Milestone) -> Result<(), <Self as StorageBackend>::Error> {
         self.inner
             .open_tree(TREE_MILESTONE_INDEX_TO_MILESTONE)?
             .insert(index.pack_new(), milestone.pack_new())?;
@@ -154,7 +158,7 @@ impl Insert<MilestoneIndex, Milestone> for Storage {
 }
 
 impl Insert<(), SnapshotInfo> for Storage {
-    fn insert(&self, (): &(), info: &SnapshotInfo) -> Result<(), <Self as StorageBackend>::Error> {
+    fn insert_op(&self, (): &(), info: &SnapshotInfo) -> Result<(), <Self as StorageBackend>::Error> {
         self.inner
             .open_tree(TREE_SNAPSHOT_INFO)?
             .insert([0x00u8], info.pack_new())?;
@@ -164,7 +168,7 @@ impl Insert<(), SnapshotInfo> for Storage {
 }
 
 impl Insert<SolidEntryPoint, MilestoneIndex> for Storage {
-    fn insert(&self, sep: &SolidEntryPoint, index: &MilestoneIndex) -> Result<(), <Self as StorageBackend>::Error> {
+    fn insert_op(&self, sep: &SolidEntryPoint, index: &MilestoneIndex) -> Result<(), <Self as StorageBackend>::Error> {
         self.inner
             .open_tree(TREE_SOLID_ENTRY_POINT_TO_MILESTONE_INDEX)?
             .insert(sep.as_ref(), index.pack_new())?;
@@ -174,7 +178,7 @@ impl Insert<SolidEntryPoint, MilestoneIndex> for Storage {
 }
 
 impl Insert<MilestoneIndex, OutputDiff> for Storage {
-    fn insert(&self, index: &MilestoneIndex, diff: &OutputDiff) -> Result<(), <Self as StorageBackend>::Error> {
+    fn insert_op(&self, index: &MilestoneIndex, diff: &OutputDiff) -> Result<(), <Self as StorageBackend>::Error> {
         self.inner
             .open_tree(TREE_MILESTONE_INDEX_TO_OUTPUT_DIFF)?
             .insert(index.pack_new(), diff.pack_new())?;
@@ -184,7 +188,7 @@ impl Insert<MilestoneIndex, OutputDiff> for Storage {
 }
 
 impl Insert<Address, Balance> for Storage {
-    fn insert(&self, address: &Address, balance: &Balance) -> Result<(), <Self as StorageBackend>::Error> {
+    fn insert_op(&self, address: &Address, balance: &Balance) -> Result<(), <Self as StorageBackend>::Error> {
         self.inner
             .open_tree(TREE_ADDRESS_TO_BALANCE)?
             .insert(address.pack_new(), balance.pack_new())?;
@@ -194,7 +198,7 @@ impl Insert<Address, Balance> for Storage {
 }
 
 impl Insert<(MilestoneIndex, UnreferencedMessage), ()> for Storage {
-    fn insert(
+    fn insert_op(
         &self,
         (index, unreferenced_message): &(MilestoneIndex, UnreferencedMessage),
         (): &(),
@@ -211,7 +215,7 @@ impl Insert<(MilestoneIndex, UnreferencedMessage), ()> for Storage {
 }
 
 impl Insert<(MilestoneIndex, Receipt), ()> for Storage {
-    fn insert(
+    fn insert_op(
         &self,
         (index, receipt): &(MilestoneIndex, Receipt),
         (): &(),
@@ -228,7 +232,11 @@ impl Insert<(MilestoneIndex, Receipt), ()> for Storage {
 }
 
 impl Insert<(bool, TreasuryOutput), ()> for Storage {
-    fn insert(&self, (spent, output): &(bool, TreasuryOutput), (): &()) -> Result<(), <Self as StorageBackend>::Error> {
+    fn insert_op(
+        &self,
+        (spent, output): &(bool, TreasuryOutput),
+        (): &(),
+    ) -> Result<(), <Self as StorageBackend>::Error> {
         let mut key = spent.pack_new();
         key.extend_from_slice(&output.pack_new());
 

--- a/bee-storage/bee-storage-sled/src/access/iter.rs
+++ b/bee-storage/bee-storage-sled/src/access/iter.rs
@@ -44,7 +44,7 @@ macro_rules! impl_iter {
         impl<'a> AsIterator<'a, $key, $value> for Storage {
             type AsIter = StorageIterator<'a, $key, $value>;
 
-            fn iter(&'a self) -> Result<Self::AsIter, <Self as StorageBackend>::Error> {
+            fn iter_op(&'a self) -> Result<Self::AsIter, <Self as StorageBackend>::Error> {
                 Ok(StorageIterator::new(self.inner.open_tree($cf)?.iter()))
             }
         }
@@ -301,7 +301,7 @@ impl<'a> StorageIterator<'a, (bool, TreasuryOutput), ()> {
 impl<'a> AsIterator<'a, u8, System> for Storage {
     type AsIter = StorageIterator<'a, u8, System>;
 
-    fn iter(&'a self) -> Result<Self::AsIter, <Self as StorageBackend>::Error> {
+    fn iter_op(&'a self) -> Result<Self::AsIter, <Self as StorageBackend>::Error> {
         Ok(StorageIterator::new(self.inner.iter()))
     }
 }

--- a/bee-storage/bee-storage-sled/src/access/multi_fetch.rs
+++ b/bee-storage/bee-storage-sled/src/access/multi_fetch.rs
@@ -65,7 +65,7 @@ impl<'a, K: Packable, V: Packable, E: From<sled::Error>> Iterator for DbIter<'a,
 impl<'a> MultiFetch<'a, u8, System> for Storage {
     type Iter = DbIter<'a, u8, System, <Self as StorageBackend>::Error>;
 
-    fn multi_fetch(&'a self, keys: &'a [u8]) -> Result<Self::Iter, <Self as StorageBackend>::Error> {
+    fn multi_fetch_op(&'a self, keys: &'a [u8]) -> Result<Self::Iter, <Self as StorageBackend>::Error> {
         Ok(DbIter {
             db: &self.inner,
             keys: keys.iter(),
@@ -79,7 +79,7 @@ macro_rules! impl_multi_fetch {
         impl<'a> MultiFetch<'a, $key, $value> for Storage {
             type Iter = TreeIter<'a, $key, $value, <Self as StorageBackend>::Error>;
 
-            fn multi_fetch(&'a self, keys: &'a [$key]) -> Result<Self::Iter, <Self as StorageBackend>::Error> {
+            fn multi_fetch_op(&'a self, keys: &'a [$key]) -> Result<Self::Iter, <Self as StorageBackend>::Error> {
                 Ok(TreeIter {
                     tree: self.inner.open_tree($cf)?,
                     keys: keys.iter(),

--- a/bee-storage/bee-storage-sled/src/access/truncate.rs
+++ b/bee-storage/bee-storage-sled/src/access/truncate.rs
@@ -24,7 +24,7 @@ use crate::{storage::Storage, trees::*};
 macro_rules! impl_truncate {
     ($key:ty, $value:ty, $cf:expr) => {
         impl Truncate<$key, $value> for Storage {
-            fn truncate(&self) -> Result<(), <Self as StorageBackend>::Error> {
+            fn truncate_op(&self) -> Result<(), <Self as StorageBackend>::Error> {
                 self.inner.drop_tree($cf)?;
 
                 Ok(())

--- a/bee-storage/bee-storage-sled/src/access/update.rs
+++ b/bee-storage/bee-storage-sled/src/access/update.rs
@@ -11,7 +11,7 @@ use bee_tangle::metadata::MessageMetadata;
 use crate::{storage::Storage, trees::*};
 
 impl Update<MessageId, MessageMetadata> for Storage {
-    fn update(&self, message_id: &MessageId, mut f: impl FnMut(&mut MessageMetadata)) -> Result<(), Self::Error> {
+    fn update_op(&self, message_id: &MessageId, mut f: impl FnMut(&mut MessageMetadata)) -> Result<(), Self::Error> {
         self.inner
             .open_tree(TREE_MESSAGE_ID_TO_METADATA)?
             .fetch_and_update(message_id, move |opt_bytes| {

--- a/bee-storage/bee-storage-sled/src/storage.rs
+++ b/bee-storage/bee-storage-sled/src/storage.rs
@@ -65,7 +65,7 @@ impl StorageBackend for Storage {
     fn start(config: Self::Config) -> Result<Self, Self::Error> {
         let storage = Self::new(config)?;
 
-        match storage.fetch_access::<u8, System>(&SYSTEM_VERSION_KEY)? {
+        match storage.fetch::<u8, System>(&SYSTEM_VERSION_KEY)? {
             Some(System::Version(version)) => {
                 if version != STORAGE_VERSION {
                     return Err(Error::VersionMismatch(version, STORAGE_VERSION));
@@ -97,7 +97,7 @@ impl StorageBackend for Storage {
     }
 
     fn get_health(&self) -> Result<Option<StorageHealth>, Self::Error> {
-        Ok(match self.fetch_access::<u8, System>(&SYSTEM_HEALTH_KEY)? {
+        Ok(match self.fetch::<u8, System>(&SYSTEM_HEALTH_KEY)? {
             Some(System::Health(health)) => Some(health),
             None => None,
             _ => panic!("Another system value was inserted on the health key."),

--- a/bee-storage/bee-storage-sled/src/storage.rs
+++ b/bee-storage/bee-storage-sled/src/storage.rs
@@ -71,7 +71,7 @@ impl StorageBackend for Storage {
                     return Err(Error::VersionMismatch(version, STORAGE_VERSION));
                 }
             }
-            None => Insert::<u8, System>::insert(&storage, &SYSTEM_VERSION_KEY, &System::Version(STORAGE_VERSION))?,
+            None => Insert::<u8, System>::insert_op(&storage, &SYSTEM_VERSION_KEY, &System::Version(STORAGE_VERSION))?,
             _ => panic!("Another system value was inserted on the version key."),
         }
 
@@ -105,6 +105,6 @@ impl StorageBackend for Storage {
     }
 
     fn set_health(&self, health: StorageHealth) -> Result<(), Self::Error> {
-        Insert::<u8, System>::insert(self, &SYSTEM_HEALTH_KEY, &System::Health(health))
+        Insert::<u8, System>::insert_op(self, &SYSTEM_HEALTH_KEY, &System::Health(health))
     }
 }

--- a/bee-storage/bee-storage-sled/src/storage.rs
+++ b/bee-storage/bee-storage-sled/src/storage.rs
@@ -70,7 +70,7 @@ impl StorageBackend for Storage {
                     return Err(Error::VersionMismatch(version, STORAGE_VERSION));
                 }
             }
-            None => storage.insert::<u8, System>(&SYSTEM_VERSION_KEY, &System::Version(STORAGE_VERSION))?,
+            None => storage.insert(&SYSTEM_VERSION_KEY, &System::Version(STORAGE_VERSION))?,
             _ => panic!("Another system value was inserted on the version key."),
         }
 
@@ -104,6 +104,6 @@ impl StorageBackend for Storage {
     }
 
     fn set_health(&self, health: StorageHealth) -> Result<(), Self::Error> {
-        self.insert::<u8, System>(&SYSTEM_HEALTH_KEY, &System::Health(health))
+        self.insert(&SYSTEM_HEALTH_KEY, &System::Health(health))
     }
 }

--- a/bee-storage/bee-storage-sled/src/storage.rs
+++ b/bee-storage/bee-storage-sled/src/storage.rs
@@ -4,8 +4,8 @@
 //! The sled storage backend.
 
 use bee_storage::{
-    access::{Fetch, Insert},
-    backend::StorageBackend,
+    access::Insert,
+    backend::{StorageBackend, StorageBackendExt},
     system::{StorageHealth, StorageVersion, System, SYSTEM_HEALTH_KEY, SYSTEM_VERSION_KEY},
 };
 use thiserror::Error;
@@ -65,7 +65,7 @@ impl StorageBackend for Storage {
     fn start(config: Self::Config) -> Result<Self, Self::Error> {
         let storage = Self::new(config)?;
 
-        match Fetch::<u8, System>::fetch(&storage, &SYSTEM_VERSION_KEY)? {
+        match storage.fetch_access::<u8, System>(&SYSTEM_VERSION_KEY)? {
             Some(System::Version(version)) => {
                 if version != STORAGE_VERSION {
                     return Err(Error::VersionMismatch(version, STORAGE_VERSION));
@@ -97,7 +97,7 @@ impl StorageBackend for Storage {
     }
 
     fn get_health(&self) -> Result<Option<StorageHealth>, Self::Error> {
-        Ok(match Fetch::<u8, System>::fetch(self, &SYSTEM_HEALTH_KEY)? {
+        Ok(match self.fetch_access::<u8, System>(&SYSTEM_HEALTH_KEY)? {
             Some(System::Health(health)) => Some(health),
             None => None,
             _ => panic!("Another system value was inserted on the health key."),

--- a/bee-storage/bee-storage-sled/src/storage.rs
+++ b/bee-storage/bee-storage-sled/src/storage.rs
@@ -4,7 +4,6 @@
 //! The sled storage backend.
 
 use bee_storage::{
-    access::Insert,
     backend::{StorageBackend, StorageBackendExt},
     system::{StorageHealth, StorageVersion, System, SYSTEM_HEALTH_KEY, SYSTEM_VERSION_KEY},
 };
@@ -71,7 +70,7 @@ impl StorageBackend for Storage {
                     return Err(Error::VersionMismatch(version, STORAGE_VERSION));
                 }
             }
-            None => Insert::<u8, System>::insert_op(&storage, &SYSTEM_VERSION_KEY, &System::Version(STORAGE_VERSION))?,
+            None => storage.insert::<u8, System>(&SYSTEM_VERSION_KEY, &System::Version(STORAGE_VERSION))?,
             _ => panic!("Another system value was inserted on the version key."),
         }
 
@@ -105,6 +104,6 @@ impl StorageBackend for Storage {
     }
 
     fn set_health(&self, health: StorageHealth) -> Result<(), Self::Error> {
-        Insert::<u8, System>::insert_op(self, &SYSTEM_HEALTH_KEY, &System::Health(health))
+        self.insert::<u8, System>(&SYSTEM_HEALTH_KEY, &System::Health(health))
     }
 }

--- a/bee-storage/bee-storage-test/src/address_to_balance.rs
+++ b/bee-storage/bee-storage-test/src/address_to_balance.rs
@@ -63,7 +63,7 @@ pub fn address_to_balance_access<B: StorageBackend>(storage: &B) {
     assert_eq!(results.len(), 1);
     assert!(matches!(results.get(0), Some(Ok(Some(v))) if v == &balance));
 
-    Delete::<Address, Balance>::delete_op(storage, &address).unwrap();
+    storage.delete::<Address, Balance>(&address).unwrap();
 
     assert!(!Exist::<Address, Balance>::exist_op(storage, &address).unwrap());
     assert!(storage.fetch::<Address, Balance>(&address).unwrap().is_none());

--- a/bee-storage/bee-storage-test/src/address_to_balance.rs
+++ b/bee-storage/bee-storage-test/src/address_to_balance.rs
@@ -51,7 +51,7 @@ pub fn address_to_balance_access<B: StorageBackend>(storage: &B) {
     assert_eq!(results.len(), 1);
     assert!(matches!(results.get(0), Some(Ok(None))));
 
-    storage.insert::<Address, Balance>(&address, &balance).unwrap();
+    storage.insert(&address, &balance).unwrap();
 
     assert!(storage.exist::<Address, Balance>(&address).unwrap());
     assert_eq!(
@@ -82,7 +82,7 @@ pub fn address_to_balance_access<B: StorageBackend>(storage: &B) {
 
     for _ in 0..10 {
         let (address, balance) = (rand_address(), rand_balance());
-        storage.insert::<Address, Balance>(&address, &balance).unwrap();
+        storage.insert(&address, &balance).unwrap();
         storage.batch_delete::<Address, Balance>(&mut batch, &address).unwrap();
         addresses.push(address);
         balances.push((address, None));
@@ -90,9 +90,7 @@ pub fn address_to_balance_access<B: StorageBackend>(storage: &B) {
 
     for _ in 0..10 {
         let (address, balance) = (rand_address(), rand_balance());
-        storage
-            .batch_insert::<Address, Balance>(&mut batch, &address, &balance)
-            .unwrap();
+        storage.batch_insert(&mut batch, &address, &balance).unwrap();
         addresses.push(address);
         balances.push((address, Some(balance)));
     }

--- a/bee-storage/bee-storage-test/src/address_to_balance.rs
+++ b/bee-storage/bee-storage-test/src/address_to_balance.rs
@@ -42,32 +42,32 @@ impl<T> StorageBackend for T where
 pub fn address_to_balance_access<B: StorageBackend>(storage: &B) {
     let (address, balance) = (rand_address(), rand_balance());
 
-    assert!(!Exist::<Address, Balance>::exist(storage, &address).unwrap());
+    assert!(!Exist::<Address, Balance>::exist_op(storage, &address).unwrap());
     assert!(storage.fetch::<Address, Balance>(&address).unwrap().is_none());
-    let results = MultiFetch::<Address, Balance>::multi_fetch(storage, &[address])
+    let results = MultiFetch::<Address, Balance>::multi_fetch_op(storage, &[address])
         .unwrap()
         .collect::<Vec<_>>();
     assert_eq!(results.len(), 1);
     assert!(matches!(results.get(0), Some(Ok(None))));
 
-    Insert::<Address, Balance>::insert(storage, &address, &balance).unwrap();
+    Insert::<Address, Balance>::insert_op(storage, &address, &balance).unwrap();
 
-    assert!(Exist::<Address, Balance>::exist(storage, &address).unwrap());
+    assert!(Exist::<Address, Balance>::exist_op(storage, &address).unwrap());
     assert_eq!(
         storage.fetch::<Address, Balance>(&address).unwrap().unwrap().pack_new(),
         balance.pack_new()
     );
-    let results = MultiFetch::<Address, Balance>::multi_fetch(storage, &[address])
+    let results = MultiFetch::<Address, Balance>::multi_fetch_op(storage, &[address])
         .unwrap()
         .collect::<Vec<_>>();
     assert_eq!(results.len(), 1);
     assert!(matches!(results.get(0), Some(Ok(Some(v))) if v == &balance));
 
-    Delete::<Address, Balance>::delete(storage, &address).unwrap();
+    Delete::<Address, Balance>::delete_op(storage, &address).unwrap();
 
-    assert!(!Exist::<Address, Balance>::exist(storage, &address).unwrap());
+    assert!(!Exist::<Address, Balance>::exist_op(storage, &address).unwrap());
     assert!(storage.fetch::<Address, Balance>(&address).unwrap().is_none());
-    let results = MultiFetch::<Address, Balance>::multi_fetch(storage, &[address])
+    let results = MultiFetch::<Address, Balance>::multi_fetch_op(storage, &[address])
         .unwrap()
         .collect::<Vec<_>>();
     assert_eq!(results.len(), 1);
@@ -79,22 +79,22 @@ pub fn address_to_balance_access<B: StorageBackend>(storage: &B) {
 
     for _ in 0..10 {
         let (address, balance) = (rand_address(), rand_balance());
-        Insert::<Address, Balance>::insert(storage, &address, &balance).unwrap();
-        Batch::<Address, Balance>::batch_delete(storage, &mut batch, &address).unwrap();
+        Insert::<Address, Balance>::insert_op(storage, &address, &balance).unwrap();
+        Batch::<Address, Balance>::batch_delete_op(storage, &mut batch, &address).unwrap();
         addresses.push(address);
         balances.push((address, None));
     }
 
     for _ in 0..10 {
         let (address, balance) = (rand_address(), rand_balance());
-        Batch::<Address, Balance>::batch_insert(storage, &mut batch, &address, &balance).unwrap();
+        Batch::<Address, Balance>::batch_insert_op(storage, &mut batch, &address, &balance).unwrap();
         addresses.push(address);
         balances.push((address, Some(balance)));
     }
 
     storage.batch_commit(batch, true).unwrap();
 
-    let iter = AsIterator::<Address, Balance>::iter(storage).unwrap();
+    let iter = AsIterator::<Address, Balance>::iter_op(storage).unwrap();
     let mut count = 0;
 
     for result in iter {
@@ -105,7 +105,7 @@ pub fn address_to_balance_access<B: StorageBackend>(storage: &B) {
 
     assert_eq!(count, 10);
 
-    let results = MultiFetch::<Address, Balance>::multi_fetch(storage, &addresses)
+    let results = MultiFetch::<Address, Balance>::multi_fetch_op(storage, &addresses)
         .unwrap()
         .collect::<Vec<_>>();
 
@@ -115,9 +115,9 @@ pub fn address_to_balance_access<B: StorageBackend>(storage: &B) {
         assert_eq!(balance, result.unwrap());
     }
 
-    Truncate::<Address, Balance>::truncate(storage).unwrap();
+    Truncate::<Address, Balance>::truncate_op(storage).unwrap();
 
-    let mut iter = AsIterator::<Address, Balance>::iter(storage).unwrap();
+    let mut iter = AsIterator::<Address, Balance>::iter_op(storage).unwrap();
 
     assert!(iter.next().is_none());
 }

--- a/bee-storage/bee-storage-test/src/address_to_balance.rs
+++ b/bee-storage/bee-storage-test/src/address_to_balance.rs
@@ -42,7 +42,7 @@ impl<T> StorageBackend for T where
 pub fn address_to_balance_access<B: StorageBackend>(storage: &B) {
     let (address, balance) = (rand_address(), rand_balance());
 
-    assert!(!Exist::<Address, Balance>::exist_op(storage, &address).unwrap());
+    assert!(!storage.exist::<Address, Balance>(&address).unwrap());
     assert!(storage.fetch::<Address, Balance>(&address).unwrap().is_none());
     let results = MultiFetch::<Address, Balance>::multi_fetch_op(storage, &[address])
         .unwrap()
@@ -52,7 +52,7 @@ pub fn address_to_balance_access<B: StorageBackend>(storage: &B) {
 
     Insert::<Address, Balance>::insert_op(storage, &address, &balance).unwrap();
 
-    assert!(Exist::<Address, Balance>::exist_op(storage, &address).unwrap());
+    assert!(storage.exist::<Address, Balance>(&address).unwrap());
     assert_eq!(
         storage.fetch::<Address, Balance>(&address).unwrap().unwrap().pack_new(),
         balance.pack_new()
@@ -65,7 +65,7 @@ pub fn address_to_balance_access<B: StorageBackend>(storage: &B) {
 
     storage.delete::<Address, Balance>(&address).unwrap();
 
-    assert!(!Exist::<Address, Balance>::exist_op(storage, &address).unwrap());
+    assert!(!storage.exist::<Address, Balance>(&address).unwrap());
     assert!(storage.fetch::<Address, Balance>(&address).unwrap().is_none());
     let results = MultiFetch::<Address, Balance>::multi_fetch_op(storage, &[address])
         .unwrap()

--- a/bee-storage/bee-storage-test/src/address_to_balance.rs
+++ b/bee-storage/bee-storage-test/src/address_to_balance.rs
@@ -121,7 +121,7 @@ pub fn address_to_balance_access<B: StorageBackend>(storage: &B) {
         assert_eq!(balance, result.unwrap());
     }
 
-    Truncate::<Address, Balance>::truncate_op(storage).unwrap();
+    storage.truncate::<Address, Balance>().unwrap();
 
     let mut iter = storage.iter::<Address, Balance>().unwrap();
 

--- a/bee-storage/bee-storage-test/src/address_to_balance.rs
+++ b/bee-storage/bee-storage-test/src/address_to_balance.rs
@@ -80,14 +80,16 @@ pub fn address_to_balance_access<B: StorageBackend>(storage: &B) {
     for _ in 0..10 {
         let (address, balance) = (rand_address(), rand_balance());
         Insert::<Address, Balance>::insert_op(storage, &address, &balance).unwrap();
-        Batch::<Address, Balance>::batch_delete_op(storage, &mut batch, &address).unwrap();
+        storage.batch_delete::<Address, Balance>(&mut batch, &address).unwrap();
         addresses.push(address);
         balances.push((address, None));
     }
 
     for _ in 0..10 {
         let (address, balance) = (rand_address(), rand_balance());
-        Batch::<Address, Balance>::batch_insert_op(storage, &mut batch, &address, &balance).unwrap();
+        storage
+            .batch_insert::<Address, Balance>(&mut batch, &address, &balance)
+            .unwrap();
         addresses.push(address);
         balances.push((address, Some(balance)));
     }

--- a/bee-storage/bee-storage-test/src/address_to_balance.rs
+++ b/bee-storage/bee-storage-test/src/address_to_balance.rs
@@ -43,7 +43,7 @@ pub fn address_to_balance_access<B: StorageBackend>(storage: &B) {
     let (address, balance) = (rand_address(), rand_balance());
 
     assert!(!Exist::<Address, Balance>::exist(storage, &address).unwrap());
-    assert!(storage.fetch_access::<Address, Balance>(&address).unwrap().is_none());
+    assert!(storage.fetch::<Address, Balance>(&address).unwrap().is_none());
     let results = MultiFetch::<Address, Balance>::multi_fetch(storage, &[address])
         .unwrap()
         .collect::<Vec<_>>();
@@ -54,11 +54,7 @@ pub fn address_to_balance_access<B: StorageBackend>(storage: &B) {
 
     assert!(Exist::<Address, Balance>::exist(storage, &address).unwrap());
     assert_eq!(
-        storage
-            .fetch_access::<Address, Balance>(&address)
-            .unwrap()
-            .unwrap()
-            .pack_new(),
+        storage.fetch::<Address, Balance>(&address).unwrap().unwrap().pack_new(),
         balance.pack_new()
     );
     let results = MultiFetch::<Address, Balance>::multi_fetch(storage, &[address])
@@ -70,7 +66,7 @@ pub fn address_to_balance_access<B: StorageBackend>(storage: &B) {
     Delete::<Address, Balance>::delete(storage, &address).unwrap();
 
     assert!(!Exist::<Address, Balance>::exist(storage, &address).unwrap());
-    assert!(storage.fetch_access::<Address, Balance>(&address).unwrap().is_none());
+    assert!(storage.fetch::<Address, Balance>(&address).unwrap().is_none());
     let results = MultiFetch::<Address, Balance>::multi_fetch(storage, &[address])
         .unwrap()
         .collect::<Vec<_>>();

--- a/bee-storage/bee-storage-test/src/address_to_balance.rs
+++ b/bee-storage/bee-storage-test/src/address_to_balance.rs
@@ -96,7 +96,7 @@ pub fn address_to_balance_access<B: StorageBackend>(storage: &B) {
 
     storage.batch_commit(batch, true).unwrap();
 
-    let iter = AsIterator::<Address, Balance>::iter_op(storage).unwrap();
+    let iter = storage.iter::<Address, Balance>().unwrap();
     let mut count = 0;
 
     for result in iter {
@@ -119,7 +119,7 @@ pub fn address_to_balance_access<B: StorageBackend>(storage: &B) {
 
     Truncate::<Address, Balance>::truncate_op(storage).unwrap();
 
-    let mut iter = AsIterator::<Address, Balance>::iter_op(storage).unwrap();
+    let mut iter = storage.iter::<Address, Balance>().unwrap();
 
     assert!(iter.next().is_none());
 }

--- a/bee-storage/bee-storage-test/src/address_to_balance.rs
+++ b/bee-storage/bee-storage-test/src/address_to_balance.rs
@@ -7,6 +7,7 @@ use bee_message::address::Address;
 use bee_storage::{
     access::{AsIterator, Batch, BatchBuilder, Delete, Exist, Fetch, Insert, MultiFetch, Truncate},
     backend,
+    backend::StorageBackendExt,
 };
 use bee_test::rand::{address::rand_address, balance::rand_balance};
 
@@ -42,7 +43,7 @@ pub fn address_to_balance_access<B: StorageBackend>(storage: &B) {
     let (address, balance) = (rand_address(), rand_balance());
 
     assert!(!Exist::<Address, Balance>::exist(storage, &address).unwrap());
-    assert!(Fetch::<Address, Balance>::fetch(storage, &address).unwrap().is_none());
+    assert!(storage.fetch_access::<Address, Balance>(&address).unwrap().is_none());
     let results = MultiFetch::<Address, Balance>::multi_fetch(storage, &[address])
         .unwrap()
         .collect::<Vec<_>>();
@@ -53,7 +54,8 @@ pub fn address_to_balance_access<B: StorageBackend>(storage: &B) {
 
     assert!(Exist::<Address, Balance>::exist(storage, &address).unwrap());
     assert_eq!(
-        Fetch::<Address, Balance>::fetch(storage, &address)
+        storage
+            .fetch_access::<Address, Balance>(&address)
             .unwrap()
             .unwrap()
             .pack_new(),
@@ -68,7 +70,7 @@ pub fn address_to_balance_access<B: StorageBackend>(storage: &B) {
     Delete::<Address, Balance>::delete(storage, &address).unwrap();
 
     assert!(!Exist::<Address, Balance>::exist(storage, &address).unwrap());
-    assert!(Fetch::<Address, Balance>::fetch(storage, &address).unwrap().is_none());
+    assert!(storage.fetch_access::<Address, Balance>(&address).unwrap().is_none());
     let results = MultiFetch::<Address, Balance>::multi_fetch(storage, &[address])
         .unwrap()
         .collect::<Vec<_>>();

--- a/bee-storage/bee-storage-test/src/address_to_balance.rs
+++ b/bee-storage/bee-storage-test/src/address_to_balance.rs
@@ -44,7 +44,8 @@ pub fn address_to_balance_access<B: StorageBackend>(storage: &B) {
 
     assert!(!storage.exist::<Address, Balance>(&address).unwrap());
     assert!(storage.fetch::<Address, Balance>(&address).unwrap().is_none());
-    let results = MultiFetch::<Address, Balance>::multi_fetch_op(storage, &[address])
+    let results = storage
+        .multi_fetch::<Address, Balance>(&[address])
         .unwrap()
         .collect::<Vec<_>>();
     assert_eq!(results.len(), 1);
@@ -57,7 +58,8 @@ pub fn address_to_balance_access<B: StorageBackend>(storage: &B) {
         storage.fetch::<Address, Balance>(&address).unwrap().unwrap().pack_new(),
         balance.pack_new()
     );
-    let results = MultiFetch::<Address, Balance>::multi_fetch_op(storage, &[address])
+    let results = storage
+        .multi_fetch::<Address, Balance>(&[address])
         .unwrap()
         .collect::<Vec<_>>();
     assert_eq!(results.len(), 1);
@@ -67,7 +69,8 @@ pub fn address_to_balance_access<B: StorageBackend>(storage: &B) {
 
     assert!(!storage.exist::<Address, Balance>(&address).unwrap());
     assert!(storage.fetch::<Address, Balance>(&address).unwrap().is_none());
-    let results = MultiFetch::<Address, Balance>::multi_fetch_op(storage, &[address])
+    let results = storage
+        .multi_fetch::<Address, Balance>(&[address])
         .unwrap()
         .collect::<Vec<_>>();
     assert_eq!(results.len(), 1);
@@ -107,7 +110,8 @@ pub fn address_to_balance_access<B: StorageBackend>(storage: &B) {
 
     assert_eq!(count, 10);
 
-    let results = MultiFetch::<Address, Balance>::multi_fetch_op(storage, &addresses)
+    let results = storage
+        .multi_fetch::<Address, Balance>(&addresses)
         .unwrap()
         .collect::<Vec<_>>();
 

--- a/bee-storage/bee-storage-test/src/address_to_balance.rs
+++ b/bee-storage/bee-storage-test/src/address_to_balance.rs
@@ -50,7 +50,7 @@ pub fn address_to_balance_access<B: StorageBackend>(storage: &B) {
     assert_eq!(results.len(), 1);
     assert!(matches!(results.get(0), Some(Ok(None))));
 
-    Insert::<Address, Balance>::insert_op(storage, &address, &balance).unwrap();
+    storage.insert::<Address, Balance>(&address, &balance).unwrap();
 
     assert!(storage.exist::<Address, Balance>(&address).unwrap());
     assert_eq!(
@@ -79,7 +79,7 @@ pub fn address_to_balance_access<B: StorageBackend>(storage: &B) {
 
     for _ in 0..10 {
         let (address, balance) = (rand_address(), rand_balance());
-        Insert::<Address, Balance>::insert_op(storage, &address, &balance).unwrap();
+        storage.insert::<Address, Balance>(&address, &balance).unwrap();
         storage.batch_delete::<Address, Balance>(&mut batch, &address).unwrap();
         addresses.push(address);
         balances.push((address, None));

--- a/bee-storage/bee-storage-test/src/ed25519_address_to_output_id.rs
+++ b/bee-storage/bee-storage-test/src/ed25519_address_to_output_id.rs
@@ -114,7 +114,7 @@ pub fn ed25519_address_to_output_id_access<B: StorageBackend>(storage: &B) {
 
     storage.batch_commit(batch, true).unwrap();
 
-    let iter = AsIterator::<(Ed25519Address, OutputId), ()>::iter_op(storage).unwrap();
+    let iter = storage.iter::<(Ed25519Address, OutputId), ()>().unwrap();
     let mut count = 0;
 
     for result in iter {
@@ -127,7 +127,7 @@ pub fn ed25519_address_to_output_id_access<B: StorageBackend>(storage: &B) {
 
     Truncate::<(Ed25519Address, OutputId), ()>::truncate_op(storage).unwrap();
 
-    let mut iter = AsIterator::<(Ed25519Address, OutputId), ()>::iter_op(storage).unwrap();
+    let mut iter = storage.iter::<(Ed25519Address, OutputId), ()>().unwrap();
 
     assert!(iter.next().is_none());
 }

--- a/bee-storage/bee-storage-test/src/ed25519_address_to_output_id.rs
+++ b/bee-storage/bee-storage-test/src/ed25519_address_to_output_id.rs
@@ -40,7 +40,11 @@ impl<T> StorageBackend for T where
 pub fn ed25519_address_to_output_id_access<B: StorageBackend>(storage: &B) {
     let (address, output_id) = (rand_ed25519_address(), rand_output_id());
 
-    assert!(!Exist::<(Ed25519Address, OutputId), ()>::exist_op(storage, &(address, output_id)).unwrap());
+    assert!(
+        !storage
+            .exist::<(Ed25519Address, OutputId), ()>(&(address, output_id))
+            .unwrap()
+    );
     assert!(
         storage
             .fetch::<Ed25519Address, Vec<OutputId>>(&address)
@@ -51,7 +55,11 @@ pub fn ed25519_address_to_output_id_access<B: StorageBackend>(storage: &B) {
 
     Insert::<(Ed25519Address, OutputId), ()>::insert_op(storage, &(address, output_id), &()).unwrap();
 
-    assert!(Exist::<(Ed25519Address, OutputId), ()>::exist_op(storage, &(address, output_id)).unwrap());
+    assert!(
+        storage
+            .exist::<(Ed25519Address, OutputId), ()>(&(address, output_id))
+            .unwrap()
+    );
     assert_eq!(
         storage
             .fetch::<Ed25519Address, Vec<OutputId>>(&address)
@@ -64,7 +72,11 @@ pub fn ed25519_address_to_output_id_access<B: StorageBackend>(storage: &B) {
         .delete::<(Ed25519Address, OutputId), ()>(&(address, output_id))
         .unwrap();
 
-    assert!(!Exist::<(Ed25519Address, OutputId), ()>::exist_op(storage, &(address, output_id)).unwrap());
+    assert!(
+        !storage
+            .exist::<(Ed25519Address, OutputId), ()>(&(address, output_id))
+            .unwrap()
+    );
     assert!(
         storage
             .fetch::<Ed25519Address, Vec<OutputId>>(&address)

--- a/bee-storage/bee-storage-test/src/ed25519_address_to_output_id.rs
+++ b/bee-storage/bee-storage-test/src/ed25519_address_to_output_id.rs
@@ -53,7 +53,9 @@ pub fn ed25519_address_to_output_id_access<B: StorageBackend>(storage: &B) {
             .is_empty()
     );
 
-    Insert::<(Ed25519Address, OutputId), ()>::insert_op(storage, &(address, output_id), &()).unwrap();
+    storage
+        .insert::<(Ed25519Address, OutputId), ()>(&(address, output_id), &())
+        .unwrap();
 
     assert!(
         storage
@@ -89,7 +91,9 @@ pub fn ed25519_address_to_output_id_access<B: StorageBackend>(storage: &B) {
 
     for _ in 0..10 {
         let (address, output_id) = (rand_ed25519_address(), rand_output_id());
-        Insert::<(Ed25519Address, OutputId), ()>::insert_op(storage, &(address, output_id), &()).unwrap();
+        storage
+            .insert::<(Ed25519Address, OutputId), ()>(&(address, output_id), &())
+            .unwrap();
         storage
             .batch_delete::<(Ed25519Address, OutputId), ()>(&mut batch, &(address, output_id))
             .unwrap();

--- a/bee-storage/bee-storage-test/src/ed25519_address_to_output_id.rs
+++ b/bee-storage/bee-storage-test/src/ed25519_address_to_output_id.rs
@@ -7,6 +7,7 @@ use bee_message::{address::Ed25519Address, output::OutputId};
 use bee_storage::{
     access::{AsIterator, Batch, BatchBuilder, Delete, Exist, Fetch, Insert, Truncate},
     backend,
+    backend::StorageBackendExt,
 };
 use bee_test::rand::{address::rand_ed25519_address, output::rand_output_id};
 
@@ -41,7 +42,8 @@ pub fn ed25519_address_to_output_id_access<B: StorageBackend>(storage: &B) {
 
     assert!(!Exist::<(Ed25519Address, OutputId), ()>::exist(storage, &(address, output_id)).unwrap());
     assert!(
-        Fetch::<Ed25519Address, Vec<OutputId>>::fetch(storage, &address)
+        storage
+            .fetch_access::<Ed25519Address, Vec<OutputId>>(&address)
             .unwrap()
             .unwrap()
             .is_empty()
@@ -51,7 +53,8 @@ pub fn ed25519_address_to_output_id_access<B: StorageBackend>(storage: &B) {
 
     assert!(Exist::<(Ed25519Address, OutputId), ()>::exist(storage, &(address, output_id)).unwrap());
     assert_eq!(
-        Fetch::<Ed25519Address, Vec<OutputId>>::fetch(storage, &address)
+        storage
+            .fetch_access::<Ed25519Address, Vec<OutputId>>(&address)
             .unwrap()
             .unwrap(),
         vec![output_id]
@@ -61,7 +64,8 @@ pub fn ed25519_address_to_output_id_access<B: StorageBackend>(storage: &B) {
 
     assert!(!Exist::<(Ed25519Address, OutputId), ()>::exist(storage, &(address, output_id)).unwrap());
     assert!(
-        Fetch::<Ed25519Address, Vec<OutputId>>::fetch(storage, &address)
+        storage
+            .fetch_access::<Ed25519Address, Vec<OutputId>>(&address)
             .unwrap()
             .unwrap()
             .is_empty()

--- a/bee-storage/bee-storage-test/src/ed25519_address_to_output_id.rs
+++ b/bee-storage/bee-storage-test/src/ed25519_address_to_output_id.rs
@@ -76,7 +76,9 @@ pub fn ed25519_address_to_output_id_access<B: StorageBackend>(storage: &B) {
     for _ in 0..10 {
         let (address, output_id) = (rand_ed25519_address(), rand_output_id());
         Insert::<(Ed25519Address, OutputId), ()>::insert_op(storage, &(address, output_id), &()).unwrap();
-        Batch::<(Ed25519Address, OutputId), ()>::batch_delete_op(storage, &mut batch, &(address, output_id)).unwrap();
+        storage
+            .batch_delete::<(Ed25519Address, OutputId), ()>(&mut batch, &(address, output_id))
+            .unwrap();
     }
 
     let mut output_ids = HashMap::<Ed25519Address, Vec<OutputId>>::new();
@@ -85,7 +87,8 @@ pub fn ed25519_address_to_output_id_access<B: StorageBackend>(storage: &B) {
         let address = rand_ed25519_address();
         for _ in 0..5 {
             let output_id = rand_output_id();
-            Batch::<(Ed25519Address, OutputId), ()>::batch_insert_op(storage, &mut batch, &(address, output_id), &())
+            storage
+                .batch_insert::<(Ed25519Address, OutputId), ()>(&mut batch, &(address, output_id), &())
                 .unwrap();
             output_ids.entry(address).or_default().push(output_id);
         }

--- a/bee-storage/bee-storage-test/src/ed25519_address_to_output_id.rs
+++ b/bee-storage/bee-storage-test/src/ed25519_address_to_output_id.rs
@@ -125,7 +125,7 @@ pub fn ed25519_address_to_output_id_access<B: StorageBackend>(storage: &B) {
 
     assert_eq!(count, output_ids.iter().fold(0, |acc, v| acc + v.1.len()));
 
-    Truncate::<(Ed25519Address, OutputId), ()>::truncate_op(storage).unwrap();
+    storage.truncate::<(Ed25519Address, OutputId), ()>().unwrap();
 
     let mut iter = storage.iter::<(Ed25519Address, OutputId), ()>().unwrap();
 

--- a/bee-storage/bee-storage-test/src/ed25519_address_to_output_id.rs
+++ b/bee-storage/bee-storage-test/src/ed25519_address_to_output_id.rs
@@ -40,7 +40,7 @@ impl<T> StorageBackend for T where
 pub fn ed25519_address_to_output_id_access<B: StorageBackend>(storage: &B) {
     let (address, output_id) = (rand_ed25519_address(), rand_output_id());
 
-    assert!(!Exist::<(Ed25519Address, OutputId), ()>::exist(storage, &(address, output_id)).unwrap());
+    assert!(!Exist::<(Ed25519Address, OutputId), ()>::exist_op(storage, &(address, output_id)).unwrap());
     assert!(
         storage
             .fetch::<Ed25519Address, Vec<OutputId>>(&address)
@@ -49,9 +49,9 @@ pub fn ed25519_address_to_output_id_access<B: StorageBackend>(storage: &B) {
             .is_empty()
     );
 
-    Insert::<(Ed25519Address, OutputId), ()>::insert(storage, &(address, output_id), &()).unwrap();
+    Insert::<(Ed25519Address, OutputId), ()>::insert_op(storage, &(address, output_id), &()).unwrap();
 
-    assert!(Exist::<(Ed25519Address, OutputId), ()>::exist(storage, &(address, output_id)).unwrap());
+    assert!(Exist::<(Ed25519Address, OutputId), ()>::exist_op(storage, &(address, output_id)).unwrap());
     assert_eq!(
         storage
             .fetch::<Ed25519Address, Vec<OutputId>>(&address)
@@ -60,9 +60,9 @@ pub fn ed25519_address_to_output_id_access<B: StorageBackend>(storage: &B) {
         vec![output_id]
     );
 
-    Delete::<(Ed25519Address, OutputId), ()>::delete(storage, &(address, output_id)).unwrap();
+    Delete::<(Ed25519Address, OutputId), ()>::delete_op(storage, &(address, output_id)).unwrap();
 
-    assert!(!Exist::<(Ed25519Address, OutputId), ()>::exist(storage, &(address, output_id)).unwrap());
+    assert!(!Exist::<(Ed25519Address, OutputId), ()>::exist_op(storage, &(address, output_id)).unwrap());
     assert!(
         storage
             .fetch::<Ed25519Address, Vec<OutputId>>(&address)
@@ -75,8 +75,8 @@ pub fn ed25519_address_to_output_id_access<B: StorageBackend>(storage: &B) {
 
     for _ in 0..10 {
         let (address, output_id) = (rand_ed25519_address(), rand_output_id());
-        Insert::<(Ed25519Address, OutputId), ()>::insert(storage, &(address, output_id), &()).unwrap();
-        Batch::<(Ed25519Address, OutputId), ()>::batch_delete(storage, &mut batch, &(address, output_id)).unwrap();
+        Insert::<(Ed25519Address, OutputId), ()>::insert_op(storage, &(address, output_id), &()).unwrap();
+        Batch::<(Ed25519Address, OutputId), ()>::batch_delete_op(storage, &mut batch, &(address, output_id)).unwrap();
     }
 
     let mut output_ids = HashMap::<Ed25519Address, Vec<OutputId>>::new();
@@ -85,7 +85,7 @@ pub fn ed25519_address_to_output_id_access<B: StorageBackend>(storage: &B) {
         let address = rand_ed25519_address();
         for _ in 0..5 {
             let output_id = rand_output_id();
-            Batch::<(Ed25519Address, OutputId), ()>::batch_insert(storage, &mut batch, &(address, output_id), &())
+            Batch::<(Ed25519Address, OutputId), ()>::batch_insert_op(storage, &mut batch, &(address, output_id), &())
                 .unwrap();
             output_ids.entry(address).or_default().push(output_id);
         }
@@ -93,7 +93,7 @@ pub fn ed25519_address_to_output_id_access<B: StorageBackend>(storage: &B) {
 
     storage.batch_commit(batch, true).unwrap();
 
-    let iter = AsIterator::<(Ed25519Address, OutputId), ()>::iter(storage).unwrap();
+    let iter = AsIterator::<(Ed25519Address, OutputId), ()>::iter_op(storage).unwrap();
     let mut count = 0;
 
     for result in iter {
@@ -104,9 +104,9 @@ pub fn ed25519_address_to_output_id_access<B: StorageBackend>(storage: &B) {
 
     assert_eq!(count, output_ids.iter().fold(0, |acc, v| acc + v.1.len()));
 
-    Truncate::<(Ed25519Address, OutputId), ()>::truncate(storage).unwrap();
+    Truncate::<(Ed25519Address, OutputId), ()>::truncate_op(storage).unwrap();
 
-    let mut iter = AsIterator::<(Ed25519Address, OutputId), ()>::iter(storage).unwrap();
+    let mut iter = AsIterator::<(Ed25519Address, OutputId), ()>::iter_op(storage).unwrap();
 
     assert!(iter.next().is_none());
 }

--- a/bee-storage/bee-storage-test/src/ed25519_address_to_output_id.rs
+++ b/bee-storage/bee-storage-test/src/ed25519_address_to_output_id.rs
@@ -60,7 +60,9 @@ pub fn ed25519_address_to_output_id_access<B: StorageBackend>(storage: &B) {
         vec![output_id]
     );
 
-    Delete::<(Ed25519Address, OutputId), ()>::delete_op(storage, &(address, output_id)).unwrap();
+    storage
+        .delete::<(Ed25519Address, OutputId), ()>(&(address, output_id))
+        .unwrap();
 
     assert!(!Exist::<(Ed25519Address, OutputId), ()>::exist_op(storage, &(address, output_id)).unwrap());
     assert!(

--- a/bee-storage/bee-storage-test/src/ed25519_address_to_output_id.rs
+++ b/bee-storage/bee-storage-test/src/ed25519_address_to_output_id.rs
@@ -43,7 +43,7 @@ pub fn ed25519_address_to_output_id_access<B: StorageBackend>(storage: &B) {
     assert!(!Exist::<(Ed25519Address, OutputId), ()>::exist(storage, &(address, output_id)).unwrap());
     assert!(
         storage
-            .fetch_access::<Ed25519Address, Vec<OutputId>>(&address)
+            .fetch::<Ed25519Address, Vec<OutputId>>(&address)
             .unwrap()
             .unwrap()
             .is_empty()
@@ -54,7 +54,7 @@ pub fn ed25519_address_to_output_id_access<B: StorageBackend>(storage: &B) {
     assert!(Exist::<(Ed25519Address, OutputId), ()>::exist(storage, &(address, output_id)).unwrap());
     assert_eq!(
         storage
-            .fetch_access::<Ed25519Address, Vec<OutputId>>(&address)
+            .fetch::<Ed25519Address, Vec<OutputId>>(&address)
             .unwrap()
             .unwrap(),
         vec![output_id]
@@ -65,7 +65,7 @@ pub fn ed25519_address_to_output_id_access<B: StorageBackend>(storage: &B) {
     assert!(!Exist::<(Ed25519Address, OutputId), ()>::exist(storage, &(address, output_id)).unwrap());
     assert!(
         storage
-            .fetch_access::<Ed25519Address, Vec<OutputId>>(&address)
+            .fetch::<Ed25519Address, Vec<OutputId>>(&address)
             .unwrap()
             .unwrap()
             .is_empty()

--- a/bee-storage/bee-storage-test/src/ed25519_address_to_output_id.rs
+++ b/bee-storage/bee-storage-test/src/ed25519_address_to_output_id.rs
@@ -53,9 +53,7 @@ pub fn ed25519_address_to_output_id_access<B: StorageBackend>(storage: &B) {
             .is_empty()
     );
 
-    storage
-        .insert::<(Ed25519Address, OutputId), ()>(&(address, output_id), &())
-        .unwrap();
+    storage.insert(&(address, output_id), &()).unwrap();
 
     assert!(
         storage
@@ -91,9 +89,7 @@ pub fn ed25519_address_to_output_id_access<B: StorageBackend>(storage: &B) {
 
     for _ in 0..10 {
         let (address, output_id) = (rand_ed25519_address(), rand_output_id());
-        storage
-            .insert::<(Ed25519Address, OutputId), ()>(&(address, output_id), &())
-            .unwrap();
+        storage.insert(&(address, output_id), &()).unwrap();
         storage
             .batch_delete::<(Ed25519Address, OutputId), ()>(&mut batch, &(address, output_id))
             .unwrap();
@@ -105,9 +101,7 @@ pub fn ed25519_address_to_output_id_access<B: StorageBackend>(storage: &B) {
         let address = rand_ed25519_address();
         for _ in 0..5 {
             let output_id = rand_output_id();
-            storage
-                .batch_insert::<(Ed25519Address, OutputId), ()>(&mut batch, &(address, output_id), &())
-                .unwrap();
+            storage.batch_insert(&mut batch, &(address, output_id), &()).unwrap();
             output_ids.entry(address).or_default().push(output_id);
         }
     }

--- a/bee-storage/bee-storage-test/src/index_to_message_id.rs
+++ b/bee-storage/bee-storage-test/src/index_to_message_id.rs
@@ -111,7 +111,7 @@ pub fn index_to_message_id_access<B: StorageBackend>(storage: &B) {
 
     storage.batch_commit(batch, true).unwrap();
 
-    let iter = AsIterator::<(PaddedIndex, MessageId), ()>::iter_op(storage).unwrap();
+    let iter = storage.iter::<(PaddedIndex, MessageId), ()>().unwrap();
     let mut count = 0;
 
     for result in iter {
@@ -124,7 +124,7 @@ pub fn index_to_message_id_access<B: StorageBackend>(storage: &B) {
 
     Truncate::<(PaddedIndex, MessageId), ()>::truncate_op(storage).unwrap();
 
-    let mut iter = AsIterator::<(PaddedIndex, MessageId), ()>::iter_op(storage).unwrap();
+    let mut iter = storage.iter::<(PaddedIndex, MessageId), ()>().unwrap();
 
     assert!(iter.next().is_none());
 }

--- a/bee-storage/bee-storage-test/src/index_to_message_id.rs
+++ b/bee-storage/bee-storage-test/src/index_to_message_id.rs
@@ -57,7 +57,9 @@ pub fn index_to_message_id_access<B: StorageBackend>(storage: &B) {
         vec![message_id]
     );
 
-    Delete::<(PaddedIndex, MessageId), ()>::delete_op(storage, &(index, message_id)).unwrap();
+    storage
+        .delete::<(PaddedIndex, MessageId), ()>(&(index, message_id))
+        .unwrap();
 
     assert!(!Exist::<(PaddedIndex, MessageId), ()>::exist_op(storage, &(index, message_id)).unwrap());
     assert!(

--- a/bee-storage/bee-storage-test/src/index_to_message_id.rs
+++ b/bee-storage/bee-storage-test/src/index_to_message_id.rs
@@ -53,7 +53,9 @@ pub fn index_to_message_id_access<B: StorageBackend>(storage: &B) {
             .is_empty()
     );
 
-    Insert::<(PaddedIndex, MessageId), ()>::insert_op(storage, &(index, message_id), &()).unwrap();
+    storage
+        .insert::<(PaddedIndex, MessageId), ()>(&(index, message_id), &())
+        .unwrap();
 
     assert!(
         storage
@@ -86,7 +88,9 @@ pub fn index_to_message_id_access<B: StorageBackend>(storage: &B) {
 
     for _ in 0..10 {
         let (index, message_id) = (rand_indexation_payload().padded_index(), rand_message_id());
-        Insert::<(PaddedIndex, MessageId), ()>::insert_op(storage, &(index, message_id), &()).unwrap();
+        storage
+            .insert::<(PaddedIndex, MessageId), ()>(&(index, message_id), &())
+            .unwrap();
         storage
             .batch_delete::<(PaddedIndex, MessageId), ()>(&mut batch, &(index, message_id))
             .unwrap();

--- a/bee-storage/bee-storage-test/src/index_to_message_id.rs
+++ b/bee-storage/bee-storage-test/src/index_to_message_id.rs
@@ -40,7 +40,7 @@ impl<T> StorageBackend for T where
 pub fn index_to_message_id_access<B: StorageBackend>(storage: &B) {
     let (index, message_id) = (rand_indexation_payload().padded_index(), rand_message_id());
 
-    assert!(!Exist::<(PaddedIndex, MessageId), ()>::exist(storage, &(index, message_id)).unwrap());
+    assert!(!Exist::<(PaddedIndex, MessageId), ()>::exist_op(storage, &(index, message_id)).unwrap());
     assert!(
         storage
             .fetch::<PaddedIndex, Vec<MessageId>>(&index)
@@ -49,17 +49,17 @@ pub fn index_to_message_id_access<B: StorageBackend>(storage: &B) {
             .is_empty()
     );
 
-    Insert::<(PaddedIndex, MessageId), ()>::insert(storage, &(index, message_id), &()).unwrap();
+    Insert::<(PaddedIndex, MessageId), ()>::insert_op(storage, &(index, message_id), &()).unwrap();
 
-    assert!(Exist::<(PaddedIndex, MessageId), ()>::exist(storage, &(index, message_id)).unwrap());
+    assert!(Exist::<(PaddedIndex, MessageId), ()>::exist_op(storage, &(index, message_id)).unwrap());
     assert_eq!(
         storage.fetch::<PaddedIndex, Vec<MessageId>>(&index).unwrap().unwrap(),
         vec![message_id]
     );
 
-    Delete::<(PaddedIndex, MessageId), ()>::delete(storage, &(index, message_id)).unwrap();
+    Delete::<(PaddedIndex, MessageId), ()>::delete_op(storage, &(index, message_id)).unwrap();
 
-    assert!(!Exist::<(PaddedIndex, MessageId), ()>::exist(storage, &(index, message_id)).unwrap());
+    assert!(!Exist::<(PaddedIndex, MessageId), ()>::exist_op(storage, &(index, message_id)).unwrap());
     assert!(
         storage
             .fetch::<PaddedIndex, Vec<MessageId>>(&index)
@@ -72,8 +72,8 @@ pub fn index_to_message_id_access<B: StorageBackend>(storage: &B) {
 
     for _ in 0..10 {
         let (index, message_id) = (rand_indexation_payload().padded_index(), rand_message_id());
-        Insert::<(PaddedIndex, MessageId), ()>::insert(storage, &(index, message_id), &()).unwrap();
-        Batch::<(PaddedIndex, MessageId), ()>::batch_delete(storage, &mut batch, &(index, message_id)).unwrap();
+        Insert::<(PaddedIndex, MessageId), ()>::insert_op(storage, &(index, message_id), &()).unwrap();
+        Batch::<(PaddedIndex, MessageId), ()>::batch_delete_op(storage, &mut batch, &(index, message_id)).unwrap();
     }
 
     let mut message_ids = HashMap::<PaddedIndex, Vec<MessageId>>::new();
@@ -82,7 +82,7 @@ pub fn index_to_message_id_access<B: StorageBackend>(storage: &B) {
         let index = rand_indexation_payload().padded_index();
         for _ in 0..5 {
             let message_id = rand_message_id();
-            Batch::<(PaddedIndex, MessageId), ()>::batch_insert(storage, &mut batch, &(index, message_id), &())
+            Batch::<(PaddedIndex, MessageId), ()>::batch_insert_op(storage, &mut batch, &(index, message_id), &())
                 .unwrap();
             message_ids.entry(index).or_default().push(message_id);
         }
@@ -90,7 +90,7 @@ pub fn index_to_message_id_access<B: StorageBackend>(storage: &B) {
 
     storage.batch_commit(batch, true).unwrap();
 
-    let iter = AsIterator::<(PaddedIndex, MessageId), ()>::iter(storage).unwrap();
+    let iter = AsIterator::<(PaddedIndex, MessageId), ()>::iter_op(storage).unwrap();
     let mut count = 0;
 
     for result in iter {
@@ -101,9 +101,9 @@ pub fn index_to_message_id_access<B: StorageBackend>(storage: &B) {
 
     assert_eq!(count, message_ids.iter().fold(0, |acc, v| acc + v.1.len()));
 
-    Truncate::<(PaddedIndex, MessageId), ()>::truncate(storage).unwrap();
+    Truncate::<(PaddedIndex, MessageId), ()>::truncate_op(storage).unwrap();
 
-    let mut iter = AsIterator::<(PaddedIndex, MessageId), ()>::iter(storage).unwrap();
+    let mut iter = AsIterator::<(PaddedIndex, MessageId), ()>::iter_op(storage).unwrap();
 
     assert!(iter.next().is_none());
 }

--- a/bee-storage/bee-storage-test/src/index_to_message_id.rs
+++ b/bee-storage/bee-storage-test/src/index_to_message_id.rs
@@ -7,6 +7,7 @@ use bee_message::{payload::indexation::PaddedIndex, MessageId};
 use bee_storage::{
     access::{AsIterator, Batch, BatchBuilder, Delete, Exist, Fetch, Insert, Truncate},
     backend,
+    backend::StorageBackendExt,
 };
 use bee_test::rand::{message::rand_message_id, payload::rand_indexation_payload};
 
@@ -41,7 +42,8 @@ pub fn index_to_message_id_access<B: StorageBackend>(storage: &B) {
 
     assert!(!Exist::<(PaddedIndex, MessageId), ()>::exist(storage, &(index, message_id)).unwrap());
     assert!(
-        Fetch::<PaddedIndex, Vec<MessageId>>::fetch(storage, &index)
+        storage
+            .fetch_access::<PaddedIndex, Vec<MessageId>>(&index)
             .unwrap()
             .unwrap()
             .is_empty()
@@ -51,7 +53,8 @@ pub fn index_to_message_id_access<B: StorageBackend>(storage: &B) {
 
     assert!(Exist::<(PaddedIndex, MessageId), ()>::exist(storage, &(index, message_id)).unwrap());
     assert_eq!(
-        Fetch::<PaddedIndex, Vec<MessageId>>::fetch(storage, &index)
+        storage
+            .fetch_access::<PaddedIndex, Vec<MessageId>>(&index)
             .unwrap()
             .unwrap(),
         vec![message_id]
@@ -61,7 +64,8 @@ pub fn index_to_message_id_access<B: StorageBackend>(storage: &B) {
 
     assert!(!Exist::<(PaddedIndex, MessageId), ()>::exist(storage, &(index, message_id)).unwrap());
     assert!(
-        Fetch::<PaddedIndex, Vec<MessageId>>::fetch(storage, &index)
+        storage
+            .fetch_access::<PaddedIndex, Vec<MessageId>>(&index)
             .unwrap()
             .unwrap()
             .is_empty()

--- a/bee-storage/bee-storage-test/src/index_to_message_id.rs
+++ b/bee-storage/bee-storage-test/src/index_to_message_id.rs
@@ -53,9 +53,7 @@ pub fn index_to_message_id_access<B: StorageBackend>(storage: &B) {
             .is_empty()
     );
 
-    storage
-        .insert::<(PaddedIndex, MessageId), ()>(&(index, message_id), &())
-        .unwrap();
+    storage.insert(&(index, message_id), &()).unwrap();
 
     assert!(
         storage
@@ -88,9 +86,7 @@ pub fn index_to_message_id_access<B: StorageBackend>(storage: &B) {
 
     for _ in 0..10 {
         let (index, message_id) = (rand_indexation_payload().padded_index(), rand_message_id());
-        storage
-            .insert::<(PaddedIndex, MessageId), ()>(&(index, message_id), &())
-            .unwrap();
+        storage.insert(&(index, message_id), &()).unwrap();
         storage
             .batch_delete::<(PaddedIndex, MessageId), ()>(&mut batch, &(index, message_id))
             .unwrap();
@@ -102,9 +98,7 @@ pub fn index_to_message_id_access<B: StorageBackend>(storage: &B) {
         let index = rand_indexation_payload().padded_index();
         for _ in 0..5 {
             let message_id = rand_message_id();
-            storage
-                .batch_insert::<(PaddedIndex, MessageId), ()>(&mut batch, &(index, message_id), &())
-                .unwrap();
+            storage.batch_insert(&mut batch, &(index, message_id), &()).unwrap();
             message_ids.entry(index).or_default().push(message_id);
         }
     }

--- a/bee-storage/bee-storage-test/src/index_to_message_id.rs
+++ b/bee-storage/bee-storage-test/src/index_to_message_id.rs
@@ -43,7 +43,7 @@ pub fn index_to_message_id_access<B: StorageBackend>(storage: &B) {
     assert!(!Exist::<(PaddedIndex, MessageId), ()>::exist(storage, &(index, message_id)).unwrap());
     assert!(
         storage
-            .fetch_access::<PaddedIndex, Vec<MessageId>>(&index)
+            .fetch::<PaddedIndex, Vec<MessageId>>(&index)
             .unwrap()
             .unwrap()
             .is_empty()
@@ -53,10 +53,7 @@ pub fn index_to_message_id_access<B: StorageBackend>(storage: &B) {
 
     assert!(Exist::<(PaddedIndex, MessageId), ()>::exist(storage, &(index, message_id)).unwrap());
     assert_eq!(
-        storage
-            .fetch_access::<PaddedIndex, Vec<MessageId>>(&index)
-            .unwrap()
-            .unwrap(),
+        storage.fetch::<PaddedIndex, Vec<MessageId>>(&index).unwrap().unwrap(),
         vec![message_id]
     );
 
@@ -65,7 +62,7 @@ pub fn index_to_message_id_access<B: StorageBackend>(storage: &B) {
     assert!(!Exist::<(PaddedIndex, MessageId), ()>::exist(storage, &(index, message_id)).unwrap());
     assert!(
         storage
-            .fetch_access::<PaddedIndex, Vec<MessageId>>(&index)
+            .fetch::<PaddedIndex, Vec<MessageId>>(&index)
             .unwrap()
             .unwrap()
             .is_empty()

--- a/bee-storage/bee-storage-test/src/index_to_message_id.rs
+++ b/bee-storage/bee-storage-test/src/index_to_message_id.rs
@@ -40,7 +40,11 @@ impl<T> StorageBackend for T where
 pub fn index_to_message_id_access<B: StorageBackend>(storage: &B) {
     let (index, message_id) = (rand_indexation_payload().padded_index(), rand_message_id());
 
-    assert!(!Exist::<(PaddedIndex, MessageId), ()>::exist_op(storage, &(index, message_id)).unwrap());
+    assert!(
+        !storage
+            .exist::<(PaddedIndex, MessageId), ()>(&(index, message_id))
+            .unwrap()
+    );
     assert!(
         storage
             .fetch::<PaddedIndex, Vec<MessageId>>(&index)
@@ -51,7 +55,11 @@ pub fn index_to_message_id_access<B: StorageBackend>(storage: &B) {
 
     Insert::<(PaddedIndex, MessageId), ()>::insert_op(storage, &(index, message_id), &()).unwrap();
 
-    assert!(Exist::<(PaddedIndex, MessageId), ()>::exist_op(storage, &(index, message_id)).unwrap());
+    assert!(
+        storage
+            .exist::<(PaddedIndex, MessageId), ()>(&(index, message_id))
+            .unwrap()
+    );
     assert_eq!(
         storage.fetch::<PaddedIndex, Vec<MessageId>>(&index).unwrap().unwrap(),
         vec![message_id]
@@ -61,7 +69,11 @@ pub fn index_to_message_id_access<B: StorageBackend>(storage: &B) {
         .delete::<(PaddedIndex, MessageId), ()>(&(index, message_id))
         .unwrap();
 
-    assert!(!Exist::<(PaddedIndex, MessageId), ()>::exist_op(storage, &(index, message_id)).unwrap());
+    assert!(
+        !storage
+            .exist::<(PaddedIndex, MessageId), ()>(&(index, message_id))
+            .unwrap()
+    );
     assert!(
         storage
             .fetch::<PaddedIndex, Vec<MessageId>>(&index)

--- a/bee-storage/bee-storage-test/src/index_to_message_id.rs
+++ b/bee-storage/bee-storage-test/src/index_to_message_id.rs
@@ -122,7 +122,7 @@ pub fn index_to_message_id_access<B: StorageBackend>(storage: &B) {
 
     assert_eq!(count, message_ids.iter().fold(0, |acc, v| acc + v.1.len()));
 
-    Truncate::<(PaddedIndex, MessageId), ()>::truncate_op(storage).unwrap();
+    storage.truncate::<(PaddedIndex, MessageId), ()>().unwrap();
 
     let mut iter = storage.iter::<(PaddedIndex, MessageId), ()>().unwrap();
 

--- a/bee-storage/bee-storage-test/src/index_to_message_id.rs
+++ b/bee-storage/bee-storage-test/src/index_to_message_id.rs
@@ -73,7 +73,9 @@ pub fn index_to_message_id_access<B: StorageBackend>(storage: &B) {
     for _ in 0..10 {
         let (index, message_id) = (rand_indexation_payload().padded_index(), rand_message_id());
         Insert::<(PaddedIndex, MessageId), ()>::insert_op(storage, &(index, message_id), &()).unwrap();
-        Batch::<(PaddedIndex, MessageId), ()>::batch_delete_op(storage, &mut batch, &(index, message_id)).unwrap();
+        storage
+            .batch_delete::<(PaddedIndex, MessageId), ()>(&mut batch, &(index, message_id))
+            .unwrap();
     }
 
     let mut message_ids = HashMap::<PaddedIndex, Vec<MessageId>>::new();
@@ -82,7 +84,8 @@ pub fn index_to_message_id_access<B: StorageBackend>(storage: &B) {
         let index = rand_indexation_payload().padded_index();
         for _ in 0..5 {
             let message_id = rand_message_id();
-            Batch::<(PaddedIndex, MessageId), ()>::batch_insert_op(storage, &mut batch, &(index, message_id), &())
+            storage
+                .batch_insert::<(PaddedIndex, MessageId), ()>(&mut batch, &(index, message_id), &())
                 .unwrap();
             message_ids.entry(index).or_default().push(message_id);
         }

--- a/bee-storage/bee-storage-test/src/ledger_index.rs
+++ b/bee-storage/bee-storage-test/src/ledger_index.rs
@@ -6,6 +6,7 @@ use bee_message::milestone::MilestoneIndex;
 use bee_storage::{
     access::{AsIterator, Batch, BatchBuilder, Delete, Exist, Fetch, Insert, Truncate},
     backend,
+    backend::StorageBackendExt,
 };
 
 pub trait StorageBackend:
@@ -38,17 +39,17 @@ pub fn ledger_index_access<B: StorageBackend>(storage: &B) {
     let index = LedgerIndex::from(MilestoneIndex::from(42));
 
     assert!(!Exist::<(), LedgerIndex>::exist(storage, &()).unwrap());
-    assert!(Fetch::<(), LedgerIndex>::fetch(storage, &()).unwrap().is_none());
+    assert!(storage.fetch_access::<(), LedgerIndex>(&()).unwrap().is_none());
 
     Insert::<(), LedgerIndex>::insert(storage, &(), &index).unwrap();
 
     assert!(Exist::<(), LedgerIndex>::exist(storage, &()).unwrap());
-    assert_eq!(Fetch::<(), LedgerIndex>::fetch(storage, &()).unwrap().unwrap(), index);
+    assert_eq!(storage.fetch_access::<(), LedgerIndex>(&()).unwrap().unwrap(), index);
 
     Delete::<(), LedgerIndex>::delete(storage, &()).unwrap();
 
     assert!(!Exist::<(), LedgerIndex>::exist(storage, &()).unwrap());
-    assert!(Fetch::<(), LedgerIndex>::fetch(storage, &()).unwrap().is_none());
+    assert!(storage.fetch_access::<(), LedgerIndex>(&()).unwrap().is_none());
 
     let mut batch = B::batch_begin();
 
@@ -57,7 +58,7 @@ pub fn ledger_index_access<B: StorageBackend>(storage: &B) {
     storage.batch_commit(batch, true).unwrap();
 
     assert!(Exist::<(), LedgerIndex>::exist(storage, &()).unwrap());
-    assert_eq!(Fetch::<(), LedgerIndex>::fetch(storage, &()).unwrap().unwrap(), index);
+    assert_eq!(storage.fetch_access::<(), LedgerIndex>(&()).unwrap().unwrap(), index);
 
     let mut batch = B::batch_begin();
 
@@ -66,7 +67,7 @@ pub fn ledger_index_access<B: StorageBackend>(storage: &B) {
     storage.batch_commit(batch, true).unwrap();
 
     assert!(!Exist::<(), LedgerIndex>::exist(storage, &()).unwrap());
-    assert!(Fetch::<(), LedgerIndex>::fetch(storage, &()).unwrap().is_none());
+    assert!(storage.fetch_access::<(), LedgerIndex>(&()).unwrap().is_none());
 
     Insert::<(), LedgerIndex>::insert(storage, &(), &index).unwrap();
 

--- a/bee-storage/bee-storage-test/src/ledger_index.rs
+++ b/bee-storage/bee-storage-test/src/ledger_index.rs
@@ -41,7 +41,7 @@ pub fn ledger_index_access<B: StorageBackend>(storage: &B) {
     assert!(!storage.exist::<(), LedgerIndex>(&()).unwrap());
     assert!(storage.fetch::<(), LedgerIndex>(&()).unwrap().is_none());
 
-    Insert::<(), LedgerIndex>::insert_op(storage, &(), &index).unwrap();
+    storage.insert::<(), LedgerIndex>(&(), &index).unwrap();
 
     assert!(storage.exist::<(), LedgerIndex>(&()).unwrap());
     assert_eq!(storage.fetch::<(), LedgerIndex>(&()).unwrap().unwrap(), index);
@@ -71,7 +71,7 @@ pub fn ledger_index_access<B: StorageBackend>(storage: &B) {
     assert!(!storage.exist::<(), LedgerIndex>(&()).unwrap());
     assert!(storage.fetch::<(), LedgerIndex>(&()).unwrap().is_none());
 
-    Insert::<(), LedgerIndex>::insert_op(storage, &(), &index).unwrap();
+    storage.insert::<(), LedgerIndex>(&(), &index).unwrap();
 
     let iter = AsIterator::<(), LedgerIndex>::iter_op(storage).unwrap();
     let mut count = 0;

--- a/bee-storage/bee-storage-test/src/ledger_index.rs
+++ b/bee-storage/bee-storage-test/src/ledger_index.rs
@@ -41,7 +41,7 @@ pub fn ledger_index_access<B: StorageBackend>(storage: &B) {
     assert!(!storage.exist::<(), LedgerIndex>(&()).unwrap());
     assert!(storage.fetch::<(), LedgerIndex>(&()).unwrap().is_none());
 
-    storage.insert::<(), LedgerIndex>(&(), &index).unwrap();
+    storage.insert(&(), &index).unwrap();
 
     assert!(storage.exist::<(), LedgerIndex>(&()).unwrap());
     assert_eq!(storage.fetch::<(), LedgerIndex>(&()).unwrap().unwrap(), index);
@@ -53,9 +53,7 @@ pub fn ledger_index_access<B: StorageBackend>(storage: &B) {
 
     let mut batch = B::batch_begin();
 
-    storage
-        .batch_insert::<(), LedgerIndex>(&mut batch, &(), &index)
-        .unwrap();
+    storage.batch_insert(&mut batch, &(), &index).unwrap();
 
     storage.batch_commit(batch, true).unwrap();
 
@@ -71,7 +69,7 @@ pub fn ledger_index_access<B: StorageBackend>(storage: &B) {
     assert!(!storage.exist::<(), LedgerIndex>(&()).unwrap());
     assert!(storage.fetch::<(), LedgerIndex>(&()).unwrap().is_none());
 
-    storage.insert::<(), LedgerIndex>(&(), &index).unwrap();
+    storage.insert(&(), &index).unwrap();
 
     let iter = storage.iter::<(), LedgerIndex>().unwrap();
     let mut count = 0;

--- a/bee-storage/bee-storage-test/src/ledger_index.rs
+++ b/bee-storage/bee-storage-test/src/ledger_index.rs
@@ -53,7 +53,9 @@ pub fn ledger_index_access<B: StorageBackend>(storage: &B) {
 
     let mut batch = B::batch_begin();
 
-    Batch::<(), LedgerIndex>::batch_insert_op(storage, &mut batch, &(), &index).unwrap();
+    storage
+        .batch_insert::<(), LedgerIndex>(&mut batch, &(), &index)
+        .unwrap();
 
     storage.batch_commit(batch, true).unwrap();
 
@@ -62,7 +64,7 @@ pub fn ledger_index_access<B: StorageBackend>(storage: &B) {
 
     let mut batch = B::batch_begin();
 
-    Batch::<(), LedgerIndex>::batch_delete_op(storage, &mut batch, &()).unwrap();
+    storage.batch_delete::<(), LedgerIndex>(&mut batch, &()).unwrap();
 
     storage.batch_commit(batch, true).unwrap();
 

--- a/bee-storage/bee-storage-test/src/ledger_index.rs
+++ b/bee-storage/bee-storage-test/src/ledger_index.rs
@@ -38,40 +38,40 @@ impl<T> StorageBackend for T where
 pub fn ledger_index_access<B: StorageBackend>(storage: &B) {
     let index = LedgerIndex::from(MilestoneIndex::from(42));
 
-    assert!(!Exist::<(), LedgerIndex>::exist(storage, &()).unwrap());
+    assert!(!Exist::<(), LedgerIndex>::exist_op(storage, &()).unwrap());
     assert!(storage.fetch::<(), LedgerIndex>(&()).unwrap().is_none());
 
-    Insert::<(), LedgerIndex>::insert(storage, &(), &index).unwrap();
+    Insert::<(), LedgerIndex>::insert_op(storage, &(), &index).unwrap();
 
-    assert!(Exist::<(), LedgerIndex>::exist(storage, &()).unwrap());
+    assert!(Exist::<(), LedgerIndex>::exist_op(storage, &()).unwrap());
     assert_eq!(storage.fetch::<(), LedgerIndex>(&()).unwrap().unwrap(), index);
 
-    Delete::<(), LedgerIndex>::delete(storage, &()).unwrap();
+    Delete::<(), LedgerIndex>::delete_op(storage, &()).unwrap();
 
-    assert!(!Exist::<(), LedgerIndex>::exist(storage, &()).unwrap());
+    assert!(!Exist::<(), LedgerIndex>::exist_op(storage, &()).unwrap());
     assert!(storage.fetch::<(), LedgerIndex>(&()).unwrap().is_none());
 
     let mut batch = B::batch_begin();
 
-    Batch::<(), LedgerIndex>::batch_insert(storage, &mut batch, &(), &index).unwrap();
+    Batch::<(), LedgerIndex>::batch_insert_op(storage, &mut batch, &(), &index).unwrap();
 
     storage.batch_commit(batch, true).unwrap();
 
-    assert!(Exist::<(), LedgerIndex>::exist(storage, &()).unwrap());
+    assert!(Exist::<(), LedgerIndex>::exist_op(storage, &()).unwrap());
     assert_eq!(storage.fetch::<(), LedgerIndex>(&()).unwrap().unwrap(), index);
 
     let mut batch = B::batch_begin();
 
-    Batch::<(), LedgerIndex>::batch_delete(storage, &mut batch, &()).unwrap();
+    Batch::<(), LedgerIndex>::batch_delete_op(storage, &mut batch, &()).unwrap();
 
     storage.batch_commit(batch, true).unwrap();
 
-    assert!(!Exist::<(), LedgerIndex>::exist(storage, &()).unwrap());
+    assert!(!Exist::<(), LedgerIndex>::exist_op(storage, &()).unwrap());
     assert!(storage.fetch::<(), LedgerIndex>(&()).unwrap().is_none());
 
-    Insert::<(), LedgerIndex>::insert(storage, &(), &index).unwrap();
+    Insert::<(), LedgerIndex>::insert_op(storage, &(), &index).unwrap();
 
-    let iter = AsIterator::<(), LedgerIndex>::iter(storage).unwrap();
+    let iter = AsIterator::<(), LedgerIndex>::iter_op(storage).unwrap();
     let mut count = 0;
 
     for result in iter {
@@ -82,11 +82,11 @@ pub fn ledger_index_access<B: StorageBackend>(storage: &B) {
 
     assert_eq!(count, 1);
 
-    Truncate::<(), LedgerIndex>::truncate(storage).unwrap();
+    Truncate::<(), LedgerIndex>::truncate_op(storage).unwrap();
 
-    assert!(!Exist::<(), LedgerIndex>::exist(storage, &()).unwrap());
+    assert!(!Exist::<(), LedgerIndex>::exist_op(storage, &()).unwrap());
 
-    let mut iter = AsIterator::<(), LedgerIndex>::iter(storage).unwrap();
+    let mut iter = AsIterator::<(), LedgerIndex>::iter_op(storage).unwrap();
 
     assert!(iter.next().is_none());
 }

--- a/bee-storage/bee-storage-test/src/ledger_index.rs
+++ b/bee-storage/bee-storage-test/src/ledger_index.rs
@@ -84,7 +84,7 @@ pub fn ledger_index_access<B: StorageBackend>(storage: &B) {
 
     assert_eq!(count, 1);
 
-    Truncate::<(), LedgerIndex>::truncate_op(storage).unwrap();
+    storage.truncate::<(), LedgerIndex>().unwrap();
 
     assert!(!storage.exist::<(), LedgerIndex>(&()).unwrap());
 

--- a/bee-storage/bee-storage-test/src/ledger_index.rs
+++ b/bee-storage/bee-storage-test/src/ledger_index.rs
@@ -38,17 +38,17 @@ impl<T> StorageBackend for T where
 pub fn ledger_index_access<B: StorageBackend>(storage: &B) {
     let index = LedgerIndex::from(MilestoneIndex::from(42));
 
-    assert!(!Exist::<(), LedgerIndex>::exist_op(storage, &()).unwrap());
+    assert!(!storage.exist::<(), LedgerIndex>(&()).unwrap());
     assert!(storage.fetch::<(), LedgerIndex>(&()).unwrap().is_none());
 
     Insert::<(), LedgerIndex>::insert_op(storage, &(), &index).unwrap();
 
-    assert!(Exist::<(), LedgerIndex>::exist_op(storage, &()).unwrap());
+    assert!(storage.exist::<(), LedgerIndex>(&()).unwrap());
     assert_eq!(storage.fetch::<(), LedgerIndex>(&()).unwrap().unwrap(), index);
 
     storage.delete::<(), LedgerIndex>(&()).unwrap();
 
-    assert!(!Exist::<(), LedgerIndex>::exist_op(storage, &()).unwrap());
+    assert!(!storage.exist::<(), LedgerIndex>(&()).unwrap());
     assert!(storage.fetch::<(), LedgerIndex>(&()).unwrap().is_none());
 
     let mut batch = B::batch_begin();
@@ -59,7 +59,7 @@ pub fn ledger_index_access<B: StorageBackend>(storage: &B) {
 
     storage.batch_commit(batch, true).unwrap();
 
-    assert!(Exist::<(), LedgerIndex>::exist_op(storage, &()).unwrap());
+    assert!(storage.exist::<(), LedgerIndex>(&()).unwrap());
     assert_eq!(storage.fetch::<(), LedgerIndex>(&()).unwrap().unwrap(), index);
 
     let mut batch = B::batch_begin();
@@ -68,7 +68,7 @@ pub fn ledger_index_access<B: StorageBackend>(storage: &B) {
 
     storage.batch_commit(batch, true).unwrap();
 
-    assert!(!Exist::<(), LedgerIndex>::exist_op(storage, &()).unwrap());
+    assert!(!storage.exist::<(), LedgerIndex>(&()).unwrap());
     assert!(storage.fetch::<(), LedgerIndex>(&()).unwrap().is_none());
 
     Insert::<(), LedgerIndex>::insert_op(storage, &(), &index).unwrap();
@@ -86,7 +86,7 @@ pub fn ledger_index_access<B: StorageBackend>(storage: &B) {
 
     Truncate::<(), LedgerIndex>::truncate_op(storage).unwrap();
 
-    assert!(!Exist::<(), LedgerIndex>::exist_op(storage, &()).unwrap());
+    assert!(!storage.exist::<(), LedgerIndex>(&()).unwrap());
 
     let mut iter = AsIterator::<(), LedgerIndex>::iter_op(storage).unwrap();
 

--- a/bee-storage/bee-storage-test/src/ledger_index.rs
+++ b/bee-storage/bee-storage-test/src/ledger_index.rs
@@ -39,17 +39,17 @@ pub fn ledger_index_access<B: StorageBackend>(storage: &B) {
     let index = LedgerIndex::from(MilestoneIndex::from(42));
 
     assert!(!Exist::<(), LedgerIndex>::exist(storage, &()).unwrap());
-    assert!(storage.fetch_access::<(), LedgerIndex>(&()).unwrap().is_none());
+    assert!(storage.fetch::<(), LedgerIndex>(&()).unwrap().is_none());
 
     Insert::<(), LedgerIndex>::insert(storage, &(), &index).unwrap();
 
     assert!(Exist::<(), LedgerIndex>::exist(storage, &()).unwrap());
-    assert_eq!(storage.fetch_access::<(), LedgerIndex>(&()).unwrap().unwrap(), index);
+    assert_eq!(storage.fetch::<(), LedgerIndex>(&()).unwrap().unwrap(), index);
 
     Delete::<(), LedgerIndex>::delete(storage, &()).unwrap();
 
     assert!(!Exist::<(), LedgerIndex>::exist(storage, &()).unwrap());
-    assert!(storage.fetch_access::<(), LedgerIndex>(&()).unwrap().is_none());
+    assert!(storage.fetch::<(), LedgerIndex>(&()).unwrap().is_none());
 
     let mut batch = B::batch_begin();
 
@@ -58,7 +58,7 @@ pub fn ledger_index_access<B: StorageBackend>(storage: &B) {
     storage.batch_commit(batch, true).unwrap();
 
     assert!(Exist::<(), LedgerIndex>::exist(storage, &()).unwrap());
-    assert_eq!(storage.fetch_access::<(), LedgerIndex>(&()).unwrap().unwrap(), index);
+    assert_eq!(storage.fetch::<(), LedgerIndex>(&()).unwrap().unwrap(), index);
 
     let mut batch = B::batch_begin();
 
@@ -67,7 +67,7 @@ pub fn ledger_index_access<B: StorageBackend>(storage: &B) {
     storage.batch_commit(batch, true).unwrap();
 
     assert!(!Exist::<(), LedgerIndex>::exist(storage, &()).unwrap());
-    assert!(storage.fetch_access::<(), LedgerIndex>(&()).unwrap().is_none());
+    assert!(storage.fetch::<(), LedgerIndex>(&()).unwrap().is_none());
 
     Insert::<(), LedgerIndex>::insert(storage, &(), &index).unwrap();
 

--- a/bee-storage/bee-storage-test/src/ledger_index.rs
+++ b/bee-storage/bee-storage-test/src/ledger_index.rs
@@ -73,7 +73,7 @@ pub fn ledger_index_access<B: StorageBackend>(storage: &B) {
 
     storage.insert::<(), LedgerIndex>(&(), &index).unwrap();
 
-    let iter = AsIterator::<(), LedgerIndex>::iter_op(storage).unwrap();
+    let iter = storage.iter::<(), LedgerIndex>().unwrap();
     let mut count = 0;
 
     for result in iter {
@@ -88,7 +88,7 @@ pub fn ledger_index_access<B: StorageBackend>(storage: &B) {
 
     assert!(!storage.exist::<(), LedgerIndex>(&()).unwrap());
 
-    let mut iter = AsIterator::<(), LedgerIndex>::iter_op(storage).unwrap();
+    let mut iter = storage.iter::<(), LedgerIndex>().unwrap();
 
     assert!(iter.next().is_none());
 }

--- a/bee-storage/bee-storage-test/src/ledger_index.rs
+++ b/bee-storage/bee-storage-test/src/ledger_index.rs
@@ -46,7 +46,7 @@ pub fn ledger_index_access<B: StorageBackend>(storage: &B) {
     assert!(Exist::<(), LedgerIndex>::exist_op(storage, &()).unwrap());
     assert_eq!(storage.fetch::<(), LedgerIndex>(&()).unwrap().unwrap(), index);
 
-    Delete::<(), LedgerIndex>::delete_op(storage, &()).unwrap();
+    storage.delete::<(), LedgerIndex>(&()).unwrap();
 
     assert!(!Exist::<(), LedgerIndex>::exist_op(storage, &()).unwrap());
     assert!(storage.fetch::<(), LedgerIndex>(&()).unwrap().is_none());

--- a/bee-storage/bee-storage-test/src/message_id_to_message.rs
+++ b/bee-storage/bee-storage-test/src/message_id_to_message.rs
@@ -69,7 +69,7 @@ pub fn message_id_to_message_access<B: StorageBackend>(storage: &B) {
     assert_eq!(results.len(), 1);
     assert!(matches!(results.get(0), Some(Ok(Some(v))) if v == &message));
 
-    Delete::<MessageId, Message>::delete_op(storage, &message_id).unwrap();
+    storage.delete::<MessageId, Message>(&message_id).unwrap();
 
     assert!(!Exist::<MessageId, Message>::exist_op(storage, &message_id).unwrap());
     assert!(storage.fetch::<MessageId, Message>(&message_id).unwrap().is_none());

--- a/bee-storage/bee-storage-test/src/message_id_to_message.rs
+++ b/bee-storage/bee-storage-test/src/message_id_to_message.rs
@@ -129,7 +129,7 @@ pub fn message_id_to_message_access<B: StorageBackend>(storage: &B) {
         assert_eq!(message, result.unwrap());
     }
 
-    Truncate::<MessageId, Message>::truncate_op(storage).unwrap();
+    storage.truncate::<MessageId, Message>().unwrap();
 
     let mut iter = storage.iter::<MessageId, Message>().unwrap();
 

--- a/bee-storage/bee-storage-test/src/message_id_to_message.rs
+++ b/bee-storage/bee-storage-test/src/message_id_to_message.rs
@@ -40,7 +40,7 @@ impl<T> StorageBackend for T where
 pub fn message_id_to_message_access<B: StorageBackend>(storage: &B) {
     let (message_id, message) = (rand_message_id(), rand_message());
 
-    assert!(!Exist::<MessageId, Message>::exist_op(storage, &message_id).unwrap());
+    assert!(!storage.exist::<MessageId, Message>(&message_id).unwrap());
     assert!(storage.fetch::<MessageId, Message>(&message_id).unwrap().is_none());
     let results = MultiFetch::<MessageId, Message>::multi_fetch_op(storage, &[message_id])
         .unwrap()
@@ -58,7 +58,7 @@ pub fn message_id_to_message_access<B: StorageBackend>(storage: &B) {
         "insert should overwrite"
     );
 
-    assert!(Exist::<MessageId, Message>::exist_op(storage, &message_id).unwrap());
+    assert!(storage.exist::<MessageId, Message>(&message_id).unwrap());
     assert_eq!(
         storage.fetch::<MessageId, Message>(&message_id).unwrap().unwrap(),
         message
@@ -71,7 +71,7 @@ pub fn message_id_to_message_access<B: StorageBackend>(storage: &B) {
 
     storage.delete::<MessageId, Message>(&message_id).unwrap();
 
-    assert!(!Exist::<MessageId, Message>::exist_op(storage, &message_id).unwrap());
+    assert!(!storage.exist::<MessageId, Message>(&message_id).unwrap());
     assert!(storage.fetch::<MessageId, Message>(&message_id).unwrap().is_none());
     let results = MultiFetch::<MessageId, Message>::multi_fetch_op(storage, &[message_id])
         .unwrap()

--- a/bee-storage/bee-storage-test/src/message_id_to_message.rs
+++ b/bee-storage/bee-storage-test/src/message_id_to_message.rs
@@ -5,6 +5,7 @@ use bee_message::{Message, MessageId};
 use bee_storage::{
     access::{AsIterator, Batch, BatchBuilder, Delete, Exist, Fetch, Insert, MultiFetch, Truncate},
     backend,
+    backend::StorageBackendExt,
 };
 use bee_test::rand::message::{rand_message, rand_message_id};
 
@@ -41,7 +42,8 @@ pub fn message_id_to_message_access<B: StorageBackend>(storage: &B) {
 
     assert!(!Exist::<MessageId, Message>::exist(storage, &message_id).unwrap());
     assert!(
-        Fetch::<MessageId, Message>::fetch(storage, &message_id)
+        storage
+            .fetch_access::<MessageId, Message>(&message_id)
             .unwrap()
             .is_none()
     );
@@ -56,7 +58,8 @@ pub fn message_id_to_message_access<B: StorageBackend>(storage: &B) {
     let message = rand_message();
     Insert::<MessageId, Message>::insert(storage, &message_id, &message).unwrap();
     assert_eq!(
-        Fetch::<MessageId, Message>::fetch(storage, &message_id)
+        storage
+            .fetch_access::<MessageId, Message>(&message_id)
             .unwrap()
             .as_ref(),
         Some(&message),
@@ -65,7 +68,8 @@ pub fn message_id_to_message_access<B: StorageBackend>(storage: &B) {
 
     assert!(Exist::<MessageId, Message>::exist(storage, &message_id).unwrap());
     assert_eq!(
-        Fetch::<MessageId, Message>::fetch(storage, &message_id)
+        storage
+            .fetch_access::<MessageId, Message>(&message_id)
             .unwrap()
             .unwrap(),
         message
@@ -80,7 +84,8 @@ pub fn message_id_to_message_access<B: StorageBackend>(storage: &B) {
 
     assert!(!Exist::<MessageId, Message>::exist(storage, &message_id).unwrap());
     assert!(
-        Fetch::<MessageId, Message>::fetch(storage, &message_id)
+        storage
+            .fetch_access::<MessageId, Message>(&message_id)
             .unwrap()
             .is_none()
     );

--- a/bee-storage/bee-storage-test/src/message_id_to_message.rs
+++ b/bee-storage/bee-storage-test/src/message_id_to_message.rs
@@ -42,7 +42,8 @@ pub fn message_id_to_message_access<B: StorageBackend>(storage: &B) {
 
     assert!(!storage.exist::<MessageId, Message>(&message_id).unwrap());
     assert!(storage.fetch::<MessageId, Message>(&message_id).unwrap().is_none());
-    let results = MultiFetch::<MessageId, Message>::multi_fetch_op(storage, &[message_id])
+    let results = storage
+        .multi_fetch::<MessageId, Message>(&[message_id])
         .unwrap()
         .collect::<Vec<_>>();
     assert_eq!(results.len(), 1);
@@ -63,7 +64,8 @@ pub fn message_id_to_message_access<B: StorageBackend>(storage: &B) {
         storage.fetch::<MessageId, Message>(&message_id).unwrap().unwrap(),
         message
     );
-    let results = MultiFetch::<MessageId, Message>::multi_fetch_op(storage, &[message_id])
+    let results = storage
+        .multi_fetch::<MessageId, Message>(&[message_id])
         .unwrap()
         .collect::<Vec<_>>();
     assert_eq!(results.len(), 1);
@@ -73,7 +75,8 @@ pub fn message_id_to_message_access<B: StorageBackend>(storage: &B) {
 
     assert!(!storage.exist::<MessageId, Message>(&message_id).unwrap());
     assert!(storage.fetch::<MessageId, Message>(&message_id).unwrap().is_none());
-    let results = MultiFetch::<MessageId, Message>::multi_fetch_op(storage, &[message_id])
+    let results = storage
+        .multi_fetch::<MessageId, Message>(&[message_id])
         .unwrap()
         .collect::<Vec<_>>();
     assert_eq!(results.len(), 1);
@@ -115,7 +118,8 @@ pub fn message_id_to_message_access<B: StorageBackend>(storage: &B) {
 
     assert_eq!(count, 10);
 
-    let results = MultiFetch::<MessageId, Message>::multi_fetch_op(storage, &message_ids)
+    let results = storage
+        .multi_fetch::<MessageId, Message>(&message_ids)
         .unwrap()
         .collect::<Vec<_>>();
 

--- a/bee-storage/bee-storage-test/src/message_id_to_message.rs
+++ b/bee-storage/bee-storage-test/src/message_id_to_message.rs
@@ -86,14 +86,18 @@ pub fn message_id_to_message_access<B: StorageBackend>(storage: &B) {
     for _ in 0..10 {
         let (message_id, message) = (rand_message_id(), rand_message());
         Insert::<MessageId, Message>::insert_op(storage, &message_id, &message).unwrap();
-        Batch::<MessageId, Message>::batch_delete_op(storage, &mut batch, &message_id).unwrap();
+        storage
+            .batch_delete::<MessageId, Message>(&mut batch, &message_id)
+            .unwrap();
         message_ids.push(message_id);
         messages.push((message_id, None));
     }
 
     for _ in 0..10 {
         let (message_id, message) = (rand_message_id(), rand_message());
-        Batch::<MessageId, Message>::batch_insert_op(storage, &mut batch, &message_id, &message).unwrap();
+        storage
+            .batch_insert::<MessageId, Message>(&mut batch, &message_id, &message)
+            .unwrap();
         message_ids.push(message_id);
         messages.push((message_id, Some(message)));
     }

--- a/bee-storage/bee-storage-test/src/message_id_to_message.rs
+++ b/bee-storage/bee-storage-test/src/message_id_to_message.rs
@@ -104,7 +104,7 @@ pub fn message_id_to_message_access<B: StorageBackend>(storage: &B) {
 
     storage.batch_commit(batch, true).unwrap();
 
-    let iter = AsIterator::<MessageId, Message>::iter_op(storage).unwrap();
+    let iter = storage.iter::<MessageId, Message>().unwrap();
     let mut count = 0;
 
     for result in iter {
@@ -127,7 +127,7 @@ pub fn message_id_to_message_access<B: StorageBackend>(storage: &B) {
 
     Truncate::<MessageId, Message>::truncate_op(storage).unwrap();
 
-    let mut iter = AsIterator::<MessageId, Message>::iter_op(storage).unwrap();
+    let mut iter = storage.iter::<MessageId, Message>().unwrap();
 
     assert!(iter.next().is_none());
 }

--- a/bee-storage/bee-storage-test/src/message_id_to_message.rs
+++ b/bee-storage/bee-storage-test/src/message_id_to_message.rs
@@ -49,10 +49,10 @@ pub fn message_id_to_message_access<B: StorageBackend>(storage: &B) {
     assert_eq!(results.len(), 1);
     assert!(matches!(results.get(0), Some(Ok(None))));
 
-    storage.insert::<MessageId, Message>(&message_id, &message).unwrap();
+    storage.insert(&message_id, &message).unwrap();
 
     let message = rand_message();
-    storage.insert::<MessageId, Message>(&message_id, &message).unwrap();
+    storage.insert(&message_id, &message).unwrap();
     assert_eq!(
         storage.fetch::<MessageId, Message>(&message_id).unwrap().as_ref(),
         Some(&message),
@@ -88,7 +88,7 @@ pub fn message_id_to_message_access<B: StorageBackend>(storage: &B) {
 
     for _ in 0..10 {
         let (message_id, message) = (rand_message_id(), rand_message());
-        storage.insert::<MessageId, Message>(&message_id, &message).unwrap();
+        storage.insert(&message_id, &message).unwrap();
         storage
             .batch_delete::<MessageId, Message>(&mut batch, &message_id)
             .unwrap();
@@ -98,9 +98,7 @@ pub fn message_id_to_message_access<B: StorageBackend>(storage: &B) {
 
     for _ in 0..10 {
         let (message_id, message) = (rand_message_id(), rand_message());
-        storage
-            .batch_insert::<MessageId, Message>(&mut batch, &message_id, &message)
-            .unwrap();
+        storage.batch_insert(&mut batch, &message_id, &message).unwrap();
         message_ids.push(message_id);
         messages.push((message_id, Some(message)));
     }

--- a/bee-storage/bee-storage-test/src/message_id_to_message.rs
+++ b/bee-storage/bee-storage-test/src/message_id_to_message.rs
@@ -41,12 +41,7 @@ pub fn message_id_to_message_access<B: StorageBackend>(storage: &B) {
     let (message_id, message) = (rand_message_id(), rand_message());
 
     assert!(!Exist::<MessageId, Message>::exist(storage, &message_id).unwrap());
-    assert!(
-        storage
-            .fetch_access::<MessageId, Message>(&message_id)
-            .unwrap()
-            .is_none()
-    );
+    assert!(storage.fetch::<MessageId, Message>(&message_id).unwrap().is_none());
     let results = MultiFetch::<MessageId, Message>::multi_fetch(storage, &[message_id])
         .unwrap()
         .collect::<Vec<_>>();
@@ -58,20 +53,14 @@ pub fn message_id_to_message_access<B: StorageBackend>(storage: &B) {
     let message = rand_message();
     Insert::<MessageId, Message>::insert(storage, &message_id, &message).unwrap();
     assert_eq!(
-        storage
-            .fetch_access::<MessageId, Message>(&message_id)
-            .unwrap()
-            .as_ref(),
+        storage.fetch::<MessageId, Message>(&message_id).unwrap().as_ref(),
         Some(&message),
         "insert should overwrite"
     );
 
     assert!(Exist::<MessageId, Message>::exist(storage, &message_id).unwrap());
     assert_eq!(
-        storage
-            .fetch_access::<MessageId, Message>(&message_id)
-            .unwrap()
-            .unwrap(),
+        storage.fetch::<MessageId, Message>(&message_id).unwrap().unwrap(),
         message
     );
     let results = MultiFetch::<MessageId, Message>::multi_fetch(storage, &[message_id])
@@ -83,12 +72,7 @@ pub fn message_id_to_message_access<B: StorageBackend>(storage: &B) {
     Delete::<MessageId, Message>::delete(storage, &message_id).unwrap();
 
     assert!(!Exist::<MessageId, Message>::exist(storage, &message_id).unwrap());
-    assert!(
-        storage
-            .fetch_access::<MessageId, Message>(&message_id)
-            .unwrap()
-            .is_none()
-    );
+    assert!(storage.fetch::<MessageId, Message>(&message_id).unwrap().is_none());
     let results = MultiFetch::<MessageId, Message>::multi_fetch(storage, &[message_id])
         .unwrap()
         .collect::<Vec<_>>();

--- a/bee-storage/bee-storage-test/src/message_id_to_message.rs
+++ b/bee-storage/bee-storage-test/src/message_id_to_message.rs
@@ -48,10 +48,10 @@ pub fn message_id_to_message_access<B: StorageBackend>(storage: &B) {
     assert_eq!(results.len(), 1);
     assert!(matches!(results.get(0), Some(Ok(None))));
 
-    Insert::<MessageId, Message>::insert_op(storage, &message_id, &message).unwrap();
+    storage.insert::<MessageId, Message>(&message_id, &message).unwrap();
 
     let message = rand_message();
-    Insert::<MessageId, Message>::insert_op(storage, &message_id, &message).unwrap();
+    storage.insert::<MessageId, Message>(&message_id, &message).unwrap();
     assert_eq!(
         storage.fetch::<MessageId, Message>(&message_id).unwrap().as_ref(),
         Some(&message),
@@ -85,7 +85,7 @@ pub fn message_id_to_message_access<B: StorageBackend>(storage: &B) {
 
     for _ in 0..10 {
         let (message_id, message) = (rand_message_id(), rand_message());
-        Insert::<MessageId, Message>::insert_op(storage, &message_id, &message).unwrap();
+        storage.insert::<MessageId, Message>(&message_id, &message).unwrap();
         storage
             .batch_delete::<MessageId, Message>(&mut batch, &message_id)
             .unwrap();

--- a/bee-storage/bee-storage-test/src/message_id_to_message_id.rs
+++ b/bee-storage/bee-storage-test/src/message_id_to_message_id.rs
@@ -57,7 +57,7 @@ pub fn message_id_to_message_id_access<B: StorageBackend>(storage: &B) {
         vec![child]
     );
 
-    Delete::<(MessageId, MessageId), ()>::delete_op(storage, &(parent, child)).unwrap();
+    storage.delete::<(MessageId, MessageId), ()>(&(parent, child)).unwrap();
 
     assert!(!Exist::<(MessageId, MessageId), ()>::exist_op(storage, &(parent, child)).unwrap());
     assert!(

--- a/bee-storage/bee-storage-test/src/message_id_to_message_id.rs
+++ b/bee-storage/bee-storage-test/src/message_id_to_message_id.rs
@@ -108,7 +108,7 @@ pub fn message_id_to_message_id_access<B: StorageBackend>(storage: &B) {
 
     assert_eq!(count, edges.iter().fold(0, |acc, v| acc + v.1.len()));
 
-    Truncate::<(MessageId, MessageId), ()>::truncate_op(storage).unwrap();
+    storage.truncate::<(MessageId, MessageId), ()>().unwrap();
 
     let mut iter = storage.iter::<(MessageId, MessageId), ()>().unwrap();
 

--- a/bee-storage/bee-storage-test/src/message_id_to_message_id.rs
+++ b/bee-storage/bee-storage-test/src/message_id_to_message_id.rs
@@ -49,9 +49,7 @@ pub fn message_id_to_message_id_access<B: StorageBackend>(storage: &B) {
             .is_empty()
     );
 
-    storage
-        .insert::<(MessageId, MessageId), ()>(&(parent, child), &())
-        .unwrap();
+    storage.insert(&(parent, child), &()).unwrap();
 
     assert!(storage.exist::<(MessageId, MessageId), ()>(&(parent, child)).unwrap());
     assert_eq!(
@@ -74,9 +72,7 @@ pub fn message_id_to_message_id_access<B: StorageBackend>(storage: &B) {
 
     for _ in 0..10 {
         let (parent, child) = (rand_message_id(), rand_message_id());
-        storage
-            .insert::<(MessageId, MessageId), ()>(&(parent, child), &())
-            .unwrap();
+        storage.insert(&(parent, child), &()).unwrap();
         storage
             .batch_delete::<(MessageId, MessageId), ()>(&mut batch, &(parent, child))
             .unwrap();
@@ -88,9 +84,7 @@ pub fn message_id_to_message_id_access<B: StorageBackend>(storage: &B) {
         let parent = rand_message_id();
         for _ in 0..5 {
             let child = rand_message_id();
-            storage
-                .batch_insert::<(MessageId, MessageId), ()>(&mut batch, &(parent, child), &())
-                .unwrap();
+            storage.batch_insert(&mut batch, &(parent, child), &()).unwrap();
             edges.entry(parent).or_default().push(child);
         }
     }

--- a/bee-storage/bee-storage-test/src/message_id_to_message_id.rs
+++ b/bee-storage/bee-storage-test/src/message_id_to_message_id.rs
@@ -73,7 +73,9 @@ pub fn message_id_to_message_id_access<B: StorageBackend>(storage: &B) {
     for _ in 0..10 {
         let (parent, child) = (rand_message_id(), rand_message_id());
         Insert::<(MessageId, MessageId), ()>::insert_op(storage, &(parent, child), &()).unwrap();
-        Batch::<(MessageId, MessageId), ()>::batch_delete_op(storage, &mut batch, &(parent, child)).unwrap();
+        storage
+            .batch_delete::<(MessageId, MessageId), ()>(&mut batch, &(parent, child))
+            .unwrap();
     }
 
     let mut edges = HashMap::<MessageId, Vec<MessageId>>::new();
@@ -82,7 +84,9 @@ pub fn message_id_to_message_id_access<B: StorageBackend>(storage: &B) {
         let parent = rand_message_id();
         for _ in 0..5 {
             let child = rand_message_id();
-            Batch::<(MessageId, MessageId), ()>::batch_insert_op(storage, &mut batch, &(parent, child), &()).unwrap();
+            storage
+                .batch_insert::<(MessageId, MessageId), ()>(&mut batch, &(parent, child), &())
+                .unwrap();
             edges.entry(parent).or_default().push(child);
         }
     }

--- a/bee-storage/bee-storage-test/src/message_id_to_message_id.rs
+++ b/bee-storage/bee-storage-test/src/message_id_to_message_id.rs
@@ -43,7 +43,7 @@ pub fn message_id_to_message_id_access<B: StorageBackend>(storage: &B) {
     assert!(!Exist::<(MessageId, MessageId), ()>::exist(storage, &(parent, child)).unwrap());
     assert!(
         storage
-            .fetch_access::<MessageId, Vec<MessageId>>(&parent)
+            .fetch::<MessageId, Vec<MessageId>>(&parent)
             .unwrap()
             .unwrap()
             .is_empty()
@@ -53,10 +53,7 @@ pub fn message_id_to_message_id_access<B: StorageBackend>(storage: &B) {
 
     assert!(Exist::<(MessageId, MessageId), ()>::exist(storage, &(parent, child)).unwrap());
     assert_eq!(
-        storage
-            .fetch_access::<MessageId, Vec<MessageId>>(&parent)
-            .unwrap()
-            .unwrap(),
+        storage.fetch::<MessageId, Vec<MessageId>>(&parent).unwrap().unwrap(),
         vec![child]
     );
 
@@ -65,7 +62,7 @@ pub fn message_id_to_message_id_access<B: StorageBackend>(storage: &B) {
     assert!(!Exist::<(MessageId, MessageId), ()>::exist(storage, &(parent, child)).unwrap());
     assert!(
         storage
-            .fetch_access::<MessageId, Vec<MessageId>>(&parent)
+            .fetch::<MessageId, Vec<MessageId>>(&parent)
             .unwrap()
             .unwrap()
             .is_empty()

--- a/bee-storage/bee-storage-test/src/message_id_to_message_id.rs
+++ b/bee-storage/bee-storage-test/src/message_id_to_message_id.rs
@@ -7,6 +7,7 @@ use bee_message::MessageId;
 use bee_storage::{
     access::{AsIterator, Batch, BatchBuilder, Delete, Exist, Fetch, Insert, Truncate},
     backend,
+    backend::StorageBackendExt,
 };
 use bee_test::rand::message::rand_message_id;
 
@@ -41,7 +42,8 @@ pub fn message_id_to_message_id_access<B: StorageBackend>(storage: &B) {
 
     assert!(!Exist::<(MessageId, MessageId), ()>::exist(storage, &(parent, child)).unwrap());
     assert!(
-        Fetch::<MessageId, Vec<MessageId>>::fetch(storage, &parent)
+        storage
+            .fetch_access::<MessageId, Vec<MessageId>>(&parent)
             .unwrap()
             .unwrap()
             .is_empty()
@@ -51,7 +53,8 @@ pub fn message_id_to_message_id_access<B: StorageBackend>(storage: &B) {
 
     assert!(Exist::<(MessageId, MessageId), ()>::exist(storage, &(parent, child)).unwrap());
     assert_eq!(
-        Fetch::<MessageId, Vec<MessageId>>::fetch(storage, &parent)
+        storage
+            .fetch_access::<MessageId, Vec<MessageId>>(&parent)
             .unwrap()
             .unwrap(),
         vec![child]
@@ -61,7 +64,8 @@ pub fn message_id_to_message_id_access<B: StorageBackend>(storage: &B) {
 
     assert!(!Exist::<(MessageId, MessageId), ()>::exist(storage, &(parent, child)).unwrap());
     assert!(
-        Fetch::<MessageId, Vec<MessageId>>::fetch(storage, &parent)
+        storage
+            .fetch_access::<MessageId, Vec<MessageId>>(&parent)
             .unwrap()
             .unwrap()
             .is_empty()

--- a/bee-storage/bee-storage-test/src/message_id_to_message_id.rs
+++ b/bee-storage/bee-storage-test/src/message_id_to_message_id.rs
@@ -49,7 +49,9 @@ pub fn message_id_to_message_id_access<B: StorageBackend>(storage: &B) {
             .is_empty()
     );
 
-    Insert::<(MessageId, MessageId), ()>::insert_op(storage, &(parent, child), &()).unwrap();
+    storage
+        .insert::<(MessageId, MessageId), ()>(&(parent, child), &())
+        .unwrap();
 
     assert!(storage.exist::<(MessageId, MessageId), ()>(&(parent, child)).unwrap());
     assert_eq!(
@@ -72,7 +74,9 @@ pub fn message_id_to_message_id_access<B: StorageBackend>(storage: &B) {
 
     for _ in 0..10 {
         let (parent, child) = (rand_message_id(), rand_message_id());
-        Insert::<(MessageId, MessageId), ()>::insert_op(storage, &(parent, child), &()).unwrap();
+        storage
+            .insert::<(MessageId, MessageId), ()>(&(parent, child), &())
+            .unwrap();
         storage
             .batch_delete::<(MessageId, MessageId), ()>(&mut batch, &(parent, child))
             .unwrap();

--- a/bee-storage/bee-storage-test/src/message_id_to_message_id.rs
+++ b/bee-storage/bee-storage-test/src/message_id_to_message_id.rs
@@ -97,7 +97,7 @@ pub fn message_id_to_message_id_access<B: StorageBackend>(storage: &B) {
 
     storage.batch_commit(batch, true).unwrap();
 
-    let iter = AsIterator::<(MessageId, MessageId), ()>::iter_op(storage).unwrap();
+    let iter = storage.iter::<(MessageId, MessageId), ()>().unwrap();
     let mut count = 0;
 
     for result in iter {
@@ -110,7 +110,7 @@ pub fn message_id_to_message_id_access<B: StorageBackend>(storage: &B) {
 
     Truncate::<(MessageId, MessageId), ()>::truncate_op(storage).unwrap();
 
-    let mut iter = AsIterator::<(MessageId, MessageId), ()>::iter_op(storage).unwrap();
+    let mut iter = storage.iter::<(MessageId, MessageId), ()>().unwrap();
 
     assert!(iter.next().is_none());
 }

--- a/bee-storage/bee-storage-test/src/message_id_to_message_id.rs
+++ b/bee-storage/bee-storage-test/src/message_id_to_message_id.rs
@@ -40,7 +40,7 @@ impl<T> StorageBackend for T where
 pub fn message_id_to_message_id_access<B: StorageBackend>(storage: &B) {
     let (parent, child) = (rand_message_id(), rand_message_id());
 
-    assert!(!Exist::<(MessageId, MessageId), ()>::exist_op(storage, &(parent, child)).unwrap());
+    assert!(!storage.exist::<(MessageId, MessageId), ()>(&(parent, child)).unwrap());
     assert!(
         storage
             .fetch::<MessageId, Vec<MessageId>>(&parent)
@@ -51,7 +51,7 @@ pub fn message_id_to_message_id_access<B: StorageBackend>(storage: &B) {
 
     Insert::<(MessageId, MessageId), ()>::insert_op(storage, &(parent, child), &()).unwrap();
 
-    assert!(Exist::<(MessageId, MessageId), ()>::exist_op(storage, &(parent, child)).unwrap());
+    assert!(storage.exist::<(MessageId, MessageId), ()>(&(parent, child)).unwrap());
     assert_eq!(
         storage.fetch::<MessageId, Vec<MessageId>>(&parent).unwrap().unwrap(),
         vec![child]
@@ -59,7 +59,7 @@ pub fn message_id_to_message_id_access<B: StorageBackend>(storage: &B) {
 
     storage.delete::<(MessageId, MessageId), ()>(&(parent, child)).unwrap();
 
-    assert!(!Exist::<(MessageId, MessageId), ()>::exist_op(storage, &(parent, child)).unwrap());
+    assert!(!storage.exist::<(MessageId, MessageId), ()>(&(parent, child)).unwrap());
     assert!(
         storage
             .fetch::<MessageId, Vec<MessageId>>(&parent)

--- a/bee-storage/bee-storage-test/src/message_id_to_message_id.rs
+++ b/bee-storage/bee-storage-test/src/message_id_to_message_id.rs
@@ -40,7 +40,7 @@ impl<T> StorageBackend for T where
 pub fn message_id_to_message_id_access<B: StorageBackend>(storage: &B) {
     let (parent, child) = (rand_message_id(), rand_message_id());
 
-    assert!(!Exist::<(MessageId, MessageId), ()>::exist(storage, &(parent, child)).unwrap());
+    assert!(!Exist::<(MessageId, MessageId), ()>::exist_op(storage, &(parent, child)).unwrap());
     assert!(
         storage
             .fetch::<MessageId, Vec<MessageId>>(&parent)
@@ -49,17 +49,17 @@ pub fn message_id_to_message_id_access<B: StorageBackend>(storage: &B) {
             .is_empty()
     );
 
-    Insert::<(MessageId, MessageId), ()>::insert(storage, &(parent, child), &()).unwrap();
+    Insert::<(MessageId, MessageId), ()>::insert_op(storage, &(parent, child), &()).unwrap();
 
-    assert!(Exist::<(MessageId, MessageId), ()>::exist(storage, &(parent, child)).unwrap());
+    assert!(Exist::<(MessageId, MessageId), ()>::exist_op(storage, &(parent, child)).unwrap());
     assert_eq!(
         storage.fetch::<MessageId, Vec<MessageId>>(&parent).unwrap().unwrap(),
         vec![child]
     );
 
-    Delete::<(MessageId, MessageId), ()>::delete(storage, &(parent, child)).unwrap();
+    Delete::<(MessageId, MessageId), ()>::delete_op(storage, &(parent, child)).unwrap();
 
-    assert!(!Exist::<(MessageId, MessageId), ()>::exist(storage, &(parent, child)).unwrap());
+    assert!(!Exist::<(MessageId, MessageId), ()>::exist_op(storage, &(parent, child)).unwrap());
     assert!(
         storage
             .fetch::<MessageId, Vec<MessageId>>(&parent)
@@ -72,8 +72,8 @@ pub fn message_id_to_message_id_access<B: StorageBackend>(storage: &B) {
 
     for _ in 0..10 {
         let (parent, child) = (rand_message_id(), rand_message_id());
-        Insert::<(MessageId, MessageId), ()>::insert(storage, &(parent, child), &()).unwrap();
-        Batch::<(MessageId, MessageId), ()>::batch_delete(storage, &mut batch, &(parent, child)).unwrap();
+        Insert::<(MessageId, MessageId), ()>::insert_op(storage, &(parent, child), &()).unwrap();
+        Batch::<(MessageId, MessageId), ()>::batch_delete_op(storage, &mut batch, &(parent, child)).unwrap();
     }
 
     let mut edges = HashMap::<MessageId, Vec<MessageId>>::new();
@@ -82,14 +82,14 @@ pub fn message_id_to_message_id_access<B: StorageBackend>(storage: &B) {
         let parent = rand_message_id();
         for _ in 0..5 {
             let child = rand_message_id();
-            Batch::<(MessageId, MessageId), ()>::batch_insert(storage, &mut batch, &(parent, child), &()).unwrap();
+            Batch::<(MessageId, MessageId), ()>::batch_insert_op(storage, &mut batch, &(parent, child), &()).unwrap();
             edges.entry(parent).or_default().push(child);
         }
     }
 
     storage.batch_commit(batch, true).unwrap();
 
-    let iter = AsIterator::<(MessageId, MessageId), ()>::iter(storage).unwrap();
+    let iter = AsIterator::<(MessageId, MessageId), ()>::iter_op(storage).unwrap();
     let mut count = 0;
 
     for result in iter {
@@ -100,9 +100,9 @@ pub fn message_id_to_message_id_access<B: StorageBackend>(storage: &B) {
 
     assert_eq!(count, edges.iter().fold(0, |acc, v| acc + v.1.len()));
 
-    Truncate::<(MessageId, MessageId), ()>::truncate(storage).unwrap();
+    Truncate::<(MessageId, MessageId), ()>::truncate_op(storage).unwrap();
 
-    let mut iter = AsIterator::<(MessageId, MessageId), ()>::iter(storage).unwrap();
+    let mut iter = AsIterator::<(MessageId, MessageId), ()>::iter_op(storage).unwrap();
 
     assert!(iter.next().is_none());
 }

--- a/bee-storage/bee-storage-test/src/message_id_to_metadata.rs
+++ b/bee-storage/bee-storage-test/src/message_id_to_metadata.rs
@@ -50,7 +50,8 @@ pub fn message_id_to_metadata_access<B: StorageBackend>(storage: &B) {
             .unwrap()
             .is_none()
     );
-    let results = MultiFetch::<MessageId, MessageMetadata>::multi_fetch_op(storage, &[message_id])
+    let results = storage
+        .multi_fetch::<MessageId, MessageMetadata>(&[message_id])
         .unwrap()
         .collect::<Vec<_>>();
     assert_eq!(results.len(), 1);
@@ -81,7 +82,8 @@ pub fn message_id_to_metadata_access<B: StorageBackend>(storage: &B) {
         "`InsertStrict` should not overwrite"
     );
 
-    let results = MultiFetch::<MessageId, MessageMetadata>::multi_fetch_op(storage, &[message_id])
+    let results = storage
+        .multi_fetch::<MessageId, MessageMetadata>(&[message_id])
         .unwrap()
         .collect::<Vec<_>>();
     assert_eq!(results.len(), 1);
@@ -121,7 +123,8 @@ pub fn message_id_to_metadata_access<B: StorageBackend>(storage: &B) {
             .is_none()
     );
 
-    let results = MultiFetch::<MessageId, MessageMetadata>::multi_fetch_op(storage, &[message_id])
+    let results = storage
+        .multi_fetch::<MessageId, MessageMetadata>(&[message_id])
         .unwrap()
         .collect::<Vec<_>>();
     assert_eq!(results.len(), 1);
@@ -165,7 +168,8 @@ pub fn message_id_to_metadata_access<B: StorageBackend>(storage: &B) {
 
     assert_eq!(count, 10);
 
-    let results = MultiFetch::<MessageId, MessageMetadata>::multi_fetch_op(storage, &message_ids)
+    let results = storage
+        .multi_fetch::<MessageId, MessageMetadata>(&message_ids)
         .unwrap()
         .collect::<Vec<_>>();
 

--- a/bee-storage/bee-storage-test/src/message_id_to_metadata.rs
+++ b/bee-storage/bee-storage-test/src/message_id_to_metadata.rs
@@ -99,10 +99,11 @@ pub fn message_id_to_metadata_access<B: StorageBackend>(storage: &B) {
         MilestoneIndex(index.map_or(0, |i| i.wrapping_add(1)))
     };
 
-    Update::<MessageId, MessageMetadata>::update_op(storage, &message_id, |metadata: &mut MessageMetadata| {
-        metadata.set_milestone_index(milestone_index);
-    })
-    .unwrap();
+    storage
+        .update::<MessageId, MessageMetadata, _>(&message_id, |metadata: &mut MessageMetadata| {
+            metadata.set_milestone_index(milestone_index);
+        })
+        .unwrap();
 
     assert_eq!(
         storage

--- a/bee-storage/bee-storage-test/src/message_id_to_metadata.rs
+++ b/bee-storage/bee-storage-test/src/message_id_to_metadata.rs
@@ -44,12 +44,10 @@ pub fn message_id_to_metadata_access<B: StorageBackend>(storage: &B) {
     let (message_id, metadata) = (rand_message_id(), rand_message_metadata());
 
     assert!(!storage.exist::<MessageId, MessageMetadata>(&message_id).unwrap());
-    assert!(
-        storage
-            .fetch::<MessageId, MessageMetadata>(&message_id)
-            .unwrap()
-            .is_none()
-    );
+    assert!(storage
+        .fetch::<MessageId, MessageMetadata>(&message_id)
+        .unwrap()
+        .is_none());
     let results = storage
         .multi_fetch::<MessageId, MessageMetadata>(&[message_id])
         .unwrap()
@@ -57,9 +55,7 @@ pub fn message_id_to_metadata_access<B: StorageBackend>(storage: &B) {
     assert_eq!(results.len(), 1);
     assert!(matches!(results.get(0), Some(Ok(None))));
 
-    storage
-        .insert_strict::<MessageId, MessageMetadata>(&message_id, &metadata)
-        .unwrap();
+    storage.insert_strict(&message_id, &metadata).unwrap();
     assert!(storage.exist::<MessageId, MessageMetadata>(&message_id).unwrap());
 
     // calling `insert_strict` with the same `MessageId` but a different `MessageMetadata` should
@@ -69,9 +65,7 @@ pub fn message_id_to_metadata_access<B: StorageBackend>(storage: &B) {
         let mut metadata = metadata.clone();
         metadata.set_milestone_index(MilestoneIndex(index));
 
-        storage
-            .insert_strict::<MessageId, MessageMetadata>(&message_id, &metadata)
-            .unwrap();
+        storage.insert_strict(&message_id, &metadata).unwrap();
     }
     assert_eq!(
         storage
@@ -100,8 +94,8 @@ pub fn message_id_to_metadata_access<B: StorageBackend>(storage: &B) {
     };
 
     storage
-        .update::<MessageId, MessageMetadata, _>(&message_id, |metadata: &mut MessageMetadata| {
-            metadata.set_milestone_index(milestone_index);
+        .update(&message_id, |metadata: &mut MessageMetadata| {
+            metadata.set_milestone_index(milestone_index)
         })
         .unwrap();
 
@@ -117,12 +111,10 @@ pub fn message_id_to_metadata_access<B: StorageBackend>(storage: &B) {
     storage.delete::<MessageId, MessageMetadata>(&message_id).unwrap();
 
     assert!(!storage.exist::<MessageId, MessageMetadata>(&message_id).unwrap());
-    assert!(
-        storage
-            .fetch::<MessageId, MessageMetadata>(&message_id)
-            .unwrap()
-            .is_none()
-    );
+    assert!(storage
+        .fetch::<MessageId, MessageMetadata>(&message_id)
+        .unwrap()
+        .is_none());
 
     let results = storage
         .multi_fetch::<MessageId, MessageMetadata>(&[message_id])
@@ -137,9 +129,7 @@ pub fn message_id_to_metadata_access<B: StorageBackend>(storage: &B) {
 
     for _ in 0..10 {
         let (message_id, metadata) = (rand_message_id(), rand_message_metadata());
-        storage
-            .insert_strict::<MessageId, MessageMetadata>(&message_id, &metadata)
-            .unwrap();
+        storage.insert_strict(&message_id, &metadata).unwrap();
         storage
             .batch_delete::<MessageId, MessageMetadata>(&mut batch, &message_id)
             .unwrap();
@@ -149,9 +139,7 @@ pub fn message_id_to_metadata_access<B: StorageBackend>(storage: &B) {
 
     for _ in 0..10 {
         let (message_id, metadata) = (rand_message_id(), rand_message_metadata());
-        storage
-            .batch_insert::<MessageId, MessageMetadata>(&mut batch, &message_id, &metadata)
-            .unwrap();
+        storage.batch_insert(&mut batch, &message_id, &metadata).unwrap();
         message_ids.push(message_id);
         metadatas.push((message_id, Some(metadata)));
     }

--- a/bee-storage/bee-storage-test/src/message_id_to_metadata.rs
+++ b/bee-storage/bee-storage-test/src/message_id_to_metadata.rs
@@ -130,14 +130,18 @@ pub fn message_id_to_metadata_access<B: StorageBackend>(storage: &B) {
     for _ in 0..10 {
         let (message_id, metadata) = (rand_message_id(), rand_message_metadata());
         InsertStrict::<MessageId, MessageMetadata>::insert_strict_op(storage, &message_id, &metadata).unwrap();
-        Batch::<MessageId, MessageMetadata>::batch_delete_op(storage, &mut batch, &message_id).unwrap();
+        storage
+            .batch_delete::<MessageId, MessageMetadata>(&mut batch, &message_id)
+            .unwrap();
         message_ids.push(message_id);
         metadatas.push((message_id, None));
     }
 
     for _ in 0..10 {
         let (message_id, metadata) = (rand_message_id(), rand_message_metadata());
-        Batch::<MessageId, MessageMetadata>::batch_insert_op(storage, &mut batch, &message_id, &metadata).unwrap();
+        storage
+            .batch_insert::<MessageId, MessageMetadata>(&mut batch, &message_id, &metadata)
+            .unwrap();
         message_ids.push(message_id);
         metadatas.push((message_id, Some(metadata)));
     }

--- a/bee-storage/bee-storage-test/src/message_id_to_metadata.rs
+++ b/bee-storage/bee-storage-test/src/message_id_to_metadata.rs
@@ -107,7 +107,7 @@ pub fn message_id_to_metadata_access<B: StorageBackend>(storage: &B) {
         Some(milestone_index),
     );
 
-    Delete::<MessageId, MessageMetadata>::delete_op(storage, &message_id).unwrap();
+    storage.delete::<MessageId, MessageMetadata>(&message_id).unwrap();
 
     assert!(!Exist::<MessageId, MessageMetadata>::exist_op(storage, &message_id).unwrap());
     assert!(

--- a/bee-storage/bee-storage-test/src/message_id_to_metadata.rs
+++ b/bee-storage/bee-storage-test/src/message_id_to_metadata.rs
@@ -5,6 +5,7 @@ use bee_message::{prelude::MilestoneIndex, MessageId};
 use bee_storage::{
     access::{AsIterator, Batch, BatchBuilder, Delete, Exist, Fetch, InsertStrict, MultiFetch, Truncate, Update},
     backend,
+    backend::StorageBackendExt,
 };
 use bee_tangle::metadata::MessageMetadata;
 use bee_test::rand::{message::rand_message_id, metadata::rand_message_metadata};
@@ -44,7 +45,8 @@ pub fn message_id_to_metadata_access<B: StorageBackend>(storage: &B) {
 
     assert!(!Exist::<MessageId, MessageMetadata>::exist(storage, &message_id).unwrap());
     assert!(
-        Fetch::<MessageId, MessageMetadata>::fetch(storage, &message_id)
+        storage
+            .fetch_access::<MessageId, MessageMetadata>(&message_id)
             .unwrap()
             .is_none()
     );
@@ -67,7 +69,8 @@ pub fn message_id_to_metadata_access<B: StorageBackend>(storage: &B) {
         InsertStrict::<MessageId, MessageMetadata>::insert_strict(storage, &message_id, &metadata).unwrap();
     }
     assert_eq!(
-        Fetch::<MessageId, MessageMetadata>::fetch(storage, &message_id)
+        storage
+            .fetch_access::<MessageId, MessageMetadata>(&message_id)
             .unwrap()
             .unwrap(),
         metadata,
@@ -81,7 +84,8 @@ pub fn message_id_to_metadata_access<B: StorageBackend>(storage: &B) {
     assert!(matches!(results.get(0), Some(Ok(Some(v))) if v == &metadata));
 
     let milestone_index = {
-        let index = Fetch::<MessageId, MessageMetadata>::fetch(storage, &message_id)
+        let index = storage
+            .fetch_access::<MessageId, MessageMetadata>(&message_id)
             .unwrap()
             .unwrap()
             .milestone_index();
@@ -95,7 +99,8 @@ pub fn message_id_to_metadata_access<B: StorageBackend>(storage: &B) {
     .unwrap();
 
     assert_eq!(
-        Fetch::<MessageId, MessageMetadata>::fetch(storage, &message_id)
+        storage
+            .fetch_access::<MessageId, MessageMetadata>(&message_id)
             .unwrap()
             .unwrap()
             .milestone_index(),
@@ -106,7 +111,8 @@ pub fn message_id_to_metadata_access<B: StorageBackend>(storage: &B) {
 
     assert!(!Exist::<MessageId, MessageMetadata>::exist(storage, &message_id).unwrap());
     assert!(
-        Fetch::<MessageId, MessageMetadata>::fetch(storage, &message_id)
+        storage
+            .fetch_access::<MessageId, MessageMetadata>(&message_id)
             .unwrap()
             .is_none()
     );

--- a/bee-storage/bee-storage-test/src/message_id_to_metadata.rs
+++ b/bee-storage/bee-storage-test/src/message_id_to_metadata.rs
@@ -44,10 +44,12 @@ pub fn message_id_to_metadata_access<B: StorageBackend>(storage: &B) {
     let (message_id, metadata) = (rand_message_id(), rand_message_metadata());
 
     assert!(!storage.exist::<MessageId, MessageMetadata>(&message_id).unwrap());
-    assert!(storage
-        .fetch::<MessageId, MessageMetadata>(&message_id)
-        .unwrap()
-        .is_none());
+    assert!(
+        storage
+            .fetch::<MessageId, MessageMetadata>(&message_id)
+            .unwrap()
+            .is_none()
+    );
     let results = storage
         .multi_fetch::<MessageId, MessageMetadata>(&[message_id])
         .unwrap()
@@ -111,10 +113,12 @@ pub fn message_id_to_metadata_access<B: StorageBackend>(storage: &B) {
     storage.delete::<MessageId, MessageMetadata>(&message_id).unwrap();
 
     assert!(!storage.exist::<MessageId, MessageMetadata>(&message_id).unwrap());
-    assert!(storage
-        .fetch::<MessageId, MessageMetadata>(&message_id)
-        .unwrap()
-        .is_none());
+    assert!(
+        storage
+            .fetch::<MessageId, MessageMetadata>(&message_id)
+            .unwrap()
+            .is_none()
+    );
 
     let results = storage
         .multi_fetch::<MessageId, MessageMetadata>(&[message_id])

--- a/bee-storage/bee-storage-test/src/message_id_to_metadata.rs
+++ b/bee-storage/bee-storage-test/src/message_id_to_metadata.rs
@@ -46,7 +46,7 @@ pub fn message_id_to_metadata_access<B: StorageBackend>(storage: &B) {
     assert!(!Exist::<MessageId, MessageMetadata>::exist(storage, &message_id).unwrap());
     assert!(
         storage
-            .fetch_access::<MessageId, MessageMetadata>(&message_id)
+            .fetch::<MessageId, MessageMetadata>(&message_id)
             .unwrap()
             .is_none()
     );
@@ -70,7 +70,7 @@ pub fn message_id_to_metadata_access<B: StorageBackend>(storage: &B) {
     }
     assert_eq!(
         storage
-            .fetch_access::<MessageId, MessageMetadata>(&message_id)
+            .fetch::<MessageId, MessageMetadata>(&message_id)
             .unwrap()
             .unwrap(),
         metadata,
@@ -85,7 +85,7 @@ pub fn message_id_to_metadata_access<B: StorageBackend>(storage: &B) {
 
     let milestone_index = {
         let index = storage
-            .fetch_access::<MessageId, MessageMetadata>(&message_id)
+            .fetch::<MessageId, MessageMetadata>(&message_id)
             .unwrap()
             .unwrap()
             .milestone_index();
@@ -100,7 +100,7 @@ pub fn message_id_to_metadata_access<B: StorageBackend>(storage: &B) {
 
     assert_eq!(
         storage
-            .fetch_access::<MessageId, MessageMetadata>(&message_id)
+            .fetch::<MessageId, MessageMetadata>(&message_id)
             .unwrap()
             .unwrap()
             .milestone_index(),
@@ -112,7 +112,7 @@ pub fn message_id_to_metadata_access<B: StorageBackend>(storage: &B) {
     assert!(!Exist::<MessageId, MessageMetadata>::exist(storage, &message_id).unwrap());
     assert!(
         storage
-            .fetch_access::<MessageId, MessageMetadata>(&message_id)
+            .fetch::<MessageId, MessageMetadata>(&message_id)
             .unwrap()
             .is_none()
     );

--- a/bee-storage/bee-storage-test/src/message_id_to_metadata.rs
+++ b/bee-storage/bee-storage-test/src/message_id_to_metadata.rs
@@ -56,7 +56,9 @@ pub fn message_id_to_metadata_access<B: StorageBackend>(storage: &B) {
     assert_eq!(results.len(), 1);
     assert!(matches!(results.get(0), Some(Ok(None))));
 
-    InsertStrict::<MessageId, MessageMetadata>::insert_strict_op(storage, &message_id, &metadata).unwrap();
+    storage
+        .insert_strict::<MessageId, MessageMetadata>(&message_id, &metadata)
+        .unwrap();
     assert!(storage.exist::<MessageId, MessageMetadata>(&message_id).unwrap());
 
     // calling `insert_strict` with the same `MessageId` but a different `MessageMetadata` should
@@ -66,7 +68,9 @@ pub fn message_id_to_metadata_access<B: StorageBackend>(storage: &B) {
         let mut metadata = metadata.clone();
         metadata.set_milestone_index(MilestoneIndex(index));
 
-        InsertStrict::<MessageId, MessageMetadata>::insert_strict_op(storage, &message_id, &metadata).unwrap();
+        storage
+            .insert_strict::<MessageId, MessageMetadata>(&message_id, &metadata)
+            .unwrap();
     }
     assert_eq!(
         storage
@@ -129,7 +133,9 @@ pub fn message_id_to_metadata_access<B: StorageBackend>(storage: &B) {
 
     for _ in 0..10 {
         let (message_id, metadata) = (rand_message_id(), rand_message_metadata());
-        InsertStrict::<MessageId, MessageMetadata>::insert_strict_op(storage, &message_id, &metadata).unwrap();
+        storage
+            .insert_strict::<MessageId, MessageMetadata>(&message_id, &metadata)
+            .unwrap();
         storage
             .batch_delete::<MessageId, MessageMetadata>(&mut batch, &message_id)
             .unwrap();

--- a/bee-storage/bee-storage-test/src/message_id_to_metadata.rs
+++ b/bee-storage/bee-storage-test/src/message_id_to_metadata.rs
@@ -43,7 +43,7 @@ impl<T> StorageBackend for T where
 pub fn message_id_to_metadata_access<B: StorageBackend>(storage: &B) {
     let (message_id, metadata) = (rand_message_id(), rand_message_metadata());
 
-    assert!(!Exist::<MessageId, MessageMetadata>::exist_op(storage, &message_id).unwrap());
+    assert!(!storage.exist::<MessageId, MessageMetadata>(&message_id).unwrap());
     assert!(
         storage
             .fetch::<MessageId, MessageMetadata>(&message_id)
@@ -57,7 +57,7 @@ pub fn message_id_to_metadata_access<B: StorageBackend>(storage: &B) {
     assert!(matches!(results.get(0), Some(Ok(None))));
 
     InsertStrict::<MessageId, MessageMetadata>::insert_strict_op(storage, &message_id, &metadata).unwrap();
-    assert!(Exist::<MessageId, MessageMetadata>::exist_op(storage, &message_id).unwrap());
+    assert!(storage.exist::<MessageId, MessageMetadata>(&message_id).unwrap());
 
     // calling `insert_strict` with the same `MessageId` but a different `MessageMetadata` should
     // not overwrite the old value.
@@ -109,7 +109,7 @@ pub fn message_id_to_metadata_access<B: StorageBackend>(storage: &B) {
 
     storage.delete::<MessageId, MessageMetadata>(&message_id).unwrap();
 
-    assert!(!Exist::<MessageId, MessageMetadata>::exist_op(storage, &message_id).unwrap());
+    assert!(!storage.exist::<MessageId, MessageMetadata>(&message_id).unwrap());
     assert!(
         storage
             .fetch::<MessageId, MessageMetadata>(&message_id)

--- a/bee-storage/bee-storage-test/src/message_id_to_metadata.rs
+++ b/bee-storage/bee-storage-test/src/message_id_to_metadata.rs
@@ -179,7 +179,7 @@ pub fn message_id_to_metadata_access<B: StorageBackend>(storage: &B) {
         assert_eq!(metadata, result.unwrap());
     }
 
-    Truncate::<MessageId, MessageMetadata>::truncate_op(storage).unwrap();
+    storage.truncate::<MessageId, MessageMetadata>().unwrap();
 
     let mut iter = storage.iter::<MessageId, MessageMetadata>().unwrap();
 

--- a/bee-storage/bee-storage-test/src/message_id_to_metadata.rs
+++ b/bee-storage/bee-storage-test/src/message_id_to_metadata.rs
@@ -154,7 +154,7 @@ pub fn message_id_to_metadata_access<B: StorageBackend>(storage: &B) {
 
     storage.batch_commit(batch, true).unwrap();
 
-    let iter = AsIterator::<MessageId, MessageMetadata>::iter_op(storage).unwrap();
+    let iter = storage.iter::<MessageId, MessageMetadata>().unwrap();
     let mut count = 0;
 
     for result in iter {
@@ -177,7 +177,7 @@ pub fn message_id_to_metadata_access<B: StorageBackend>(storage: &B) {
 
     Truncate::<MessageId, MessageMetadata>::truncate_op(storage).unwrap();
 
-    let mut iter = AsIterator::<MessageId, MessageMetadata>::iter_op(storage).unwrap();
+    let mut iter = storage.iter::<MessageId, MessageMetadata>().unwrap();
 
     assert!(iter.next().is_none());
 }

--- a/bee-storage/bee-storage-test/src/milestone_index_to_milestone.rs
+++ b/bee-storage/bee-storage-test/src/milestone_index_to_milestone.rs
@@ -78,14 +78,18 @@ pub fn milestone_index_to_milestone_access<B: StorageBackend>(storage: &B) {
     for _ in 0..10 {
         let (index, milestone) = (rand_milestone_index(), rand_milestone());
         Insert::<MilestoneIndex, Milestone>::insert_op(storage, &index, &milestone).unwrap();
-        Batch::<MilestoneIndex, Milestone>::batch_delete_op(storage, &mut batch, &index).unwrap();
+        storage
+            .batch_delete::<MilestoneIndex, Milestone>(&mut batch, &index)
+            .unwrap();
         indexes.push(index);
         milestones.push((index, None));
     }
 
     for _ in 0..10 {
         let (index, milestone) = (rand_milestone_index(), rand_milestone());
-        Batch::<MilestoneIndex, Milestone>::batch_insert_op(storage, &mut batch, &index, &milestone).unwrap();
+        storage
+            .batch_insert::<MilestoneIndex, Milestone>(&mut batch, &index, &milestone)
+            .unwrap();
         indexes.push(index);
         milestones.push((index, Some(milestone)));
     }

--- a/bee-storage/bee-storage-test/src/milestone_index_to_milestone.rs
+++ b/bee-storage/bee-storage-test/src/milestone_index_to_milestone.rs
@@ -48,7 +48,7 @@ pub fn milestone_index_to_milestone_access<B: StorageBackend>(storage: &B) {
     assert_eq!(results.len(), 1);
     assert!(matches!(results.get(0), Some(Ok(None))));
 
-    Insert::<MilestoneIndex, Milestone>::insert_op(storage, &index, &milestone).unwrap();
+    storage.insert::<MilestoneIndex, Milestone>(&index, &milestone).unwrap();
 
     assert!(storage.exist::<MilestoneIndex, Milestone>(&index).unwrap());
     assert_eq!(
@@ -77,7 +77,7 @@ pub fn milestone_index_to_milestone_access<B: StorageBackend>(storage: &B) {
 
     for _ in 0..10 {
         let (index, milestone) = (rand_milestone_index(), rand_milestone());
-        Insert::<MilestoneIndex, Milestone>::insert_op(storage, &index, &milestone).unwrap();
+        storage.insert::<MilestoneIndex, Milestone>(&index, &milestone).unwrap();
         storage
             .batch_delete::<MilestoneIndex, Milestone>(&mut batch, &index)
             .unwrap();

--- a/bee-storage/bee-storage-test/src/milestone_index_to_milestone.rs
+++ b/bee-storage/bee-storage-test/src/milestone_index_to_milestone.rs
@@ -96,7 +96,7 @@ pub fn milestone_index_to_milestone_access<B: StorageBackend>(storage: &B) {
 
     storage.batch_commit(batch, true).unwrap();
 
-    let iter = AsIterator::<MilestoneIndex, Milestone>::iter_op(storage).unwrap();
+    let iter = storage.iter::<MilestoneIndex, Milestone>().unwrap();
     let mut count = 0;
 
     for result in iter {
@@ -119,7 +119,7 @@ pub fn milestone_index_to_milestone_access<B: StorageBackend>(storage: &B) {
 
     Truncate::<MilestoneIndex, Milestone>::truncate_op(storage).unwrap();
 
-    let mut iter = AsIterator::<MilestoneIndex, Milestone>::iter_op(storage).unwrap();
+    let mut iter = storage.iter::<MilestoneIndex, Milestone>().unwrap();
 
     assert!(iter.next().is_none());
 }

--- a/bee-storage/bee-storage-test/src/milestone_index_to_milestone.rs
+++ b/bee-storage/bee-storage-test/src/milestone_index_to_milestone.rs
@@ -40,7 +40,7 @@ impl<T> StorageBackend for T where
 pub fn milestone_index_to_milestone_access<B: StorageBackend>(storage: &B) {
     let (index, milestone) = (rand_milestone_index(), rand_milestone());
 
-    assert!(!Exist::<MilestoneIndex, Milestone>::exist_op(storage, &index).unwrap());
+    assert!(!storage.exist::<MilestoneIndex, Milestone>(&index).unwrap());
     assert!(storage.fetch::<MilestoneIndex, Milestone>(&index).unwrap().is_none());
     let results = MultiFetch::<MilestoneIndex, Milestone>::multi_fetch_op(storage, &[index])
         .unwrap()
@@ -50,7 +50,7 @@ pub fn milestone_index_to_milestone_access<B: StorageBackend>(storage: &B) {
 
     Insert::<MilestoneIndex, Milestone>::insert_op(storage, &index, &milestone).unwrap();
 
-    assert!(Exist::<MilestoneIndex, Milestone>::exist_op(storage, &index).unwrap());
+    assert!(storage.exist::<MilestoneIndex, Milestone>(&index).unwrap());
     assert_eq!(
         storage.fetch::<MilestoneIndex, Milestone>(&index).unwrap().unwrap(),
         milestone
@@ -63,7 +63,7 @@ pub fn milestone_index_to_milestone_access<B: StorageBackend>(storage: &B) {
 
     storage.delete::<MilestoneIndex, Milestone>(&index).unwrap();
 
-    assert!(!Exist::<MilestoneIndex, Milestone>::exist_op(storage, &index).unwrap());
+    assert!(!storage.exist::<MilestoneIndex, Milestone>(&index).unwrap());
     assert!(storage.fetch::<MilestoneIndex, Milestone>(&index).unwrap().is_none());
     let results = MultiFetch::<MilestoneIndex, Milestone>::multi_fetch_op(storage, &[index])
         .unwrap()

--- a/bee-storage/bee-storage-test/src/milestone_index_to_milestone.rs
+++ b/bee-storage/bee-storage-test/src/milestone_index_to_milestone.rs
@@ -41,12 +41,7 @@ pub fn milestone_index_to_milestone_access<B: StorageBackend>(storage: &B) {
     let (index, milestone) = (rand_milestone_index(), rand_milestone());
 
     assert!(!Exist::<MilestoneIndex, Milestone>::exist(storage, &index).unwrap());
-    assert!(
-        storage
-            .fetch_access::<MilestoneIndex, Milestone>(&index)
-            .unwrap()
-            .is_none()
-    );
+    assert!(storage.fetch::<MilestoneIndex, Milestone>(&index).unwrap().is_none());
     let results = MultiFetch::<MilestoneIndex, Milestone>::multi_fetch(storage, &[index])
         .unwrap()
         .collect::<Vec<_>>();
@@ -57,10 +52,7 @@ pub fn milestone_index_to_milestone_access<B: StorageBackend>(storage: &B) {
 
     assert!(Exist::<MilestoneIndex, Milestone>::exist(storage, &index).unwrap());
     assert_eq!(
-        storage
-            .fetch_access::<MilestoneIndex, Milestone>(&index)
-            .unwrap()
-            .unwrap(),
+        storage.fetch::<MilestoneIndex, Milestone>(&index).unwrap().unwrap(),
         milestone
     );
     let results = MultiFetch::<MilestoneIndex, Milestone>::multi_fetch(storage, &[index])
@@ -72,12 +64,7 @@ pub fn milestone_index_to_milestone_access<B: StorageBackend>(storage: &B) {
     Delete::<MilestoneIndex, Milestone>::delete(storage, &index).unwrap();
 
     assert!(!Exist::<MilestoneIndex, Milestone>::exist(storage, &index).unwrap());
-    assert!(
-        storage
-            .fetch_access::<MilestoneIndex, Milestone>(&index)
-            .unwrap()
-            .is_none()
-    );
+    assert!(storage.fetch::<MilestoneIndex, Milestone>(&index).unwrap().is_none());
     let results = MultiFetch::<MilestoneIndex, Milestone>::multi_fetch(storage, &[index])
         .unwrap()
         .collect::<Vec<_>>();

--- a/bee-storage/bee-storage-test/src/milestone_index_to_milestone.rs
+++ b/bee-storage/bee-storage-test/src/milestone_index_to_milestone.rs
@@ -121,7 +121,7 @@ pub fn milestone_index_to_milestone_access<B: StorageBackend>(storage: &B) {
         assert_eq!(milestone, result.unwrap());
     }
 
-    Truncate::<MilestoneIndex, Milestone>::truncate_op(storage).unwrap();
+    storage.truncate::<MilestoneIndex, Milestone>().unwrap();
 
     let mut iter = storage.iter::<MilestoneIndex, Milestone>().unwrap();
 

--- a/bee-storage/bee-storage-test/src/milestone_index_to_milestone.rs
+++ b/bee-storage/bee-storage-test/src/milestone_index_to_milestone.rs
@@ -42,7 +42,8 @@ pub fn milestone_index_to_milestone_access<B: StorageBackend>(storage: &B) {
 
     assert!(!storage.exist::<MilestoneIndex, Milestone>(&index).unwrap());
     assert!(storage.fetch::<MilestoneIndex, Milestone>(&index).unwrap().is_none());
-    let results = MultiFetch::<MilestoneIndex, Milestone>::multi_fetch_op(storage, &[index])
+    let results = storage
+        .multi_fetch::<MilestoneIndex, Milestone>(&[index])
         .unwrap()
         .collect::<Vec<_>>();
     assert_eq!(results.len(), 1);
@@ -55,7 +56,8 @@ pub fn milestone_index_to_milestone_access<B: StorageBackend>(storage: &B) {
         storage.fetch::<MilestoneIndex, Milestone>(&index).unwrap().unwrap(),
         milestone
     );
-    let results = MultiFetch::<MilestoneIndex, Milestone>::multi_fetch_op(storage, &[index])
+    let results = storage
+        .multi_fetch::<MilestoneIndex, Milestone>(&[index])
         .unwrap()
         .collect::<Vec<_>>();
     assert_eq!(results.len(), 1);
@@ -65,7 +67,8 @@ pub fn milestone_index_to_milestone_access<B: StorageBackend>(storage: &B) {
 
     assert!(!storage.exist::<MilestoneIndex, Milestone>(&index).unwrap());
     assert!(storage.fetch::<MilestoneIndex, Milestone>(&index).unwrap().is_none());
-    let results = MultiFetch::<MilestoneIndex, Milestone>::multi_fetch_op(storage, &[index])
+    let results = storage
+        .multi_fetch::<MilestoneIndex, Milestone>(&[index])
         .unwrap()
         .collect::<Vec<_>>();
     assert_eq!(results.len(), 1);
@@ -107,7 +110,8 @@ pub fn milestone_index_to_milestone_access<B: StorageBackend>(storage: &B) {
 
     assert_eq!(count, 10);
 
-    let results = MultiFetch::<MilestoneIndex, Milestone>::multi_fetch_op(storage, &indexes)
+    let results = storage
+        .multi_fetch::<MilestoneIndex, Milestone>(&indexes)
         .unwrap()
         .collect::<Vec<_>>();
 

--- a/bee-storage/bee-storage-test/src/milestone_index_to_milestone.rs
+++ b/bee-storage/bee-storage-test/src/milestone_index_to_milestone.rs
@@ -49,7 +49,7 @@ pub fn milestone_index_to_milestone_access<B: StorageBackend>(storage: &B) {
     assert_eq!(results.len(), 1);
     assert!(matches!(results.get(0), Some(Ok(None))));
 
-    storage.insert::<MilestoneIndex, Milestone>(&index, &milestone).unwrap();
+    storage.insert(&index, &milestone).unwrap();
 
     assert!(storage.exist::<MilestoneIndex, Milestone>(&index).unwrap());
     assert_eq!(
@@ -80,7 +80,7 @@ pub fn milestone_index_to_milestone_access<B: StorageBackend>(storage: &B) {
 
     for _ in 0..10 {
         let (index, milestone) = (rand_milestone_index(), rand_milestone());
-        storage.insert::<MilestoneIndex, Milestone>(&index, &milestone).unwrap();
+        storage.insert(&index, &milestone).unwrap();
         storage
             .batch_delete::<MilestoneIndex, Milestone>(&mut batch, &index)
             .unwrap();
@@ -90,9 +90,7 @@ pub fn milestone_index_to_milestone_access<B: StorageBackend>(storage: &B) {
 
     for _ in 0..10 {
         let (index, milestone) = (rand_milestone_index(), rand_milestone());
-        storage
-            .batch_insert::<MilestoneIndex, Milestone>(&mut batch, &index, &milestone)
-            .unwrap();
+        storage.batch_insert(&mut batch, &index, &milestone).unwrap();
         indexes.push(index);
         milestones.push((index, Some(milestone)));
     }

--- a/bee-storage/bee-storage-test/src/milestone_index_to_milestone.rs
+++ b/bee-storage/bee-storage-test/src/milestone_index_to_milestone.rs
@@ -5,6 +5,7 @@ use bee_message::milestone::{Milestone, MilestoneIndex};
 use bee_storage::{
     access::{AsIterator, Batch, BatchBuilder, Delete, Exist, Fetch, Insert, MultiFetch, Truncate},
     backend,
+    backend::StorageBackendExt,
 };
 use bee_test::rand::milestone::{rand_milestone, rand_milestone_index};
 
@@ -41,7 +42,8 @@ pub fn milestone_index_to_milestone_access<B: StorageBackend>(storage: &B) {
 
     assert!(!Exist::<MilestoneIndex, Milestone>::exist(storage, &index).unwrap());
     assert!(
-        Fetch::<MilestoneIndex, Milestone>::fetch(storage, &index)
+        storage
+            .fetch_access::<MilestoneIndex, Milestone>(&index)
             .unwrap()
             .is_none()
     );
@@ -55,7 +57,8 @@ pub fn milestone_index_to_milestone_access<B: StorageBackend>(storage: &B) {
 
     assert!(Exist::<MilestoneIndex, Milestone>::exist(storage, &index).unwrap());
     assert_eq!(
-        Fetch::<MilestoneIndex, Milestone>::fetch(storage, &index)
+        storage
+            .fetch_access::<MilestoneIndex, Milestone>(&index)
             .unwrap()
             .unwrap(),
         milestone
@@ -70,7 +73,8 @@ pub fn milestone_index_to_milestone_access<B: StorageBackend>(storage: &B) {
 
     assert!(!Exist::<MilestoneIndex, Milestone>::exist(storage, &index).unwrap());
     assert!(
-        Fetch::<MilestoneIndex, Milestone>::fetch(storage, &index)
+        storage
+            .fetch_access::<MilestoneIndex, Milestone>(&index)
             .unwrap()
             .is_none()
     );

--- a/bee-storage/bee-storage-test/src/milestone_index_to_milestone.rs
+++ b/bee-storage/bee-storage-test/src/milestone_index_to_milestone.rs
@@ -40,32 +40,32 @@ impl<T> StorageBackend for T where
 pub fn milestone_index_to_milestone_access<B: StorageBackend>(storage: &B) {
     let (index, milestone) = (rand_milestone_index(), rand_milestone());
 
-    assert!(!Exist::<MilestoneIndex, Milestone>::exist(storage, &index).unwrap());
+    assert!(!Exist::<MilestoneIndex, Milestone>::exist_op(storage, &index).unwrap());
     assert!(storage.fetch::<MilestoneIndex, Milestone>(&index).unwrap().is_none());
-    let results = MultiFetch::<MilestoneIndex, Milestone>::multi_fetch(storage, &[index])
+    let results = MultiFetch::<MilestoneIndex, Milestone>::multi_fetch_op(storage, &[index])
         .unwrap()
         .collect::<Vec<_>>();
     assert_eq!(results.len(), 1);
     assert!(matches!(results.get(0), Some(Ok(None))));
 
-    Insert::<MilestoneIndex, Milestone>::insert(storage, &index, &milestone).unwrap();
+    Insert::<MilestoneIndex, Milestone>::insert_op(storage, &index, &milestone).unwrap();
 
-    assert!(Exist::<MilestoneIndex, Milestone>::exist(storage, &index).unwrap());
+    assert!(Exist::<MilestoneIndex, Milestone>::exist_op(storage, &index).unwrap());
     assert_eq!(
         storage.fetch::<MilestoneIndex, Milestone>(&index).unwrap().unwrap(),
         milestone
     );
-    let results = MultiFetch::<MilestoneIndex, Milestone>::multi_fetch(storage, &[index])
+    let results = MultiFetch::<MilestoneIndex, Milestone>::multi_fetch_op(storage, &[index])
         .unwrap()
         .collect::<Vec<_>>();
     assert_eq!(results.len(), 1);
     assert!(matches!(results.get(0), Some(Ok(Some(v))) if v == &milestone));
 
-    Delete::<MilestoneIndex, Milestone>::delete(storage, &index).unwrap();
+    Delete::<MilestoneIndex, Milestone>::delete_op(storage, &index).unwrap();
 
-    assert!(!Exist::<MilestoneIndex, Milestone>::exist(storage, &index).unwrap());
+    assert!(!Exist::<MilestoneIndex, Milestone>::exist_op(storage, &index).unwrap());
     assert!(storage.fetch::<MilestoneIndex, Milestone>(&index).unwrap().is_none());
-    let results = MultiFetch::<MilestoneIndex, Milestone>::multi_fetch(storage, &[index])
+    let results = MultiFetch::<MilestoneIndex, Milestone>::multi_fetch_op(storage, &[index])
         .unwrap()
         .collect::<Vec<_>>();
     assert_eq!(results.len(), 1);
@@ -77,22 +77,22 @@ pub fn milestone_index_to_milestone_access<B: StorageBackend>(storage: &B) {
 
     for _ in 0..10 {
         let (index, milestone) = (rand_milestone_index(), rand_milestone());
-        Insert::<MilestoneIndex, Milestone>::insert(storage, &index, &milestone).unwrap();
-        Batch::<MilestoneIndex, Milestone>::batch_delete(storage, &mut batch, &index).unwrap();
+        Insert::<MilestoneIndex, Milestone>::insert_op(storage, &index, &milestone).unwrap();
+        Batch::<MilestoneIndex, Milestone>::batch_delete_op(storage, &mut batch, &index).unwrap();
         indexes.push(index);
         milestones.push((index, None));
     }
 
     for _ in 0..10 {
         let (index, milestone) = (rand_milestone_index(), rand_milestone());
-        Batch::<MilestoneIndex, Milestone>::batch_insert(storage, &mut batch, &index, &milestone).unwrap();
+        Batch::<MilestoneIndex, Milestone>::batch_insert_op(storage, &mut batch, &index, &milestone).unwrap();
         indexes.push(index);
         milestones.push((index, Some(milestone)));
     }
 
     storage.batch_commit(batch, true).unwrap();
 
-    let iter = AsIterator::<MilestoneIndex, Milestone>::iter(storage).unwrap();
+    let iter = AsIterator::<MilestoneIndex, Milestone>::iter_op(storage).unwrap();
     let mut count = 0;
 
     for result in iter {
@@ -103,7 +103,7 @@ pub fn milestone_index_to_milestone_access<B: StorageBackend>(storage: &B) {
 
     assert_eq!(count, 10);
 
-    let results = MultiFetch::<MilestoneIndex, Milestone>::multi_fetch(storage, &indexes)
+    let results = MultiFetch::<MilestoneIndex, Milestone>::multi_fetch_op(storage, &indexes)
         .unwrap()
         .collect::<Vec<_>>();
 
@@ -113,9 +113,9 @@ pub fn milestone_index_to_milestone_access<B: StorageBackend>(storage: &B) {
         assert_eq!(milestone, result.unwrap());
     }
 
-    Truncate::<MilestoneIndex, Milestone>::truncate(storage).unwrap();
+    Truncate::<MilestoneIndex, Milestone>::truncate_op(storage).unwrap();
 
-    let mut iter = AsIterator::<MilestoneIndex, Milestone>::iter(storage).unwrap();
+    let mut iter = AsIterator::<MilestoneIndex, Milestone>::iter_op(storage).unwrap();
 
     assert!(iter.next().is_none());
 }

--- a/bee-storage/bee-storage-test/src/milestone_index_to_milestone.rs
+++ b/bee-storage/bee-storage-test/src/milestone_index_to_milestone.rs
@@ -61,7 +61,7 @@ pub fn milestone_index_to_milestone_access<B: StorageBackend>(storage: &B) {
     assert_eq!(results.len(), 1);
     assert!(matches!(results.get(0), Some(Ok(Some(v))) if v == &milestone));
 
-    Delete::<MilestoneIndex, Milestone>::delete_op(storage, &index).unwrap();
+    storage.delete::<MilestoneIndex, Milestone>(&index).unwrap();
 
     assert!(!Exist::<MilestoneIndex, Milestone>::exist_op(storage, &index).unwrap());
     assert!(storage.fetch::<MilestoneIndex, Milestone>(&index).unwrap().is_none());

--- a/bee-storage/bee-storage-test/src/milestone_index_to_output_diff.rs
+++ b/bee-storage/bee-storage-test/src/milestone_index_to_output_diff.rs
@@ -44,7 +44,8 @@ pub fn milestone_index_to_output_diff_access<B: StorageBackend>(storage: &B) {
 
     assert!(!storage.exist::<MilestoneIndex, OutputDiff>(&index).unwrap());
     assert!(storage.fetch::<MilestoneIndex, OutputDiff>(&index).unwrap().is_none());
-    let results = MultiFetch::<MilestoneIndex, OutputDiff>::multi_fetch_op(storage, &[index])
+    let results = storage
+        .multi_fetch::<MilestoneIndex, OutputDiff>(&[index])
         .unwrap()
         .collect::<Vec<_>>();
     assert_eq!(results.len(), 1);
@@ -63,7 +64,8 @@ pub fn milestone_index_to_output_diff_access<B: StorageBackend>(storage: &B) {
             .pack_new(),
         output_diff.pack_new()
     );
-    let results = MultiFetch::<MilestoneIndex, OutputDiff>::multi_fetch_op(storage, &[index])
+    let results = storage
+        .multi_fetch::<MilestoneIndex, OutputDiff>(&[index])
         .unwrap()
         .collect::<Vec<_>>();
     assert_eq!(results.len(), 1);
@@ -73,7 +75,8 @@ pub fn milestone_index_to_output_diff_access<B: StorageBackend>(storage: &B) {
 
     assert!(!storage.exist::<MilestoneIndex, OutputDiff>(&index).unwrap());
     assert!(storage.fetch::<MilestoneIndex, OutputDiff>(&index).unwrap().is_none());
-    let results = MultiFetch::<MilestoneIndex, OutputDiff>::multi_fetch_op(storage, &[index])
+    let results = storage
+        .multi_fetch::<MilestoneIndex, OutputDiff>(&[index])
         .unwrap()
         .collect::<Vec<_>>();
     assert_eq!(results.len(), 1);
@@ -117,7 +120,8 @@ pub fn milestone_index_to_output_diff_access<B: StorageBackend>(storage: &B) {
 
     assert_eq!(count, 10);
 
-    let results = MultiFetch::<MilestoneIndex, OutputDiff>::multi_fetch_op(storage, &indexes)
+    let results = storage
+        .multi_fetch::<MilestoneIndex, OutputDiff>(&indexes)
         .unwrap()
         .collect::<Vec<_>>();
 

--- a/bee-storage/bee-storage-test/src/milestone_index_to_output_diff.rs
+++ b/bee-storage/bee-storage-test/src/milestone_index_to_output_diff.rs
@@ -51,9 +51,7 @@ pub fn milestone_index_to_output_diff_access<B: StorageBackend>(storage: &B) {
     assert_eq!(results.len(), 1);
     assert!(matches!(results.get(0), Some(Ok(None))));
 
-    storage
-        .insert::<MilestoneIndex, OutputDiff>(&index, &output_diff)
-        .unwrap();
+    storage.insert(&index, &output_diff).unwrap();
 
     assert!(storage.exist::<MilestoneIndex, OutputDiff>(&index).unwrap());
     assert_eq!(
@@ -88,9 +86,7 @@ pub fn milestone_index_to_output_diff_access<B: StorageBackend>(storage: &B) {
 
     for _ in 0..10 {
         let (index, output_diff) = (rand_milestone_index(), rand_output_diff());
-        storage
-            .insert::<MilestoneIndex, OutputDiff>(&index, &output_diff)
-            .unwrap();
+        storage.insert(&index, &output_diff).unwrap();
         storage
             .batch_delete::<MilestoneIndex, OutputDiff>(&mut batch, &index)
             .unwrap();
@@ -100,9 +96,7 @@ pub fn milestone_index_to_output_diff_access<B: StorageBackend>(storage: &B) {
 
     for _ in 0..10 {
         let (index, output_diff) = (rand_milestone_index(), rand_output_diff());
-        storage
-            .batch_insert::<MilestoneIndex, OutputDiff>(&mut batch, &index, &output_diff)
-            .unwrap();
+        storage.batch_insert(&mut batch, &index, &output_diff).unwrap();
         indexes.push(index);
         output_diffs.push((index, Some(output_diff)));
     }

--- a/bee-storage/bee-storage-test/src/milestone_index_to_output_diff.rs
+++ b/bee-storage/bee-storage-test/src/milestone_index_to_output_diff.rs
@@ -106,7 +106,7 @@ pub fn milestone_index_to_output_diff_access<B: StorageBackend>(storage: &B) {
 
     storage.batch_commit(batch, true).unwrap();
 
-    let iter = AsIterator::<MilestoneIndex, OutputDiff>::iter_op(storage).unwrap();
+    let iter = storage.iter::<MilestoneIndex, OutputDiff>().unwrap();
     let mut count = 0;
 
     for result in iter {
@@ -129,7 +129,7 @@ pub fn milestone_index_to_output_diff_access<B: StorageBackend>(storage: &B) {
 
     Truncate::<MilestoneIndex, OutputDiff>::truncate_op(storage).unwrap();
 
-    let mut iter = AsIterator::<MilestoneIndex, OutputDiff>::iter_op(storage).unwrap();
+    let mut iter = storage.iter::<MilestoneIndex, OutputDiff>().unwrap();
 
     assert!(iter.next().is_none());
 }

--- a/bee-storage/bee-storage-test/src/milestone_index_to_output_diff.rs
+++ b/bee-storage/bee-storage-test/src/milestone_index_to_output_diff.rs
@@ -42,7 +42,7 @@ impl<T> StorageBackend for T where
 pub fn milestone_index_to_output_diff_access<B: StorageBackend>(storage: &B) {
     let (index, output_diff) = (rand_milestone_index(), rand_output_diff());
 
-    assert!(!Exist::<MilestoneIndex, OutputDiff>::exist_op(storage, &index).unwrap());
+    assert!(!storage.exist::<MilestoneIndex, OutputDiff>(&index).unwrap());
     assert!(storage.fetch::<MilestoneIndex, OutputDiff>(&index).unwrap().is_none());
     let results = MultiFetch::<MilestoneIndex, OutputDiff>::multi_fetch_op(storage, &[index])
         .unwrap()
@@ -52,7 +52,7 @@ pub fn milestone_index_to_output_diff_access<B: StorageBackend>(storage: &B) {
 
     Insert::<MilestoneIndex, OutputDiff>::insert_op(storage, &index, &output_diff).unwrap();
 
-    assert!(Exist::<MilestoneIndex, OutputDiff>::exist_op(storage, &index).unwrap());
+    assert!(storage.exist::<MilestoneIndex, OutputDiff>(&index).unwrap());
     assert_eq!(
         storage
             .fetch::<MilestoneIndex, OutputDiff>(&index)
@@ -69,7 +69,7 @@ pub fn milestone_index_to_output_diff_access<B: StorageBackend>(storage: &B) {
 
     storage.delete::<MilestoneIndex, OutputDiff>(&index).unwrap();
 
-    assert!(!Exist::<MilestoneIndex, OutputDiff>::exist_op(storage, &index).unwrap());
+    assert!(!storage.exist::<MilestoneIndex, OutputDiff>(&index).unwrap());
     assert!(storage.fetch::<MilestoneIndex, OutputDiff>(&index).unwrap().is_none());
     let results = MultiFetch::<MilestoneIndex, OutputDiff>::multi_fetch_op(storage, &[index])
         .unwrap()

--- a/bee-storage/bee-storage-test/src/milestone_index_to_output_diff.rs
+++ b/bee-storage/bee-storage-test/src/milestone_index_to_output_diff.rs
@@ -84,14 +84,18 @@ pub fn milestone_index_to_output_diff_access<B: StorageBackend>(storage: &B) {
     for _ in 0..10 {
         let (index, output_diff) = (rand_milestone_index(), rand_output_diff());
         Insert::<MilestoneIndex, OutputDiff>::insert_op(storage, &index, &output_diff).unwrap();
-        Batch::<MilestoneIndex, OutputDiff>::batch_delete_op(storage, &mut batch, &index).unwrap();
+        storage
+            .batch_delete::<MilestoneIndex, OutputDiff>(&mut batch, &index)
+            .unwrap();
         indexes.push(index);
         output_diffs.push((index, None));
     }
 
     for _ in 0..10 {
         let (index, output_diff) = (rand_milestone_index(), rand_output_diff());
-        Batch::<MilestoneIndex, OutputDiff>::batch_insert_op(storage, &mut batch, &index, &output_diff).unwrap();
+        storage
+            .batch_insert::<MilestoneIndex, OutputDiff>(&mut batch, &index, &output_diff)
+            .unwrap();
         indexes.push(index);
         output_diffs.push((index, Some(output_diff)));
     }

--- a/bee-storage/bee-storage-test/src/milestone_index_to_output_diff.rs
+++ b/bee-storage/bee-storage-test/src/milestone_index_to_output_diff.rs
@@ -42,17 +42,17 @@ impl<T> StorageBackend for T where
 pub fn milestone_index_to_output_diff_access<B: StorageBackend>(storage: &B) {
     let (index, output_diff) = (rand_milestone_index(), rand_output_diff());
 
-    assert!(!Exist::<MilestoneIndex, OutputDiff>::exist(storage, &index).unwrap());
+    assert!(!Exist::<MilestoneIndex, OutputDiff>::exist_op(storage, &index).unwrap());
     assert!(storage.fetch::<MilestoneIndex, OutputDiff>(&index).unwrap().is_none());
-    let results = MultiFetch::<MilestoneIndex, OutputDiff>::multi_fetch(storage, &[index])
+    let results = MultiFetch::<MilestoneIndex, OutputDiff>::multi_fetch_op(storage, &[index])
         .unwrap()
         .collect::<Vec<_>>();
     assert_eq!(results.len(), 1);
     assert!(matches!(results.get(0), Some(Ok(None))));
 
-    Insert::<MilestoneIndex, OutputDiff>::insert(storage, &index, &output_diff).unwrap();
+    Insert::<MilestoneIndex, OutputDiff>::insert_op(storage, &index, &output_diff).unwrap();
 
-    assert!(Exist::<MilestoneIndex, OutputDiff>::exist(storage, &index).unwrap());
+    assert!(Exist::<MilestoneIndex, OutputDiff>::exist_op(storage, &index).unwrap());
     assert_eq!(
         storage
             .fetch::<MilestoneIndex, OutputDiff>(&index)
@@ -61,17 +61,17 @@ pub fn milestone_index_to_output_diff_access<B: StorageBackend>(storage: &B) {
             .pack_new(),
         output_diff.pack_new()
     );
-    let results = MultiFetch::<MilestoneIndex, OutputDiff>::multi_fetch(storage, &[index])
+    let results = MultiFetch::<MilestoneIndex, OutputDiff>::multi_fetch_op(storage, &[index])
         .unwrap()
         .collect::<Vec<_>>();
     assert_eq!(results.len(), 1);
     assert!(matches!(results.get(0), Some(Ok(Some(v))) if v == &output_diff));
 
-    Delete::<MilestoneIndex, OutputDiff>::delete(storage, &index).unwrap();
+    Delete::<MilestoneIndex, OutputDiff>::delete_op(storage, &index).unwrap();
 
-    assert!(!Exist::<MilestoneIndex, OutputDiff>::exist(storage, &index).unwrap());
+    assert!(!Exist::<MilestoneIndex, OutputDiff>::exist_op(storage, &index).unwrap());
     assert!(storage.fetch::<MilestoneIndex, OutputDiff>(&index).unwrap().is_none());
-    let results = MultiFetch::<MilestoneIndex, OutputDiff>::multi_fetch(storage, &[index])
+    let results = MultiFetch::<MilestoneIndex, OutputDiff>::multi_fetch_op(storage, &[index])
         .unwrap()
         .collect::<Vec<_>>();
     assert_eq!(results.len(), 1);
@@ -83,22 +83,22 @@ pub fn milestone_index_to_output_diff_access<B: StorageBackend>(storage: &B) {
 
     for _ in 0..10 {
         let (index, output_diff) = (rand_milestone_index(), rand_output_diff());
-        Insert::<MilestoneIndex, OutputDiff>::insert(storage, &index, &output_diff).unwrap();
-        Batch::<MilestoneIndex, OutputDiff>::batch_delete(storage, &mut batch, &index).unwrap();
+        Insert::<MilestoneIndex, OutputDiff>::insert_op(storage, &index, &output_diff).unwrap();
+        Batch::<MilestoneIndex, OutputDiff>::batch_delete_op(storage, &mut batch, &index).unwrap();
         indexes.push(index);
         output_diffs.push((index, None));
     }
 
     for _ in 0..10 {
         let (index, output_diff) = (rand_milestone_index(), rand_output_diff());
-        Batch::<MilestoneIndex, OutputDiff>::batch_insert(storage, &mut batch, &index, &output_diff).unwrap();
+        Batch::<MilestoneIndex, OutputDiff>::batch_insert_op(storage, &mut batch, &index, &output_diff).unwrap();
         indexes.push(index);
         output_diffs.push((index, Some(output_diff)));
     }
 
     storage.batch_commit(batch, true).unwrap();
 
-    let iter = AsIterator::<MilestoneIndex, OutputDiff>::iter(storage).unwrap();
+    let iter = AsIterator::<MilestoneIndex, OutputDiff>::iter_op(storage).unwrap();
     let mut count = 0;
 
     for result in iter {
@@ -109,7 +109,7 @@ pub fn milestone_index_to_output_diff_access<B: StorageBackend>(storage: &B) {
 
     assert_eq!(count, 10);
 
-    let results = MultiFetch::<MilestoneIndex, OutputDiff>::multi_fetch(storage, &indexes)
+    let results = MultiFetch::<MilestoneIndex, OutputDiff>::multi_fetch_op(storage, &indexes)
         .unwrap()
         .collect::<Vec<_>>();
 
@@ -119,9 +119,9 @@ pub fn milestone_index_to_output_diff_access<B: StorageBackend>(storage: &B) {
         assert_eq!(diff, result.unwrap());
     }
 
-    Truncate::<MilestoneIndex, OutputDiff>::truncate(storage).unwrap();
+    Truncate::<MilestoneIndex, OutputDiff>::truncate_op(storage).unwrap();
 
-    let mut iter = AsIterator::<MilestoneIndex, OutputDiff>::iter(storage).unwrap();
+    let mut iter = AsIterator::<MilestoneIndex, OutputDiff>::iter_op(storage).unwrap();
 
     assert!(iter.next().is_none());
 }

--- a/bee-storage/bee-storage-test/src/milestone_index_to_output_diff.rs
+++ b/bee-storage/bee-storage-test/src/milestone_index_to_output_diff.rs
@@ -43,12 +43,7 @@ pub fn milestone_index_to_output_diff_access<B: StorageBackend>(storage: &B) {
     let (index, output_diff) = (rand_milestone_index(), rand_output_diff());
 
     assert!(!Exist::<MilestoneIndex, OutputDiff>::exist(storage, &index).unwrap());
-    assert!(
-        storage
-            .fetch_access::<MilestoneIndex, OutputDiff>(&index)
-            .unwrap()
-            .is_none()
-    );
+    assert!(storage.fetch::<MilestoneIndex, OutputDiff>(&index).unwrap().is_none());
     let results = MultiFetch::<MilestoneIndex, OutputDiff>::multi_fetch(storage, &[index])
         .unwrap()
         .collect::<Vec<_>>();
@@ -60,7 +55,7 @@ pub fn milestone_index_to_output_diff_access<B: StorageBackend>(storage: &B) {
     assert!(Exist::<MilestoneIndex, OutputDiff>::exist(storage, &index).unwrap());
     assert_eq!(
         storage
-            .fetch_access::<MilestoneIndex, OutputDiff>(&index)
+            .fetch::<MilestoneIndex, OutputDiff>(&index)
             .unwrap()
             .unwrap()
             .pack_new(),
@@ -75,12 +70,7 @@ pub fn milestone_index_to_output_diff_access<B: StorageBackend>(storage: &B) {
     Delete::<MilestoneIndex, OutputDiff>::delete(storage, &index).unwrap();
 
     assert!(!Exist::<MilestoneIndex, OutputDiff>::exist(storage, &index).unwrap());
-    assert!(
-        storage
-            .fetch_access::<MilestoneIndex, OutputDiff>(&index)
-            .unwrap()
-            .is_none()
-    );
+    assert!(storage.fetch::<MilestoneIndex, OutputDiff>(&index).unwrap().is_none());
     let results = MultiFetch::<MilestoneIndex, OutputDiff>::multi_fetch(storage, &[index])
         .unwrap()
         .collect::<Vec<_>>();

--- a/bee-storage/bee-storage-test/src/milestone_index_to_output_diff.rs
+++ b/bee-storage/bee-storage-test/src/milestone_index_to_output_diff.rs
@@ -131,7 +131,7 @@ pub fn milestone_index_to_output_diff_access<B: StorageBackend>(storage: &B) {
         assert_eq!(diff, result.unwrap());
     }
 
-    Truncate::<MilestoneIndex, OutputDiff>::truncate_op(storage).unwrap();
+    storage.truncate::<MilestoneIndex, OutputDiff>().unwrap();
 
     let mut iter = storage.iter::<MilestoneIndex, OutputDiff>().unwrap();
 

--- a/bee-storage/bee-storage-test/src/milestone_index_to_output_diff.rs
+++ b/bee-storage/bee-storage-test/src/milestone_index_to_output_diff.rs
@@ -7,6 +7,7 @@ use bee_message::milestone::MilestoneIndex;
 use bee_storage::{
     access::{AsIterator, Batch, BatchBuilder, Delete, Exist, Fetch, Insert, MultiFetch, Truncate},
     backend,
+    backend::StorageBackendExt,
 };
 use bee_test::rand::{milestone::rand_milestone_index, output_diff::rand_output_diff};
 
@@ -43,7 +44,8 @@ pub fn milestone_index_to_output_diff_access<B: StorageBackend>(storage: &B) {
 
     assert!(!Exist::<MilestoneIndex, OutputDiff>::exist(storage, &index).unwrap());
     assert!(
-        Fetch::<MilestoneIndex, OutputDiff>::fetch(storage, &index)
+        storage
+            .fetch_access::<MilestoneIndex, OutputDiff>(&index)
             .unwrap()
             .is_none()
     );
@@ -57,7 +59,8 @@ pub fn milestone_index_to_output_diff_access<B: StorageBackend>(storage: &B) {
 
     assert!(Exist::<MilestoneIndex, OutputDiff>::exist(storage, &index).unwrap());
     assert_eq!(
-        Fetch::<MilestoneIndex, OutputDiff>::fetch(storage, &index)
+        storage
+            .fetch_access::<MilestoneIndex, OutputDiff>(&index)
             .unwrap()
             .unwrap()
             .pack_new(),
@@ -73,7 +76,8 @@ pub fn milestone_index_to_output_diff_access<B: StorageBackend>(storage: &B) {
 
     assert!(!Exist::<MilestoneIndex, OutputDiff>::exist(storage, &index).unwrap());
     assert!(
-        Fetch::<MilestoneIndex, OutputDiff>::fetch(storage, &index)
+        storage
+            .fetch_access::<MilestoneIndex, OutputDiff>(&index)
             .unwrap()
             .is_none()
     );

--- a/bee-storage/bee-storage-test/src/milestone_index_to_output_diff.rs
+++ b/bee-storage/bee-storage-test/src/milestone_index_to_output_diff.rs
@@ -67,7 +67,7 @@ pub fn milestone_index_to_output_diff_access<B: StorageBackend>(storage: &B) {
     assert_eq!(results.len(), 1);
     assert!(matches!(results.get(0), Some(Ok(Some(v))) if v == &output_diff));
 
-    Delete::<MilestoneIndex, OutputDiff>::delete_op(storage, &index).unwrap();
+    storage.delete::<MilestoneIndex, OutputDiff>(&index).unwrap();
 
     assert!(!Exist::<MilestoneIndex, OutputDiff>::exist_op(storage, &index).unwrap());
     assert!(storage.fetch::<MilestoneIndex, OutputDiff>(&index).unwrap().is_none());

--- a/bee-storage/bee-storage-test/src/milestone_index_to_output_diff.rs
+++ b/bee-storage/bee-storage-test/src/milestone_index_to_output_diff.rs
@@ -50,7 +50,9 @@ pub fn milestone_index_to_output_diff_access<B: StorageBackend>(storage: &B) {
     assert_eq!(results.len(), 1);
     assert!(matches!(results.get(0), Some(Ok(None))));
 
-    Insert::<MilestoneIndex, OutputDiff>::insert_op(storage, &index, &output_diff).unwrap();
+    storage
+        .insert::<MilestoneIndex, OutputDiff>(&index, &output_diff)
+        .unwrap();
 
     assert!(storage.exist::<MilestoneIndex, OutputDiff>(&index).unwrap());
     assert_eq!(
@@ -83,7 +85,9 @@ pub fn milestone_index_to_output_diff_access<B: StorageBackend>(storage: &B) {
 
     for _ in 0..10 {
         let (index, output_diff) = (rand_milestone_index(), rand_output_diff());
-        Insert::<MilestoneIndex, OutputDiff>::insert_op(storage, &index, &output_diff).unwrap();
+        storage
+            .insert::<MilestoneIndex, OutputDiff>(&index, &output_diff)
+            .unwrap();
         storage
             .batch_delete::<MilestoneIndex, OutputDiff>(&mut batch, &index)
             .unwrap();

--- a/bee-storage/bee-storage-test/src/milestone_index_to_receipt.rs
+++ b/bee-storage/bee-storage-test/src/milestone_index_to_receipt.rs
@@ -54,9 +54,7 @@ pub fn milestone_index_to_receipt_access<B: StorageBackend>(storage: &B) {
             .is_empty()
     );
 
-    storage
-        .insert::<(MilestoneIndex, Receipt), ()>(&(index, receipt.clone()), &())
-        .unwrap();
+    storage.insert(&(index, receipt.clone()), &()).unwrap();
 
     assert!(
         storage
@@ -89,9 +87,7 @@ pub fn milestone_index_to_receipt_access<B: StorageBackend>(storage: &B) {
 
     for _ in 0..10 {
         let (index, receipt) = (rand_milestone_index(), rand_ledger_receipt());
-        storage
-            .insert::<(MilestoneIndex, Receipt), ()>(&(index, receipt.clone()), &())
-            .unwrap();
+        storage.insert(&(index, receipt.clone()), &()).unwrap();
         storage
             .batch_delete::<(MilestoneIndex, Receipt), ()>(&mut batch, &(index, receipt))
             .unwrap();
@@ -104,7 +100,7 @@ pub fn milestone_index_to_receipt_access<B: StorageBackend>(storage: &B) {
         for _ in 0..5 {
             let receipt = rand_ledger_receipt();
             storage
-                .batch_insert::<(MilestoneIndex, Receipt), ()>(&mut batch, &(index, receipt.clone()), &())
+                .batch_insert(&mut batch, &(index, receipt.clone()), &())
                 .unwrap();
             receipts.entry(index).or_default().push(receipt);
         }

--- a/bee-storage/bee-storage-test/src/milestone_index_to_receipt.rs
+++ b/bee-storage/bee-storage-test/src/milestone_index_to_receipt.rs
@@ -54,7 +54,9 @@ pub fn milestone_index_to_receipt_access<B: StorageBackend>(storage: &B) {
             .is_empty()
     );
 
-    Insert::<(MilestoneIndex, Receipt), ()>::insert_op(storage, &(index, receipt.clone()), &()).unwrap();
+    storage
+        .insert::<(MilestoneIndex, Receipt), ()>(&(index, receipt.clone()), &())
+        .unwrap();
 
     assert!(
         storage
@@ -87,7 +89,9 @@ pub fn milestone_index_to_receipt_access<B: StorageBackend>(storage: &B) {
 
     for _ in 0..10 {
         let (index, receipt) = (rand_milestone_index(), rand_ledger_receipt());
-        Insert::<(MilestoneIndex, Receipt), ()>::insert_op(storage, &(index, receipt.clone()), &()).unwrap();
+        storage
+            .insert::<(MilestoneIndex, Receipt), ()>(&(index, receipt.clone()), &())
+            .unwrap();
         storage
             .batch_delete::<(MilestoneIndex, Receipt), ()>(&mut batch, &(index, receipt))
             .unwrap();

--- a/bee-storage/bee-storage-test/src/milestone_index_to_receipt.rs
+++ b/bee-storage/bee-storage-test/src/milestone_index_to_receipt.rs
@@ -41,7 +41,7 @@ impl<T> StorageBackend for T where
 pub fn milestone_index_to_receipt_access<B: StorageBackend>(storage: &B) {
     let (index, receipt) = (rand_milestone_index(), rand_ledger_receipt());
 
-    assert!(!Exist::<(MilestoneIndex, Receipt), ()>::exist(storage, &(index, receipt.clone())).unwrap());
+    assert!(!Exist::<(MilestoneIndex, Receipt), ()>::exist_op(storage, &(index, receipt.clone())).unwrap());
     assert!(
         storage
             .fetch::<MilestoneIndex, Vec<Receipt>>(&index)
@@ -50,17 +50,17 @@ pub fn milestone_index_to_receipt_access<B: StorageBackend>(storage: &B) {
             .is_empty()
     );
 
-    Insert::<(MilestoneIndex, Receipt), ()>::insert(storage, &(index, receipt.clone()), &()).unwrap();
+    Insert::<(MilestoneIndex, Receipt), ()>::insert_op(storage, &(index, receipt.clone()), &()).unwrap();
 
-    assert!(Exist::<(MilestoneIndex, Receipt), ()>::exist(storage, &(index, receipt.clone())).unwrap());
+    assert!(Exist::<(MilestoneIndex, Receipt), ()>::exist_op(storage, &(index, receipt.clone())).unwrap());
     assert_eq!(
         storage.fetch::<MilestoneIndex, Vec<Receipt>>(&index).unwrap().unwrap(),
         vec![receipt.clone()]
     );
 
-    Delete::<(MilestoneIndex, Receipt), ()>::delete(storage, &(index, receipt.clone())).unwrap();
+    Delete::<(MilestoneIndex, Receipt), ()>::delete_op(storage, &(index, receipt.clone())).unwrap();
 
-    assert!(!Exist::<(MilestoneIndex, Receipt), ()>::exist(storage, &(index, receipt)).unwrap());
+    assert!(!Exist::<(MilestoneIndex, Receipt), ()>::exist_op(storage, &(index, receipt)).unwrap());
     assert!(
         storage
             .fetch::<MilestoneIndex, Vec<Receipt>>(&index)
@@ -73,8 +73,8 @@ pub fn milestone_index_to_receipt_access<B: StorageBackend>(storage: &B) {
 
     for _ in 0..10 {
         let (index, receipt) = (rand_milestone_index(), rand_ledger_receipt());
-        Insert::<(MilestoneIndex, Receipt), ()>::insert(storage, &(index, receipt.clone()), &()).unwrap();
-        Batch::<(MilestoneIndex, Receipt), ()>::batch_delete(storage, &mut batch, &(index, receipt)).unwrap();
+        Insert::<(MilestoneIndex, Receipt), ()>::insert_op(storage, &(index, receipt.clone()), &()).unwrap();
+        Batch::<(MilestoneIndex, Receipt), ()>::batch_delete_op(storage, &mut batch, &(index, receipt)).unwrap();
     }
 
     let mut receipts = HashMap::<MilestoneIndex, Vec<Receipt>>::new();
@@ -83,15 +83,20 @@ pub fn milestone_index_to_receipt_access<B: StorageBackend>(storage: &B) {
         let index = rand_milestone_index();
         for _ in 0..5 {
             let receipt = rand_ledger_receipt();
-            Batch::<(MilestoneIndex, Receipt), ()>::batch_insert(storage, &mut batch, &(index, receipt.clone()), &())
-                .unwrap();
+            Batch::<(MilestoneIndex, Receipt), ()>::batch_insert_op(
+                storage,
+                &mut batch,
+                &(index, receipt.clone()),
+                &(),
+            )
+            .unwrap();
             receipts.entry(index).or_default().push(receipt);
         }
     }
 
     storage.batch_commit(batch, true).unwrap();
 
-    let iter = AsIterator::<(MilestoneIndex, Receipt), ()>::iter(storage).unwrap();
+    let iter = AsIterator::<(MilestoneIndex, Receipt), ()>::iter_op(storage).unwrap();
     let mut count = 0;
 
     for result in iter {
@@ -102,9 +107,9 @@ pub fn milestone_index_to_receipt_access<B: StorageBackend>(storage: &B) {
 
     assert_eq!(count, receipts.iter().fold(0, |acc, v| acc + v.1.len()));
 
-    Truncate::<(MilestoneIndex, Receipt), ()>::truncate(storage).unwrap();
+    Truncate::<(MilestoneIndex, Receipt), ()>::truncate_op(storage).unwrap();
 
-    let mut iter = AsIterator::<(MilestoneIndex, Receipt), ()>::iter(storage).unwrap();
+    let mut iter = AsIterator::<(MilestoneIndex, Receipt), ()>::iter_op(storage).unwrap();
 
     assert!(iter.next().is_none());
 }

--- a/bee-storage/bee-storage-test/src/milestone_index_to_receipt.rs
+++ b/bee-storage/bee-storage-test/src/milestone_index_to_receipt.rs
@@ -8,6 +8,7 @@ use bee_message::milestone::MilestoneIndex;
 use bee_storage::{
     access::{AsIterator, Batch, BatchBuilder, Delete, Exist, Fetch, Insert, Truncate},
     backend,
+    backend::StorageBackendExt,
 };
 use bee_test::rand::{milestone::rand_milestone_index, receipt::rand_ledger_receipt};
 
@@ -42,7 +43,8 @@ pub fn milestone_index_to_receipt_access<B: StorageBackend>(storage: &B) {
 
     assert!(!Exist::<(MilestoneIndex, Receipt), ()>::exist(storage, &(index, receipt.clone())).unwrap());
     assert!(
-        Fetch::<MilestoneIndex, Vec<Receipt>>::fetch(storage, &index)
+        storage
+            .fetch_access::<MilestoneIndex, Vec<Receipt>>(&index)
             .unwrap()
             .unwrap()
             .is_empty()
@@ -52,7 +54,8 @@ pub fn milestone_index_to_receipt_access<B: StorageBackend>(storage: &B) {
 
     assert!(Exist::<(MilestoneIndex, Receipt), ()>::exist(storage, &(index, receipt.clone())).unwrap());
     assert_eq!(
-        Fetch::<MilestoneIndex, Vec<Receipt>>::fetch(storage, &index)
+        storage
+            .fetch_access::<MilestoneIndex, Vec<Receipt>>(&index)
             .unwrap()
             .unwrap(),
         vec![receipt.clone()]
@@ -62,7 +65,8 @@ pub fn milestone_index_to_receipt_access<B: StorageBackend>(storage: &B) {
 
     assert!(!Exist::<(MilestoneIndex, Receipt), ()>::exist(storage, &(index, receipt)).unwrap());
     assert!(
-        Fetch::<MilestoneIndex, Vec<Receipt>>::fetch(storage, &index)
+        storage
+            .fetch_access::<MilestoneIndex, Vec<Receipt>>(&index)
             .unwrap()
             .unwrap()
             .is_empty()

--- a/bee-storage/bee-storage-test/src/milestone_index_to_receipt.rs
+++ b/bee-storage/bee-storage-test/src/milestone_index_to_receipt.rs
@@ -123,7 +123,7 @@ pub fn milestone_index_to_receipt_access<B: StorageBackend>(storage: &B) {
 
     assert_eq!(count, receipts.iter().fold(0, |acc, v| acc + v.1.len()));
 
-    Truncate::<(MilestoneIndex, Receipt), ()>::truncate_op(storage).unwrap();
+    storage.truncate::<(MilestoneIndex, Receipt), ()>().unwrap();
 
     let mut iter = storage.iter::<(MilestoneIndex, Receipt), ()>().unwrap();
 

--- a/bee-storage/bee-storage-test/src/milestone_index_to_receipt.rs
+++ b/bee-storage/bee-storage-test/src/milestone_index_to_receipt.rs
@@ -74,7 +74,9 @@ pub fn milestone_index_to_receipt_access<B: StorageBackend>(storage: &B) {
     for _ in 0..10 {
         let (index, receipt) = (rand_milestone_index(), rand_ledger_receipt());
         Insert::<(MilestoneIndex, Receipt), ()>::insert_op(storage, &(index, receipt.clone()), &()).unwrap();
-        Batch::<(MilestoneIndex, Receipt), ()>::batch_delete_op(storage, &mut batch, &(index, receipt)).unwrap();
+        storage
+            .batch_delete::<(MilestoneIndex, Receipt), ()>(&mut batch, &(index, receipt))
+            .unwrap();
     }
 
     let mut receipts = HashMap::<MilestoneIndex, Vec<Receipt>>::new();
@@ -83,13 +85,9 @@ pub fn milestone_index_to_receipt_access<B: StorageBackend>(storage: &B) {
         let index = rand_milestone_index();
         for _ in 0..5 {
             let receipt = rand_ledger_receipt();
-            Batch::<(MilestoneIndex, Receipt), ()>::batch_insert_op(
-                storage,
-                &mut batch,
-                &(index, receipt.clone()),
-                &(),
-            )
-            .unwrap();
+            storage
+                .batch_insert::<(MilestoneIndex, Receipt), ()>(&mut batch, &(index, receipt.clone()), &())
+                .unwrap();
             receipts.entry(index).or_default().push(receipt);
         }
     }

--- a/bee-storage/bee-storage-test/src/milestone_index_to_receipt.rs
+++ b/bee-storage/bee-storage-test/src/milestone_index_to_receipt.rs
@@ -41,7 +41,11 @@ impl<T> StorageBackend for T where
 pub fn milestone_index_to_receipt_access<B: StorageBackend>(storage: &B) {
     let (index, receipt) = (rand_milestone_index(), rand_ledger_receipt());
 
-    assert!(!Exist::<(MilestoneIndex, Receipt), ()>::exist_op(storage, &(index, receipt.clone())).unwrap());
+    assert!(
+        !storage
+            .exist::<(MilestoneIndex, Receipt), ()>(&(index, receipt.clone()))
+            .unwrap()
+    );
     assert!(
         storage
             .fetch::<MilestoneIndex, Vec<Receipt>>(&index)
@@ -52,7 +56,11 @@ pub fn milestone_index_to_receipt_access<B: StorageBackend>(storage: &B) {
 
     Insert::<(MilestoneIndex, Receipt), ()>::insert_op(storage, &(index, receipt.clone()), &()).unwrap();
 
-    assert!(Exist::<(MilestoneIndex, Receipt), ()>::exist_op(storage, &(index, receipt.clone())).unwrap());
+    assert!(
+        storage
+            .exist::<(MilestoneIndex, Receipt), ()>(&(index, receipt.clone()))
+            .unwrap()
+    );
     assert_eq!(
         storage.fetch::<MilestoneIndex, Vec<Receipt>>(&index).unwrap().unwrap(),
         vec![receipt.clone()]
@@ -62,7 +70,11 @@ pub fn milestone_index_to_receipt_access<B: StorageBackend>(storage: &B) {
         .delete::<(MilestoneIndex, Receipt), ()>(&(index, receipt.clone()))
         .unwrap();
 
-    assert!(!Exist::<(MilestoneIndex, Receipt), ()>::exist_op(storage, &(index, receipt)).unwrap());
+    assert!(
+        !storage
+            .exist::<(MilestoneIndex, Receipt), ()>(&(index, receipt))
+            .unwrap()
+    );
     assert!(
         storage
             .fetch::<MilestoneIndex, Vec<Receipt>>(&index)

--- a/bee-storage/bee-storage-test/src/milestone_index_to_receipt.rs
+++ b/bee-storage/bee-storage-test/src/milestone_index_to_receipt.rs
@@ -58,7 +58,9 @@ pub fn milestone_index_to_receipt_access<B: StorageBackend>(storage: &B) {
         vec![receipt.clone()]
     );
 
-    Delete::<(MilestoneIndex, Receipt), ()>::delete_op(storage, &(index, receipt.clone())).unwrap();
+    storage
+        .delete::<(MilestoneIndex, Receipt), ()>(&(index, receipt.clone()))
+        .unwrap();
 
     assert!(!Exist::<(MilestoneIndex, Receipt), ()>::exist_op(storage, &(index, receipt)).unwrap());
     assert!(

--- a/bee-storage/bee-storage-test/src/milestone_index_to_receipt.rs
+++ b/bee-storage/bee-storage-test/src/milestone_index_to_receipt.rs
@@ -112,7 +112,7 @@ pub fn milestone_index_to_receipt_access<B: StorageBackend>(storage: &B) {
 
     storage.batch_commit(batch, true).unwrap();
 
-    let iter = AsIterator::<(MilestoneIndex, Receipt), ()>::iter_op(storage).unwrap();
+    let iter = storage.iter::<(MilestoneIndex, Receipt), ()>().unwrap();
     let mut count = 0;
 
     for result in iter {
@@ -125,7 +125,7 @@ pub fn milestone_index_to_receipt_access<B: StorageBackend>(storage: &B) {
 
     Truncate::<(MilestoneIndex, Receipt), ()>::truncate_op(storage).unwrap();
 
-    let mut iter = AsIterator::<(MilestoneIndex, Receipt), ()>::iter_op(storage).unwrap();
+    let mut iter = storage.iter::<(MilestoneIndex, Receipt), ()>().unwrap();
 
     assert!(iter.next().is_none());
 }

--- a/bee-storage/bee-storage-test/src/milestone_index_to_receipt.rs
+++ b/bee-storage/bee-storage-test/src/milestone_index_to_receipt.rs
@@ -44,7 +44,7 @@ pub fn milestone_index_to_receipt_access<B: StorageBackend>(storage: &B) {
     assert!(!Exist::<(MilestoneIndex, Receipt), ()>::exist(storage, &(index, receipt.clone())).unwrap());
     assert!(
         storage
-            .fetch_access::<MilestoneIndex, Vec<Receipt>>(&index)
+            .fetch::<MilestoneIndex, Vec<Receipt>>(&index)
             .unwrap()
             .unwrap()
             .is_empty()
@@ -54,10 +54,7 @@ pub fn milestone_index_to_receipt_access<B: StorageBackend>(storage: &B) {
 
     assert!(Exist::<(MilestoneIndex, Receipt), ()>::exist(storage, &(index, receipt.clone())).unwrap());
     assert_eq!(
-        storage
-            .fetch_access::<MilestoneIndex, Vec<Receipt>>(&index)
-            .unwrap()
-            .unwrap(),
+        storage.fetch::<MilestoneIndex, Vec<Receipt>>(&index).unwrap().unwrap(),
         vec![receipt.clone()]
     );
 
@@ -66,7 +63,7 @@ pub fn milestone_index_to_receipt_access<B: StorageBackend>(storage: &B) {
     assert!(!Exist::<(MilestoneIndex, Receipt), ()>::exist(storage, &(index, receipt)).unwrap());
     assert!(
         storage
-            .fetch_access::<MilestoneIndex, Vec<Receipt>>(&index)
+            .fetch::<MilestoneIndex, Vec<Receipt>>(&index)
             .unwrap()
             .unwrap()
             .is_empty()

--- a/bee-storage/bee-storage-test/src/milestone_index_to_unreferenced_message.rs
+++ b/bee-storage/bee-storage-test/src/milestone_index_to_unreferenced_message.rs
@@ -42,7 +42,7 @@ pub fn milestone_index_to_unreferenced_message_access<B: StorageBackend>(storage
     let (index, unreferenced_message) = (rand_milestone_index(), rand_unreferenced_message());
 
     assert!(
-        !Exist::<(MilestoneIndex, UnreferencedMessage), ()>::exist(storage, &(index, unreferenced_message)).unwrap()
+        !Exist::<(MilestoneIndex, UnreferencedMessage), ()>::exist_op(storage, &(index, unreferenced_message)).unwrap()
     );
     assert!(
         storage
@@ -52,10 +52,11 @@ pub fn milestone_index_to_unreferenced_message_access<B: StorageBackend>(storage
             .is_empty()
     );
 
-    Insert::<(MilestoneIndex, UnreferencedMessage), ()>::insert(storage, &(index, unreferenced_message), &()).unwrap();
+    Insert::<(MilestoneIndex, UnreferencedMessage), ()>::insert_op(storage, &(index, unreferenced_message), &())
+        .unwrap();
 
     assert!(
-        Exist::<(MilestoneIndex, UnreferencedMessage), ()>::exist(storage, &(index, unreferenced_message)).unwrap()
+        Exist::<(MilestoneIndex, UnreferencedMessage), ()>::exist_op(storage, &(index, unreferenced_message)).unwrap()
     );
     assert_eq!(
         storage
@@ -65,10 +66,10 @@ pub fn milestone_index_to_unreferenced_message_access<B: StorageBackend>(storage
         vec![unreferenced_message]
     );
 
-    Delete::<(MilestoneIndex, UnreferencedMessage), ()>::delete(storage, &(index, unreferenced_message)).unwrap();
+    Delete::<(MilestoneIndex, UnreferencedMessage), ()>::delete_op(storage, &(index, unreferenced_message)).unwrap();
 
     assert!(
-        !Exist::<(MilestoneIndex, UnreferencedMessage), ()>::exist(storage, &(index, unreferenced_message)).unwrap()
+        !Exist::<(MilestoneIndex, UnreferencedMessage), ()>::exist_op(storage, &(index, unreferenced_message)).unwrap()
     );
     assert!(
         storage
@@ -82,9 +83,9 @@ pub fn milestone_index_to_unreferenced_message_access<B: StorageBackend>(storage
 
     for _ in 0..10 {
         let (index, unreferenced_message) = (rand_milestone_index(), rand_unreferenced_message());
-        Insert::<(MilestoneIndex, UnreferencedMessage), ()>::insert(storage, &(index, unreferenced_message), &())
+        Insert::<(MilestoneIndex, UnreferencedMessage), ()>::insert_op(storage, &(index, unreferenced_message), &())
             .unwrap();
-        Batch::<(MilestoneIndex, UnreferencedMessage), ()>::batch_delete(
+        Batch::<(MilestoneIndex, UnreferencedMessage), ()>::batch_delete_op(
             storage,
             &mut batch,
             &(index, unreferenced_message),
@@ -98,7 +99,7 @@ pub fn milestone_index_to_unreferenced_message_access<B: StorageBackend>(storage
         let index = rand_milestone_index();
         for _ in 0..5 {
             let unreferenced_message = rand_unreferenced_message();
-            Batch::<(MilestoneIndex, UnreferencedMessage), ()>::batch_insert(
+            Batch::<(MilestoneIndex, UnreferencedMessage), ()>::batch_insert_op(
                 storage,
                 &mut batch,
                 &(index, unreferenced_message),
@@ -114,7 +115,7 @@ pub fn milestone_index_to_unreferenced_message_access<B: StorageBackend>(storage
 
     storage.batch_commit(batch, true).unwrap();
 
-    let iter = AsIterator::<(MilestoneIndex, UnreferencedMessage), ()>::iter(storage).unwrap();
+    let iter = AsIterator::<(MilestoneIndex, UnreferencedMessage), ()>::iter_op(storage).unwrap();
     let mut count = 0;
 
     for result in iter {
@@ -125,9 +126,9 @@ pub fn milestone_index_to_unreferenced_message_access<B: StorageBackend>(storage
 
     assert_eq!(count, unreferenced_messages.iter().fold(0, |acc, v| acc + v.1.len()));
 
-    Truncate::<(MilestoneIndex, UnreferencedMessage), ()>::truncate(storage).unwrap();
+    Truncate::<(MilestoneIndex, UnreferencedMessage), ()>::truncate_op(storage).unwrap();
 
-    let mut iter = AsIterator::<(MilestoneIndex, UnreferencedMessage), ()>::iter(storage).unwrap();
+    let mut iter = AsIterator::<(MilestoneIndex, UnreferencedMessage), ()>::iter_op(storage).unwrap();
 
     assert!(iter.next().is_none());
 }

--- a/bee-storage/bee-storage-test/src/milestone_index_to_unreferenced_message.rs
+++ b/bee-storage/bee-storage-test/src/milestone_index_to_unreferenced_message.rs
@@ -42,7 +42,9 @@ pub fn milestone_index_to_unreferenced_message_access<B: StorageBackend>(storage
     let (index, unreferenced_message) = (rand_milestone_index(), rand_unreferenced_message());
 
     assert!(
-        !Exist::<(MilestoneIndex, UnreferencedMessage), ()>::exist_op(storage, &(index, unreferenced_message)).unwrap()
+        !storage
+            .exist::<(MilestoneIndex, UnreferencedMessage), ()>(&(index, unreferenced_message))
+            .unwrap()
     );
     assert!(
         storage
@@ -56,7 +58,9 @@ pub fn milestone_index_to_unreferenced_message_access<B: StorageBackend>(storage
         .unwrap();
 
     assert!(
-        Exist::<(MilestoneIndex, UnreferencedMessage), ()>::exist_op(storage, &(index, unreferenced_message)).unwrap()
+        storage
+            .exist::<(MilestoneIndex, UnreferencedMessage), ()>(&(index, unreferenced_message))
+            .unwrap()
     );
     assert_eq!(
         storage
@@ -71,7 +75,9 @@ pub fn milestone_index_to_unreferenced_message_access<B: StorageBackend>(storage
         .unwrap();
 
     assert!(
-        !Exist::<(MilestoneIndex, UnreferencedMessage), ()>::exist_op(storage, &(index, unreferenced_message)).unwrap()
+        !storage
+            .exist::<(MilestoneIndex, UnreferencedMessage), ()>(&(index, unreferenced_message))
+            .unwrap()
     );
     assert!(
         storage

--- a/bee-storage/bee-storage-test/src/milestone_index_to_unreferenced_message.rs
+++ b/bee-storage/bee-storage-test/src/milestone_index_to_unreferenced_message.rs
@@ -66,7 +66,9 @@ pub fn milestone_index_to_unreferenced_message_access<B: StorageBackend>(storage
         vec![unreferenced_message]
     );
 
-    Delete::<(MilestoneIndex, UnreferencedMessage), ()>::delete_op(storage, &(index, unreferenced_message)).unwrap();
+    storage
+        .delete::<(MilestoneIndex, UnreferencedMessage), ()>(&(index, unreferenced_message))
+        .unwrap();
 
     assert!(
         !Exist::<(MilestoneIndex, UnreferencedMessage), ()>::exist_op(storage, &(index, unreferenced_message)).unwrap()

--- a/bee-storage/bee-storage-test/src/milestone_index_to_unreferenced_message.rs
+++ b/bee-storage/bee-storage-test/src/milestone_index_to_unreferenced_message.rs
@@ -122,7 +122,7 @@ pub fn milestone_index_to_unreferenced_message_access<B: StorageBackend>(storage
 
     storage.batch_commit(batch, true).unwrap();
 
-    let iter = AsIterator::<(MilestoneIndex, UnreferencedMessage), ()>::iter_op(storage).unwrap();
+    let iter = storage.iter::<(MilestoneIndex, UnreferencedMessage), ()>().unwrap();
     let mut count = 0;
 
     for result in iter {
@@ -135,7 +135,7 @@ pub fn milestone_index_to_unreferenced_message_access<B: StorageBackend>(storage
 
     Truncate::<(MilestoneIndex, UnreferencedMessage), ()>::truncate_op(storage).unwrap();
 
-    let mut iter = AsIterator::<(MilestoneIndex, UnreferencedMessage), ()>::iter_op(storage).unwrap();
+    let mut iter = storage.iter::<(MilestoneIndex, UnreferencedMessage), ()>().unwrap();
 
     assert!(iter.next().is_none());
 }

--- a/bee-storage/bee-storage-test/src/milestone_index_to_unreferenced_message.rs
+++ b/bee-storage/bee-storage-test/src/milestone_index_to_unreferenced_message.rs
@@ -7,6 +7,7 @@ use bee_message::milestone::MilestoneIndex;
 use bee_storage::{
     access::{AsIterator, Batch, BatchBuilder, Delete, Exist, Fetch, Insert, Truncate},
     backend,
+    backend::StorageBackendExt,
 };
 use bee_tangle::unreferenced_message::UnreferencedMessage;
 use bee_test::rand::{milestone::rand_milestone_index, unreferenced_message::rand_unreferenced_message};
@@ -44,7 +45,8 @@ pub fn milestone_index_to_unreferenced_message_access<B: StorageBackend>(storage
         !Exist::<(MilestoneIndex, UnreferencedMessage), ()>::exist(storage, &(index, unreferenced_message)).unwrap()
     );
     assert!(
-        Fetch::<MilestoneIndex, Vec<UnreferencedMessage>>::fetch(storage, &index)
+        storage
+            .fetch_access::<MilestoneIndex, Vec<UnreferencedMessage>>(&index)
             .unwrap()
             .unwrap()
             .is_empty()
@@ -56,7 +58,8 @@ pub fn milestone_index_to_unreferenced_message_access<B: StorageBackend>(storage
         Exist::<(MilestoneIndex, UnreferencedMessage), ()>::exist(storage, &(index, unreferenced_message)).unwrap()
     );
     assert_eq!(
-        Fetch::<MilestoneIndex, Vec<UnreferencedMessage>>::fetch(storage, &index)
+        storage
+            .fetch_access::<MilestoneIndex, Vec<UnreferencedMessage>>(&index)
             .unwrap()
             .unwrap(),
         vec![unreferenced_message]
@@ -68,7 +71,8 @@ pub fn milestone_index_to_unreferenced_message_access<B: StorageBackend>(storage
         !Exist::<(MilestoneIndex, UnreferencedMessage), ()>::exist(storage, &(index, unreferenced_message)).unwrap()
     );
     assert!(
-        Fetch::<MilestoneIndex, Vec<UnreferencedMessage>>::fetch(storage, &index)
+        storage
+            .fetch_access::<MilestoneIndex, Vec<UnreferencedMessage>>(&index)
             .unwrap()
             .unwrap()
             .is_empty()

--- a/bee-storage/bee-storage-test/src/milestone_index_to_unreferenced_message.rs
+++ b/bee-storage/bee-storage-test/src/milestone_index_to_unreferenced_message.rs
@@ -85,12 +85,9 @@ pub fn milestone_index_to_unreferenced_message_access<B: StorageBackend>(storage
         let (index, unreferenced_message) = (rand_milestone_index(), rand_unreferenced_message());
         Insert::<(MilestoneIndex, UnreferencedMessage), ()>::insert_op(storage, &(index, unreferenced_message), &())
             .unwrap();
-        Batch::<(MilestoneIndex, UnreferencedMessage), ()>::batch_delete_op(
-            storage,
-            &mut batch,
-            &(index, unreferenced_message),
-        )
-        .unwrap();
+        storage
+            .batch_delete::<(MilestoneIndex, UnreferencedMessage), ()>(&mut batch, &(index, unreferenced_message))
+            .unwrap();
     }
 
     let mut unreferenced_messages = HashMap::<MilestoneIndex, Vec<UnreferencedMessage>>::new();
@@ -99,13 +96,13 @@ pub fn milestone_index_to_unreferenced_message_access<B: StorageBackend>(storage
         let index = rand_milestone_index();
         for _ in 0..5 {
             let unreferenced_message = rand_unreferenced_message();
-            Batch::<(MilestoneIndex, UnreferencedMessage), ()>::batch_insert_op(
-                storage,
-                &mut batch,
-                &(index, unreferenced_message),
-                &(),
-            )
-            .unwrap();
+            storage
+                .batch_insert::<(MilestoneIndex, UnreferencedMessage), ()>(
+                    &mut batch,
+                    &(index, unreferenced_message),
+                    &(),
+                )
+                .unwrap();
             unreferenced_messages
                 .entry(index)
                 .or_default()

--- a/bee-storage/bee-storage-test/src/milestone_index_to_unreferenced_message.rs
+++ b/bee-storage/bee-storage-test/src/milestone_index_to_unreferenced_message.rs
@@ -54,9 +54,7 @@ pub fn milestone_index_to_unreferenced_message_access<B: StorageBackend>(storage
             .is_empty()
     );
 
-    storage
-        .insert::<(MilestoneIndex, UnreferencedMessage), ()>(&(index, unreferenced_message), &())
-        .unwrap();
+    storage.insert(&(index, unreferenced_message), &()).unwrap();
 
     assert!(
         storage
@@ -92,9 +90,7 @@ pub fn milestone_index_to_unreferenced_message_access<B: StorageBackend>(storage
 
     for _ in 0..10 {
         let (index, unreferenced_message) = (rand_milestone_index(), rand_unreferenced_message());
-        storage
-            .insert::<(MilestoneIndex, UnreferencedMessage), ()>(&(index, unreferenced_message), &())
-            .unwrap();
+        storage.insert(&(index, unreferenced_message), &()).unwrap();
         storage
             .batch_delete::<(MilestoneIndex, UnreferencedMessage), ()>(&mut batch, &(index, unreferenced_message))
             .unwrap();
@@ -107,11 +103,7 @@ pub fn milestone_index_to_unreferenced_message_access<B: StorageBackend>(storage
         for _ in 0..5 {
             let unreferenced_message = rand_unreferenced_message();
             storage
-                .batch_insert::<(MilestoneIndex, UnreferencedMessage), ()>(
-                    &mut batch,
-                    &(index, unreferenced_message),
-                    &(),
-                )
+                .batch_insert(&mut batch, &(index, unreferenced_message), &())
                 .unwrap();
             unreferenced_messages
                 .entry(index)

--- a/bee-storage/bee-storage-test/src/milestone_index_to_unreferenced_message.rs
+++ b/bee-storage/bee-storage-test/src/milestone_index_to_unreferenced_message.rs
@@ -54,7 +54,8 @@ pub fn milestone_index_to_unreferenced_message_access<B: StorageBackend>(storage
             .is_empty()
     );
 
-    Insert::<(MilestoneIndex, UnreferencedMessage), ()>::insert_op(storage, &(index, unreferenced_message), &())
+    storage
+        .insert::<(MilestoneIndex, UnreferencedMessage), ()>(&(index, unreferenced_message), &())
         .unwrap();
 
     assert!(
@@ -91,7 +92,8 @@ pub fn milestone_index_to_unreferenced_message_access<B: StorageBackend>(storage
 
     for _ in 0..10 {
         let (index, unreferenced_message) = (rand_milestone_index(), rand_unreferenced_message());
-        Insert::<(MilestoneIndex, UnreferencedMessage), ()>::insert_op(storage, &(index, unreferenced_message), &())
+        storage
+            .insert::<(MilestoneIndex, UnreferencedMessage), ()>(&(index, unreferenced_message), &())
             .unwrap();
         storage
             .batch_delete::<(MilestoneIndex, UnreferencedMessage), ()>(&mut batch, &(index, unreferenced_message))

--- a/bee-storage/bee-storage-test/src/milestone_index_to_unreferenced_message.rs
+++ b/bee-storage/bee-storage-test/src/milestone_index_to_unreferenced_message.rs
@@ -133,7 +133,7 @@ pub fn milestone_index_to_unreferenced_message_access<B: StorageBackend>(storage
 
     assert_eq!(count, unreferenced_messages.iter().fold(0, |acc, v| acc + v.1.len()));
 
-    Truncate::<(MilestoneIndex, UnreferencedMessage), ()>::truncate_op(storage).unwrap();
+    storage.truncate::<(MilestoneIndex, UnreferencedMessage), ()>().unwrap();
 
     let mut iter = storage.iter::<(MilestoneIndex, UnreferencedMessage), ()>().unwrap();
 

--- a/bee-storage/bee-storage-test/src/milestone_index_to_unreferenced_message.rs
+++ b/bee-storage/bee-storage-test/src/milestone_index_to_unreferenced_message.rs
@@ -46,7 +46,7 @@ pub fn milestone_index_to_unreferenced_message_access<B: StorageBackend>(storage
     );
     assert!(
         storage
-            .fetch_access::<MilestoneIndex, Vec<UnreferencedMessage>>(&index)
+            .fetch::<MilestoneIndex, Vec<UnreferencedMessage>>(&index)
             .unwrap()
             .unwrap()
             .is_empty()
@@ -59,7 +59,7 @@ pub fn milestone_index_to_unreferenced_message_access<B: StorageBackend>(storage
     );
     assert_eq!(
         storage
-            .fetch_access::<MilestoneIndex, Vec<UnreferencedMessage>>(&index)
+            .fetch::<MilestoneIndex, Vec<UnreferencedMessage>>(&index)
             .unwrap()
             .unwrap(),
         vec![unreferenced_message]
@@ -72,7 +72,7 @@ pub fn milestone_index_to_unreferenced_message_access<B: StorageBackend>(storage
     );
     assert!(
         storage
-            .fetch_access::<MilestoneIndex, Vec<UnreferencedMessage>>(&index)
+            .fetch::<MilestoneIndex, Vec<UnreferencedMessage>>(&index)
             .unwrap()
             .unwrap()
             .is_empty()

--- a/bee-storage/bee-storage-test/src/output_id_to_consumed_output.rs
+++ b/bee-storage/bee-storage-test/src/output_id_to_consumed_output.rs
@@ -41,32 +41,32 @@ impl<T> StorageBackend for T where
 pub fn output_id_to_consumed_output_access<B: StorageBackend>(storage: &B) {
     let (output_id, consumed_output) = (rand_output_id(), rand_consumed_output());
 
-    assert!(!Exist::<OutputId, ConsumedOutput>::exist(storage, &output_id).unwrap());
+    assert!(!Exist::<OutputId, ConsumedOutput>::exist_op(storage, &output_id).unwrap());
     assert!(storage.fetch::<OutputId, ConsumedOutput>(&output_id).unwrap().is_none());
-    let results = MultiFetch::<OutputId, ConsumedOutput>::multi_fetch(storage, &[output_id])
+    let results = MultiFetch::<OutputId, ConsumedOutput>::multi_fetch_op(storage, &[output_id])
         .unwrap()
         .collect::<Vec<_>>();
     assert_eq!(results.len(), 1);
     assert!(matches!(results.get(0), Some(Ok(None))));
 
-    Insert::<OutputId, ConsumedOutput>::insert(storage, &output_id, &consumed_output).unwrap();
+    Insert::<OutputId, ConsumedOutput>::insert_op(storage, &output_id, &consumed_output).unwrap();
 
-    assert!(Exist::<OutputId, ConsumedOutput>::exist(storage, &output_id).unwrap());
+    assert!(Exist::<OutputId, ConsumedOutput>::exist_op(storage, &output_id).unwrap());
     assert_eq!(
         storage.fetch::<OutputId, ConsumedOutput>(&output_id).unwrap().unwrap(),
         consumed_output
     );
-    let results = MultiFetch::<OutputId, ConsumedOutput>::multi_fetch(storage, &[output_id])
+    let results = MultiFetch::<OutputId, ConsumedOutput>::multi_fetch_op(storage, &[output_id])
         .unwrap()
         .collect::<Vec<_>>();
     assert_eq!(results.len(), 1);
     assert!(matches!(results.get(0), Some(Ok(Some(v))) if v == &consumed_output));
 
-    Delete::<OutputId, ConsumedOutput>::delete(storage, &output_id).unwrap();
+    Delete::<OutputId, ConsumedOutput>::delete_op(storage, &output_id).unwrap();
 
-    assert!(!Exist::<OutputId, ConsumedOutput>::exist(storage, &output_id).unwrap());
+    assert!(!Exist::<OutputId, ConsumedOutput>::exist_op(storage, &output_id).unwrap());
     assert!(storage.fetch::<OutputId, ConsumedOutput>(&output_id).unwrap().is_none());
-    let results = MultiFetch::<OutputId, ConsumedOutput>::multi_fetch(storage, &[output_id])
+    let results = MultiFetch::<OutputId, ConsumedOutput>::multi_fetch_op(storage, &[output_id])
         .unwrap()
         .collect::<Vec<_>>();
     assert_eq!(results.len(), 1);
@@ -78,22 +78,22 @@ pub fn output_id_to_consumed_output_access<B: StorageBackend>(storage: &B) {
 
     for _ in 0..10 {
         let (output_id, consumed_output) = (rand_output_id(), rand_consumed_output());
-        Insert::<OutputId, ConsumedOutput>::insert(storage, &output_id, &consumed_output).unwrap();
-        Batch::<OutputId, ConsumedOutput>::batch_delete(storage, &mut batch, &output_id).unwrap();
+        Insert::<OutputId, ConsumedOutput>::insert_op(storage, &output_id, &consumed_output).unwrap();
+        Batch::<OutputId, ConsumedOutput>::batch_delete_op(storage, &mut batch, &output_id).unwrap();
         output_ids.push(output_id);
         consumed_outputs.push((output_id, None));
     }
 
     for _ in 0..10 {
         let (output_id, consumed_output) = (rand_output_id(), rand_consumed_output());
-        Batch::<OutputId, ConsumedOutput>::batch_insert(storage, &mut batch, &output_id, &consumed_output).unwrap();
+        Batch::<OutputId, ConsumedOutput>::batch_insert_op(storage, &mut batch, &output_id, &consumed_output).unwrap();
         output_ids.push(output_id);
         consumed_outputs.push((output_id, Some(consumed_output)));
     }
 
     storage.batch_commit(batch, true).unwrap();
 
-    let iter = AsIterator::<OutputId, ConsumedOutput>::iter(storage).unwrap();
+    let iter = AsIterator::<OutputId, ConsumedOutput>::iter_op(storage).unwrap();
     let mut count = 0;
 
     for result in iter {
@@ -104,7 +104,7 @@ pub fn output_id_to_consumed_output_access<B: StorageBackend>(storage: &B) {
 
     assert_eq!(count, 10);
 
-    let results = MultiFetch::<OutputId, ConsumedOutput>::multi_fetch(storage, &output_ids)
+    let results = MultiFetch::<OutputId, ConsumedOutput>::multi_fetch_op(storage, &output_ids)
         .unwrap()
         .collect::<Vec<_>>();
 
@@ -114,9 +114,9 @@ pub fn output_id_to_consumed_output_access<B: StorageBackend>(storage: &B) {
         assert_eq!(consumed_output, result.unwrap());
     }
 
-    Truncate::<OutputId, ConsumedOutput>::truncate(storage).unwrap();
+    Truncate::<OutputId, ConsumedOutput>::truncate_op(storage).unwrap();
 
-    let mut iter = AsIterator::<OutputId, ConsumedOutput>::iter(storage).unwrap();
+    let mut iter = AsIterator::<OutputId, ConsumedOutput>::iter_op(storage).unwrap();
 
     assert!(iter.next().is_none());
 }

--- a/bee-storage/bee-storage-test/src/output_id_to_consumed_output.rs
+++ b/bee-storage/bee-storage-test/src/output_id_to_consumed_output.rs
@@ -79,14 +79,18 @@ pub fn output_id_to_consumed_output_access<B: StorageBackend>(storage: &B) {
     for _ in 0..10 {
         let (output_id, consumed_output) = (rand_output_id(), rand_consumed_output());
         Insert::<OutputId, ConsumedOutput>::insert_op(storage, &output_id, &consumed_output).unwrap();
-        Batch::<OutputId, ConsumedOutput>::batch_delete_op(storage, &mut batch, &output_id).unwrap();
+        storage
+            .batch_delete::<OutputId, ConsumedOutput>(&mut batch, &output_id)
+            .unwrap();
         output_ids.push(output_id);
         consumed_outputs.push((output_id, None));
     }
 
     for _ in 0..10 {
         let (output_id, consumed_output) = (rand_output_id(), rand_consumed_output());
-        Batch::<OutputId, ConsumedOutput>::batch_insert_op(storage, &mut batch, &output_id, &consumed_output).unwrap();
+        storage
+            .batch_insert::<OutputId, ConsumedOutput>(&mut batch, &output_id, &consumed_output)
+            .unwrap();
         output_ids.push(output_id);
         consumed_outputs.push((output_id, Some(consumed_output)));
     }

--- a/bee-storage/bee-storage-test/src/output_id_to_consumed_output.rs
+++ b/bee-storage/bee-storage-test/src/output_id_to_consumed_output.rs
@@ -42,12 +42,7 @@ pub fn output_id_to_consumed_output_access<B: StorageBackend>(storage: &B) {
     let (output_id, consumed_output) = (rand_output_id(), rand_consumed_output());
 
     assert!(!Exist::<OutputId, ConsumedOutput>::exist(storage, &output_id).unwrap());
-    assert!(
-        storage
-            .fetch_access::<OutputId, ConsumedOutput>(&output_id)
-            .unwrap()
-            .is_none()
-    );
+    assert!(storage.fetch::<OutputId, ConsumedOutput>(&output_id).unwrap().is_none());
     let results = MultiFetch::<OutputId, ConsumedOutput>::multi_fetch(storage, &[output_id])
         .unwrap()
         .collect::<Vec<_>>();
@@ -58,10 +53,7 @@ pub fn output_id_to_consumed_output_access<B: StorageBackend>(storage: &B) {
 
     assert!(Exist::<OutputId, ConsumedOutput>::exist(storage, &output_id).unwrap());
     assert_eq!(
-        storage
-            .fetch_access::<OutputId, ConsumedOutput>(&output_id)
-            .unwrap()
-            .unwrap(),
+        storage.fetch::<OutputId, ConsumedOutput>(&output_id).unwrap().unwrap(),
         consumed_output
     );
     let results = MultiFetch::<OutputId, ConsumedOutput>::multi_fetch(storage, &[output_id])
@@ -73,12 +65,7 @@ pub fn output_id_to_consumed_output_access<B: StorageBackend>(storage: &B) {
     Delete::<OutputId, ConsumedOutput>::delete(storage, &output_id).unwrap();
 
     assert!(!Exist::<OutputId, ConsumedOutput>::exist(storage, &output_id).unwrap());
-    assert!(
-        storage
-            .fetch_access::<OutputId, ConsumedOutput>(&output_id)
-            .unwrap()
-            .is_none()
-    );
+    assert!(storage.fetch::<OutputId, ConsumedOutput>(&output_id).unwrap().is_none());
     let results = MultiFetch::<OutputId, ConsumedOutput>::multi_fetch(storage, &[output_id])
         .unwrap()
         .collect::<Vec<_>>();

--- a/bee-storage/bee-storage-test/src/output_id_to_consumed_output.rs
+++ b/bee-storage/bee-storage-test/src/output_id_to_consumed_output.rs
@@ -62,7 +62,7 @@ pub fn output_id_to_consumed_output_access<B: StorageBackend>(storage: &B) {
     assert_eq!(results.len(), 1);
     assert!(matches!(results.get(0), Some(Ok(Some(v))) if v == &consumed_output));
 
-    Delete::<OutputId, ConsumedOutput>::delete_op(storage, &output_id).unwrap();
+    storage.delete::<OutputId, ConsumedOutput>(&output_id).unwrap();
 
     assert!(!Exist::<OutputId, ConsumedOutput>::exist_op(storage, &output_id).unwrap());
     assert!(storage.fetch::<OutputId, ConsumedOutput>(&output_id).unwrap().is_none());

--- a/bee-storage/bee-storage-test/src/output_id_to_consumed_output.rs
+++ b/bee-storage/bee-storage-test/src/output_id_to_consumed_output.rs
@@ -41,7 +41,7 @@ impl<T> StorageBackend for T where
 pub fn output_id_to_consumed_output_access<B: StorageBackend>(storage: &B) {
     let (output_id, consumed_output) = (rand_output_id(), rand_consumed_output());
 
-    assert!(!Exist::<OutputId, ConsumedOutput>::exist_op(storage, &output_id).unwrap());
+    assert!(!storage.exist::<OutputId, ConsumedOutput>(&output_id).unwrap());
     assert!(storage.fetch::<OutputId, ConsumedOutput>(&output_id).unwrap().is_none());
     let results = MultiFetch::<OutputId, ConsumedOutput>::multi_fetch_op(storage, &[output_id])
         .unwrap()
@@ -51,7 +51,7 @@ pub fn output_id_to_consumed_output_access<B: StorageBackend>(storage: &B) {
 
     Insert::<OutputId, ConsumedOutput>::insert_op(storage, &output_id, &consumed_output).unwrap();
 
-    assert!(Exist::<OutputId, ConsumedOutput>::exist_op(storage, &output_id).unwrap());
+    assert!(storage.exist::<OutputId, ConsumedOutput>(&output_id).unwrap());
     assert_eq!(
         storage.fetch::<OutputId, ConsumedOutput>(&output_id).unwrap().unwrap(),
         consumed_output
@@ -64,7 +64,7 @@ pub fn output_id_to_consumed_output_access<B: StorageBackend>(storage: &B) {
 
     storage.delete::<OutputId, ConsumedOutput>(&output_id).unwrap();
 
-    assert!(!Exist::<OutputId, ConsumedOutput>::exist_op(storage, &output_id).unwrap());
+    assert!(!storage.exist::<OutputId, ConsumedOutput>(&output_id).unwrap());
     assert!(storage.fetch::<OutputId, ConsumedOutput>(&output_id).unwrap().is_none());
     let results = MultiFetch::<OutputId, ConsumedOutput>::multi_fetch_op(storage, &[output_id])
         .unwrap()

--- a/bee-storage/bee-storage-test/src/output_id_to_consumed_output.rs
+++ b/bee-storage/bee-storage-test/src/output_id_to_consumed_output.rs
@@ -101,7 +101,7 @@ pub fn output_id_to_consumed_output_access<B: StorageBackend>(storage: &B) {
 
     storage.batch_commit(batch, true).unwrap();
 
-    let iter = AsIterator::<OutputId, ConsumedOutput>::iter_op(storage).unwrap();
+    let iter = storage.iter::<OutputId, ConsumedOutput>().unwrap();
     let mut count = 0;
 
     for result in iter {
@@ -124,7 +124,7 @@ pub fn output_id_to_consumed_output_access<B: StorageBackend>(storage: &B) {
 
     Truncate::<OutputId, ConsumedOutput>::truncate_op(storage).unwrap();
 
-    let mut iter = AsIterator::<OutputId, ConsumedOutput>::iter_op(storage).unwrap();
+    let mut iter = storage.iter::<OutputId, ConsumedOutput>().unwrap();
 
     assert!(iter.next().is_none());
 }

--- a/bee-storage/bee-storage-test/src/output_id_to_consumed_output.rs
+++ b/bee-storage/bee-storage-test/src/output_id_to_consumed_output.rs
@@ -126,7 +126,7 @@ pub fn output_id_to_consumed_output_access<B: StorageBackend>(storage: &B) {
         assert_eq!(consumed_output, result.unwrap());
     }
 
-    Truncate::<OutputId, ConsumedOutput>::truncate_op(storage).unwrap();
+    storage.truncate::<OutputId, ConsumedOutput>().unwrap();
 
     let mut iter = storage.iter::<OutputId, ConsumedOutput>().unwrap();
 

--- a/bee-storage/bee-storage-test/src/output_id_to_consumed_output.rs
+++ b/bee-storage/bee-storage-test/src/output_id_to_consumed_output.rs
@@ -49,7 +49,9 @@ pub fn output_id_to_consumed_output_access<B: StorageBackend>(storage: &B) {
     assert_eq!(results.len(), 1);
     assert!(matches!(results.get(0), Some(Ok(None))));
 
-    Insert::<OutputId, ConsumedOutput>::insert_op(storage, &output_id, &consumed_output).unwrap();
+    storage
+        .insert::<OutputId, ConsumedOutput>(&output_id, &consumed_output)
+        .unwrap();
 
     assert!(storage.exist::<OutputId, ConsumedOutput>(&output_id).unwrap());
     assert_eq!(
@@ -78,7 +80,9 @@ pub fn output_id_to_consumed_output_access<B: StorageBackend>(storage: &B) {
 
     for _ in 0..10 {
         let (output_id, consumed_output) = (rand_output_id(), rand_consumed_output());
-        Insert::<OutputId, ConsumedOutput>::insert_op(storage, &output_id, &consumed_output).unwrap();
+        storage
+            .insert::<OutputId, ConsumedOutput>(&output_id, &consumed_output)
+            .unwrap();
         storage
             .batch_delete::<OutputId, ConsumedOutput>(&mut batch, &output_id)
             .unwrap();

--- a/bee-storage/bee-storage-test/src/output_id_to_consumed_output.rs
+++ b/bee-storage/bee-storage-test/src/output_id_to_consumed_output.rs
@@ -43,7 +43,8 @@ pub fn output_id_to_consumed_output_access<B: StorageBackend>(storage: &B) {
 
     assert!(!storage.exist::<OutputId, ConsumedOutput>(&output_id).unwrap());
     assert!(storage.fetch::<OutputId, ConsumedOutput>(&output_id).unwrap().is_none());
-    let results = MultiFetch::<OutputId, ConsumedOutput>::multi_fetch_op(storage, &[output_id])
+    let results = storage
+        .multi_fetch::<OutputId, ConsumedOutput>(&[output_id])
         .unwrap()
         .collect::<Vec<_>>();
     assert_eq!(results.len(), 1);
@@ -58,7 +59,8 @@ pub fn output_id_to_consumed_output_access<B: StorageBackend>(storage: &B) {
         storage.fetch::<OutputId, ConsumedOutput>(&output_id).unwrap().unwrap(),
         consumed_output
     );
-    let results = MultiFetch::<OutputId, ConsumedOutput>::multi_fetch_op(storage, &[output_id])
+    let results = storage
+        .multi_fetch::<OutputId, ConsumedOutput>(&[output_id])
         .unwrap()
         .collect::<Vec<_>>();
     assert_eq!(results.len(), 1);
@@ -68,7 +70,8 @@ pub fn output_id_to_consumed_output_access<B: StorageBackend>(storage: &B) {
 
     assert!(!storage.exist::<OutputId, ConsumedOutput>(&output_id).unwrap());
     assert!(storage.fetch::<OutputId, ConsumedOutput>(&output_id).unwrap().is_none());
-    let results = MultiFetch::<OutputId, ConsumedOutput>::multi_fetch_op(storage, &[output_id])
+    let results = storage
+        .multi_fetch::<OutputId, ConsumedOutput>(&[output_id])
         .unwrap()
         .collect::<Vec<_>>();
     assert_eq!(results.len(), 1);
@@ -112,7 +115,8 @@ pub fn output_id_to_consumed_output_access<B: StorageBackend>(storage: &B) {
 
     assert_eq!(count, 10);
 
-    let results = MultiFetch::<OutputId, ConsumedOutput>::multi_fetch_op(storage, &output_ids)
+    let results = storage
+        .multi_fetch::<OutputId, ConsumedOutput>(&output_ids)
         .unwrap()
         .collect::<Vec<_>>();
 

--- a/bee-storage/bee-storage-test/src/output_id_to_consumed_output.rs
+++ b/bee-storage/bee-storage-test/src/output_id_to_consumed_output.rs
@@ -50,9 +50,7 @@ pub fn output_id_to_consumed_output_access<B: StorageBackend>(storage: &B) {
     assert_eq!(results.len(), 1);
     assert!(matches!(results.get(0), Some(Ok(None))));
 
-    storage
-        .insert::<OutputId, ConsumedOutput>(&output_id, &consumed_output)
-        .unwrap();
+    storage.insert(&output_id, &consumed_output).unwrap();
 
     assert!(storage.exist::<OutputId, ConsumedOutput>(&output_id).unwrap());
     assert_eq!(
@@ -83,9 +81,7 @@ pub fn output_id_to_consumed_output_access<B: StorageBackend>(storage: &B) {
 
     for _ in 0..10 {
         let (output_id, consumed_output) = (rand_output_id(), rand_consumed_output());
-        storage
-            .insert::<OutputId, ConsumedOutput>(&output_id, &consumed_output)
-            .unwrap();
+        storage.insert(&output_id, &consumed_output).unwrap();
         storage
             .batch_delete::<OutputId, ConsumedOutput>(&mut batch, &output_id)
             .unwrap();
@@ -95,9 +91,7 @@ pub fn output_id_to_consumed_output_access<B: StorageBackend>(storage: &B) {
 
     for _ in 0..10 {
         let (output_id, consumed_output) = (rand_output_id(), rand_consumed_output());
-        storage
-            .batch_insert::<OutputId, ConsumedOutput>(&mut batch, &output_id, &consumed_output)
-            .unwrap();
+        storage.batch_insert(&mut batch, &output_id, &consumed_output).unwrap();
         output_ids.push(output_id);
         consumed_outputs.push((output_id, Some(consumed_output)));
     }

--- a/bee-storage/bee-storage-test/src/output_id_to_consumed_output.rs
+++ b/bee-storage/bee-storage-test/src/output_id_to_consumed_output.rs
@@ -6,6 +6,7 @@ use bee_message::output::OutputId;
 use bee_storage::{
     access::{AsIterator, Batch, BatchBuilder, Delete, Exist, Fetch, Insert, MultiFetch, Truncate},
     backend,
+    backend::StorageBackendExt,
 };
 use bee_test::rand::output::{rand_consumed_output, rand_output_id};
 
@@ -42,7 +43,8 @@ pub fn output_id_to_consumed_output_access<B: StorageBackend>(storage: &B) {
 
     assert!(!Exist::<OutputId, ConsumedOutput>::exist(storage, &output_id).unwrap());
     assert!(
-        Fetch::<OutputId, ConsumedOutput>::fetch(storage, &output_id)
+        storage
+            .fetch_access::<OutputId, ConsumedOutput>(&output_id)
             .unwrap()
             .is_none()
     );
@@ -56,7 +58,8 @@ pub fn output_id_to_consumed_output_access<B: StorageBackend>(storage: &B) {
 
     assert!(Exist::<OutputId, ConsumedOutput>::exist(storage, &output_id).unwrap());
     assert_eq!(
-        Fetch::<OutputId, ConsumedOutput>::fetch(storage, &output_id)
+        storage
+            .fetch_access::<OutputId, ConsumedOutput>(&output_id)
             .unwrap()
             .unwrap(),
         consumed_output
@@ -71,7 +74,8 @@ pub fn output_id_to_consumed_output_access<B: StorageBackend>(storage: &B) {
 
     assert!(!Exist::<OutputId, ConsumedOutput>::exist(storage, &output_id).unwrap());
     assert!(
-        Fetch::<OutputId, ConsumedOutput>::fetch(storage, &output_id)
+        storage
+            .fetch_access::<OutputId, ConsumedOutput>(&output_id)
             .unwrap()
             .is_none()
     );

--- a/bee-storage/bee-storage-test/src/output_id_to_created_output.rs
+++ b/bee-storage/bee-storage-test/src/output_id_to_created_output.rs
@@ -126,7 +126,7 @@ pub fn output_id_to_created_output_access<B: StorageBackend>(storage: &B) {
         assert_eq!(created_output, result.unwrap());
     }
 
-    Truncate::<OutputId, CreatedOutput>::truncate_op(storage).unwrap();
+    storage.truncate::<OutputId, CreatedOutput>().unwrap();
 
     let mut iter = storage.iter::<OutputId, CreatedOutput>().unwrap();
 

--- a/bee-storage/bee-storage-test/src/output_id_to_created_output.rs
+++ b/bee-storage/bee-storage-test/src/output_id_to_created_output.rs
@@ -50,9 +50,7 @@ pub fn output_id_to_created_output_access<B: StorageBackend>(storage: &B) {
     assert_eq!(results.len(), 1);
     assert!(matches!(results.get(0), Some(Ok(None))));
 
-    storage
-        .insert::<OutputId, CreatedOutput>(&output_id, &created_output)
-        .unwrap();
+    storage.insert(&output_id, &created_output).unwrap();
 
     assert!(storage.exist::<OutputId, CreatedOutput>(&output_id).unwrap());
     assert_eq!(
@@ -83,9 +81,7 @@ pub fn output_id_to_created_output_access<B: StorageBackend>(storage: &B) {
 
     for _ in 0..10 {
         let (output_id, created_output) = (rand_output_id(), rand_created_output());
-        storage
-            .insert::<OutputId, CreatedOutput>(&output_id, &created_output)
-            .unwrap();
+        storage.insert(&output_id, &created_output).unwrap();
         storage
             .batch_delete::<OutputId, CreatedOutput>(&mut batch, &output_id)
             .unwrap();
@@ -95,9 +91,7 @@ pub fn output_id_to_created_output_access<B: StorageBackend>(storage: &B) {
 
     for _ in 0..10 {
         let (output_id, created_output) = (rand_output_id(), rand_created_output());
-        storage
-            .batch_insert::<OutputId, CreatedOutput>(&mut batch, &output_id, &created_output)
-            .unwrap();
+        storage.batch_insert(&mut batch, &output_id, &created_output).unwrap();
         output_ids.push(output_id);
         created_outputs.push((output_id, Some(created_output)));
     }

--- a/bee-storage/bee-storage-test/src/output_id_to_created_output.rs
+++ b/bee-storage/bee-storage-test/src/output_id_to_created_output.rs
@@ -101,7 +101,7 @@ pub fn output_id_to_created_output_access<B: StorageBackend>(storage: &B) {
 
     storage.batch_commit(batch, true).unwrap();
 
-    let iter = AsIterator::<OutputId, CreatedOutput>::iter_op(storage).unwrap();
+    let iter = storage.iter::<OutputId, CreatedOutput>().unwrap();
     let mut count = 0;
 
     for result in iter {
@@ -124,7 +124,7 @@ pub fn output_id_to_created_output_access<B: StorageBackend>(storage: &B) {
 
     Truncate::<OutputId, CreatedOutput>::truncate_op(storage).unwrap();
 
-    let mut iter = AsIterator::<OutputId, CreatedOutput>::iter_op(storage).unwrap();
+    let mut iter = storage.iter::<OutputId, CreatedOutput>().unwrap();
 
     assert!(iter.next().is_none());
 }

--- a/bee-storage/bee-storage-test/src/output_id_to_created_output.rs
+++ b/bee-storage/bee-storage-test/src/output_id_to_created_output.rs
@@ -62,7 +62,7 @@ pub fn output_id_to_created_output_access<B: StorageBackend>(storage: &B) {
     assert_eq!(results.len(), 1);
     assert!(matches!(results.get(0), Some(Ok(Some(v))) if v == &created_output));
 
-    Delete::<OutputId, CreatedOutput>::delete_op(storage, &output_id).unwrap();
+    storage.delete::<OutputId, CreatedOutput>(&output_id).unwrap();
 
     assert!(!Exist::<OutputId, CreatedOutput>::exist_op(storage, &output_id).unwrap());
     assert!(storage.fetch::<OutputId, CreatedOutput>(&output_id).unwrap().is_none());

--- a/bee-storage/bee-storage-test/src/output_id_to_created_output.rs
+++ b/bee-storage/bee-storage-test/src/output_id_to_created_output.rs
@@ -41,32 +41,32 @@ impl<T> StorageBackend for T where
 pub fn output_id_to_created_output_access<B: StorageBackend>(storage: &B) {
     let (output_id, created_output) = (rand_output_id(), rand_created_output());
 
-    assert!(!Exist::<OutputId, CreatedOutput>::exist(storage, &output_id).unwrap());
+    assert!(!Exist::<OutputId, CreatedOutput>::exist_op(storage, &output_id).unwrap());
     assert!(storage.fetch::<OutputId, CreatedOutput>(&output_id).unwrap().is_none());
-    let results = MultiFetch::<OutputId, CreatedOutput>::multi_fetch(storage, &[output_id])
+    let results = MultiFetch::<OutputId, CreatedOutput>::multi_fetch_op(storage, &[output_id])
         .unwrap()
         .collect::<Vec<_>>();
     assert_eq!(results.len(), 1);
     assert!(matches!(results.get(0), Some(Ok(None))));
 
-    Insert::<OutputId, CreatedOutput>::insert(storage, &output_id, &created_output).unwrap();
+    Insert::<OutputId, CreatedOutput>::insert_op(storage, &output_id, &created_output).unwrap();
 
-    assert!(Exist::<OutputId, CreatedOutput>::exist(storage, &output_id).unwrap());
+    assert!(Exist::<OutputId, CreatedOutput>::exist_op(storage, &output_id).unwrap());
     assert_eq!(
         storage.fetch::<OutputId, CreatedOutput>(&output_id).unwrap().unwrap(),
         created_output
     );
-    let results = MultiFetch::<OutputId, CreatedOutput>::multi_fetch(storage, &[output_id])
+    let results = MultiFetch::<OutputId, CreatedOutput>::multi_fetch_op(storage, &[output_id])
         .unwrap()
         .collect::<Vec<_>>();
     assert_eq!(results.len(), 1);
     assert!(matches!(results.get(0), Some(Ok(Some(v))) if v == &created_output));
 
-    Delete::<OutputId, CreatedOutput>::delete(storage, &output_id).unwrap();
+    Delete::<OutputId, CreatedOutput>::delete_op(storage, &output_id).unwrap();
 
-    assert!(!Exist::<OutputId, CreatedOutput>::exist(storage, &output_id).unwrap());
+    assert!(!Exist::<OutputId, CreatedOutput>::exist_op(storage, &output_id).unwrap());
     assert!(storage.fetch::<OutputId, CreatedOutput>(&output_id).unwrap().is_none());
-    let results = MultiFetch::<OutputId, CreatedOutput>::multi_fetch(storage, &[output_id])
+    let results = MultiFetch::<OutputId, CreatedOutput>::multi_fetch_op(storage, &[output_id])
         .unwrap()
         .collect::<Vec<_>>();
     assert_eq!(results.len(), 1);
@@ -78,22 +78,22 @@ pub fn output_id_to_created_output_access<B: StorageBackend>(storage: &B) {
 
     for _ in 0..10 {
         let (output_id, created_output) = (rand_output_id(), rand_created_output());
-        Insert::<OutputId, CreatedOutput>::insert(storage, &output_id, &created_output).unwrap();
-        Batch::<OutputId, CreatedOutput>::batch_delete(storage, &mut batch, &output_id).unwrap();
+        Insert::<OutputId, CreatedOutput>::insert_op(storage, &output_id, &created_output).unwrap();
+        Batch::<OutputId, CreatedOutput>::batch_delete_op(storage, &mut batch, &output_id).unwrap();
         output_ids.push(output_id);
         created_outputs.push((output_id, None));
     }
 
     for _ in 0..10 {
         let (output_id, created_output) = (rand_output_id(), rand_created_output());
-        Batch::<OutputId, CreatedOutput>::batch_insert(storage, &mut batch, &output_id, &created_output).unwrap();
+        Batch::<OutputId, CreatedOutput>::batch_insert_op(storage, &mut batch, &output_id, &created_output).unwrap();
         output_ids.push(output_id);
         created_outputs.push((output_id, Some(created_output)));
     }
 
     storage.batch_commit(batch, true).unwrap();
 
-    let iter = AsIterator::<OutputId, CreatedOutput>::iter(storage).unwrap();
+    let iter = AsIterator::<OutputId, CreatedOutput>::iter_op(storage).unwrap();
     let mut count = 0;
 
     for result in iter {
@@ -104,7 +104,7 @@ pub fn output_id_to_created_output_access<B: StorageBackend>(storage: &B) {
 
     assert_eq!(count, 10);
 
-    let results = MultiFetch::<OutputId, CreatedOutput>::multi_fetch(storage, &output_ids)
+    let results = MultiFetch::<OutputId, CreatedOutput>::multi_fetch_op(storage, &output_ids)
         .unwrap()
         .collect::<Vec<_>>();
 
@@ -114,9 +114,9 @@ pub fn output_id_to_created_output_access<B: StorageBackend>(storage: &B) {
         assert_eq!(created_output, result.unwrap());
     }
 
-    Truncate::<OutputId, CreatedOutput>::truncate(storage).unwrap();
+    Truncate::<OutputId, CreatedOutput>::truncate_op(storage).unwrap();
 
-    let mut iter = AsIterator::<OutputId, CreatedOutput>::iter(storage).unwrap();
+    let mut iter = AsIterator::<OutputId, CreatedOutput>::iter_op(storage).unwrap();
 
     assert!(iter.next().is_none());
 }

--- a/bee-storage/bee-storage-test/src/output_id_to_created_output.rs
+++ b/bee-storage/bee-storage-test/src/output_id_to_created_output.rs
@@ -42,12 +42,7 @@ pub fn output_id_to_created_output_access<B: StorageBackend>(storage: &B) {
     let (output_id, created_output) = (rand_output_id(), rand_created_output());
 
     assert!(!Exist::<OutputId, CreatedOutput>::exist(storage, &output_id).unwrap());
-    assert!(
-        storage
-            .fetch_access::<OutputId, CreatedOutput>(&output_id)
-            .unwrap()
-            .is_none()
-    );
+    assert!(storage.fetch::<OutputId, CreatedOutput>(&output_id).unwrap().is_none());
     let results = MultiFetch::<OutputId, CreatedOutput>::multi_fetch(storage, &[output_id])
         .unwrap()
         .collect::<Vec<_>>();
@@ -58,10 +53,7 @@ pub fn output_id_to_created_output_access<B: StorageBackend>(storage: &B) {
 
     assert!(Exist::<OutputId, CreatedOutput>::exist(storage, &output_id).unwrap());
     assert_eq!(
-        storage
-            .fetch_access::<OutputId, CreatedOutput>(&output_id)
-            .unwrap()
-            .unwrap(),
+        storage.fetch::<OutputId, CreatedOutput>(&output_id).unwrap().unwrap(),
         created_output
     );
     let results = MultiFetch::<OutputId, CreatedOutput>::multi_fetch(storage, &[output_id])
@@ -73,12 +65,7 @@ pub fn output_id_to_created_output_access<B: StorageBackend>(storage: &B) {
     Delete::<OutputId, CreatedOutput>::delete(storage, &output_id).unwrap();
 
     assert!(!Exist::<OutputId, CreatedOutput>::exist(storage, &output_id).unwrap());
-    assert!(
-        storage
-            .fetch_access::<OutputId, CreatedOutput>(&output_id)
-            .unwrap()
-            .is_none()
-    );
+    assert!(storage.fetch::<OutputId, CreatedOutput>(&output_id).unwrap().is_none());
     let results = MultiFetch::<OutputId, CreatedOutput>::multi_fetch(storage, &[output_id])
         .unwrap()
         .collect::<Vec<_>>();

--- a/bee-storage/bee-storage-test/src/output_id_to_created_output.rs
+++ b/bee-storage/bee-storage-test/src/output_id_to_created_output.rs
@@ -79,14 +79,18 @@ pub fn output_id_to_created_output_access<B: StorageBackend>(storage: &B) {
     for _ in 0..10 {
         let (output_id, created_output) = (rand_output_id(), rand_created_output());
         Insert::<OutputId, CreatedOutput>::insert_op(storage, &output_id, &created_output).unwrap();
-        Batch::<OutputId, CreatedOutput>::batch_delete_op(storage, &mut batch, &output_id).unwrap();
+        storage
+            .batch_delete::<OutputId, CreatedOutput>(&mut batch, &output_id)
+            .unwrap();
         output_ids.push(output_id);
         created_outputs.push((output_id, None));
     }
 
     for _ in 0..10 {
         let (output_id, created_output) = (rand_output_id(), rand_created_output());
-        Batch::<OutputId, CreatedOutput>::batch_insert_op(storage, &mut batch, &output_id, &created_output).unwrap();
+        storage
+            .batch_insert::<OutputId, CreatedOutput>(&mut batch, &output_id, &created_output)
+            .unwrap();
         output_ids.push(output_id);
         created_outputs.push((output_id, Some(created_output)));
     }

--- a/bee-storage/bee-storage-test/src/output_id_to_created_output.rs
+++ b/bee-storage/bee-storage-test/src/output_id_to_created_output.rs
@@ -41,7 +41,7 @@ impl<T> StorageBackend for T where
 pub fn output_id_to_created_output_access<B: StorageBackend>(storage: &B) {
     let (output_id, created_output) = (rand_output_id(), rand_created_output());
 
-    assert!(!Exist::<OutputId, CreatedOutput>::exist_op(storage, &output_id).unwrap());
+    assert!(!storage.exist::<OutputId, CreatedOutput>(&output_id).unwrap());
     assert!(storage.fetch::<OutputId, CreatedOutput>(&output_id).unwrap().is_none());
     let results = MultiFetch::<OutputId, CreatedOutput>::multi_fetch_op(storage, &[output_id])
         .unwrap()
@@ -51,7 +51,7 @@ pub fn output_id_to_created_output_access<B: StorageBackend>(storage: &B) {
 
     Insert::<OutputId, CreatedOutput>::insert_op(storage, &output_id, &created_output).unwrap();
 
-    assert!(Exist::<OutputId, CreatedOutput>::exist_op(storage, &output_id).unwrap());
+    assert!(storage.exist::<OutputId, CreatedOutput>(&output_id).unwrap());
     assert_eq!(
         storage.fetch::<OutputId, CreatedOutput>(&output_id).unwrap().unwrap(),
         created_output
@@ -64,7 +64,7 @@ pub fn output_id_to_created_output_access<B: StorageBackend>(storage: &B) {
 
     storage.delete::<OutputId, CreatedOutput>(&output_id).unwrap();
 
-    assert!(!Exist::<OutputId, CreatedOutput>::exist_op(storage, &output_id).unwrap());
+    assert!(!storage.exist::<OutputId, CreatedOutput>(&output_id).unwrap());
     assert!(storage.fetch::<OutputId, CreatedOutput>(&output_id).unwrap().is_none());
     let results = MultiFetch::<OutputId, CreatedOutput>::multi_fetch_op(storage, &[output_id])
         .unwrap()

--- a/bee-storage/bee-storage-test/src/output_id_to_created_output.rs
+++ b/bee-storage/bee-storage-test/src/output_id_to_created_output.rs
@@ -43,7 +43,8 @@ pub fn output_id_to_created_output_access<B: StorageBackend>(storage: &B) {
 
     assert!(!storage.exist::<OutputId, CreatedOutput>(&output_id).unwrap());
     assert!(storage.fetch::<OutputId, CreatedOutput>(&output_id).unwrap().is_none());
-    let results = MultiFetch::<OutputId, CreatedOutput>::multi_fetch_op(storage, &[output_id])
+    let results = storage
+        .multi_fetch::<OutputId, CreatedOutput>(&[output_id])
         .unwrap()
         .collect::<Vec<_>>();
     assert_eq!(results.len(), 1);
@@ -58,7 +59,8 @@ pub fn output_id_to_created_output_access<B: StorageBackend>(storage: &B) {
         storage.fetch::<OutputId, CreatedOutput>(&output_id).unwrap().unwrap(),
         created_output
     );
-    let results = MultiFetch::<OutputId, CreatedOutput>::multi_fetch_op(storage, &[output_id])
+    let results = storage
+        .multi_fetch::<OutputId, CreatedOutput>(&[output_id])
         .unwrap()
         .collect::<Vec<_>>();
     assert_eq!(results.len(), 1);
@@ -68,7 +70,8 @@ pub fn output_id_to_created_output_access<B: StorageBackend>(storage: &B) {
 
     assert!(!storage.exist::<OutputId, CreatedOutput>(&output_id).unwrap());
     assert!(storage.fetch::<OutputId, CreatedOutput>(&output_id).unwrap().is_none());
-    let results = MultiFetch::<OutputId, CreatedOutput>::multi_fetch_op(storage, &[output_id])
+    let results = storage
+        .multi_fetch::<OutputId, CreatedOutput>(&[output_id])
         .unwrap()
         .collect::<Vec<_>>();
     assert_eq!(results.len(), 1);
@@ -112,7 +115,8 @@ pub fn output_id_to_created_output_access<B: StorageBackend>(storage: &B) {
 
     assert_eq!(count, 10);
 
-    let results = MultiFetch::<OutputId, CreatedOutput>::multi_fetch_op(storage, &output_ids)
+    let results = storage
+        .multi_fetch::<OutputId, CreatedOutput>(&output_ids)
         .unwrap()
         .collect::<Vec<_>>();
 

--- a/bee-storage/bee-storage-test/src/output_id_to_created_output.rs
+++ b/bee-storage/bee-storage-test/src/output_id_to_created_output.rs
@@ -49,7 +49,9 @@ pub fn output_id_to_created_output_access<B: StorageBackend>(storage: &B) {
     assert_eq!(results.len(), 1);
     assert!(matches!(results.get(0), Some(Ok(None))));
 
-    Insert::<OutputId, CreatedOutput>::insert_op(storage, &output_id, &created_output).unwrap();
+    storage
+        .insert::<OutputId, CreatedOutput>(&output_id, &created_output)
+        .unwrap();
 
     assert!(storage.exist::<OutputId, CreatedOutput>(&output_id).unwrap());
     assert_eq!(
@@ -78,7 +80,9 @@ pub fn output_id_to_created_output_access<B: StorageBackend>(storage: &B) {
 
     for _ in 0..10 {
         let (output_id, created_output) = (rand_output_id(), rand_created_output());
-        Insert::<OutputId, CreatedOutput>::insert_op(storage, &output_id, &created_output).unwrap();
+        storage
+            .insert::<OutputId, CreatedOutput>(&output_id, &created_output)
+            .unwrap();
         storage
             .batch_delete::<OutputId, CreatedOutput>(&mut batch, &output_id)
             .unwrap();

--- a/bee-storage/bee-storage-test/src/output_id_to_created_output.rs
+++ b/bee-storage/bee-storage-test/src/output_id_to_created_output.rs
@@ -6,6 +6,7 @@ use bee_message::output::OutputId;
 use bee_storage::{
     access::{AsIterator, Batch, BatchBuilder, Delete, Exist, Fetch, Insert, MultiFetch, Truncate},
     backend,
+    backend::StorageBackendExt,
 };
 use bee_test::rand::output::{rand_created_output, rand_output_id};
 
@@ -42,7 +43,8 @@ pub fn output_id_to_created_output_access<B: StorageBackend>(storage: &B) {
 
     assert!(!Exist::<OutputId, CreatedOutput>::exist(storage, &output_id).unwrap());
     assert!(
-        Fetch::<OutputId, CreatedOutput>::fetch(storage, &output_id)
+        storage
+            .fetch_access::<OutputId, CreatedOutput>(&output_id)
             .unwrap()
             .is_none()
     );
@@ -56,7 +58,8 @@ pub fn output_id_to_created_output_access<B: StorageBackend>(storage: &B) {
 
     assert!(Exist::<OutputId, CreatedOutput>::exist(storage, &output_id).unwrap());
     assert_eq!(
-        Fetch::<OutputId, CreatedOutput>::fetch(storage, &output_id)
+        storage
+            .fetch_access::<OutputId, CreatedOutput>(&output_id)
             .unwrap()
             .unwrap(),
         created_output
@@ -71,7 +74,8 @@ pub fn output_id_to_created_output_access<B: StorageBackend>(storage: &B) {
 
     assert!(!Exist::<OutputId, CreatedOutput>::exist(storage, &output_id).unwrap());
     assert!(
-        Fetch::<OutputId, CreatedOutput>::fetch(storage, &output_id)
+        storage
+            .fetch_access::<OutputId, CreatedOutput>(&output_id)
             .unwrap()
             .is_none()
     );

--- a/bee-storage/bee-storage-test/src/output_id_unspent.rs
+++ b/bee-storage/bee-storage-test/src/output_id_unspent.rs
@@ -35,15 +35,15 @@ impl<T> StorageBackend for T where
 pub fn output_id_unspent_access<B: StorageBackend>(storage: &B) {
     let unspent = rand_unspent_output_id();
 
-    assert!(!Exist::<Unspent, ()>::exist_op(storage, &unspent).unwrap());
+    assert!(!storage.exist::<Unspent, ()>(&unspent).unwrap());
 
     Insert::<Unspent, ()>::insert_op(storage, &unspent, &()).unwrap();
 
-    assert!(Exist::<Unspent, ()>::exist_op(storage, &unspent).unwrap());
+    assert!(storage.exist::<Unspent, ()>(&unspent).unwrap());
 
     storage.delete::<Unspent, ()>(&unspent).unwrap();
 
-    assert!(!Exist::<Unspent, ()>::exist_op(storage, &unspent).unwrap());
+    assert!(!storage.exist::<Unspent, ()>(&unspent).unwrap());
 
     let mut batch = B::batch_begin();
 

--- a/bee-storage/bee-storage-test/src/output_id_unspent.rs
+++ b/bee-storage/bee-storage-test/src/output_id_unspent.rs
@@ -74,7 +74,7 @@ pub fn output_id_unspent_access<B: StorageBackend>(storage: &B) {
 
     assert_eq!(count, unspents.len());
 
-    Truncate::<Unspent, ()>::truncate_op(storage).unwrap();
+    storage.truncate::<Unspent, ()>().unwrap();
 
     let mut iter = storage.iter::<Unspent, ()>().unwrap();
 

--- a/bee-storage/bee-storage-test/src/output_id_unspent.rs
+++ b/bee-storage/bee-storage-test/src/output_id_unspent.rs
@@ -37,7 +37,7 @@ pub fn output_id_unspent_access<B: StorageBackend>(storage: &B) {
 
     assert!(!storage.exist::<Unspent, ()>(&unspent).unwrap());
 
-    Insert::<Unspent, ()>::insert_op(storage, &unspent, &()).unwrap();
+    storage.insert::<Unspent, ()>(&unspent, &()).unwrap();
 
     assert!(storage.exist::<Unspent, ()>(&unspent).unwrap());
 
@@ -49,7 +49,7 @@ pub fn output_id_unspent_access<B: StorageBackend>(storage: &B) {
 
     for _ in 0..10 {
         let unspent = rand_unspent_output_id();
-        Insert::<Unspent, ()>::insert_op(storage, &unspent, &()).unwrap();
+        storage.insert::<Unspent, ()>(&unspent, &()).unwrap();
         storage.batch_delete::<Unspent, ()>(&mut batch, &unspent).unwrap();
     }
 

--- a/bee-storage/bee-storage-test/src/output_id_unspent.rs
+++ b/bee-storage/bee-storage-test/src/output_id_unspent.rs
@@ -4,7 +4,7 @@
 use bee_ledger::types::Unspent;
 use bee_storage::{
     access::{AsIterator, Batch, BatchBuilder, Delete, Exist, Insert, Truncate},
-    backend,
+    backend::{self, StorageBackendExt},
 };
 use bee_test::rand::output::rand_unspent_output_id;
 
@@ -50,14 +50,14 @@ pub fn output_id_unspent_access<B: StorageBackend>(storage: &B) {
     for _ in 0..10 {
         let unspent = rand_unspent_output_id();
         Insert::<Unspent, ()>::insert_op(storage, &unspent, &()).unwrap();
-        Batch::<Unspent, ()>::batch_delete_op(storage, &mut batch, &unspent).unwrap();
+        storage.batch_delete::<Unspent, ()>(&mut batch, &unspent).unwrap();
     }
 
     let mut unspents = Vec::new();
 
     for _ in 0..10 {
         let unspent = rand_unspent_output_id();
-        Batch::<Unspent, ()>::batch_insert_op(storage, &mut batch, &unspent, &()).unwrap();
+        storage.batch_insert::<Unspent, ()>(&mut batch, &unspent, &()).unwrap();
         unspents.push(unspent);
     }
 

--- a/bee-storage/bee-storage-test/src/output_id_unspent.rs
+++ b/bee-storage/bee-storage-test/src/output_id_unspent.rs
@@ -37,7 +37,7 @@ pub fn output_id_unspent_access<B: StorageBackend>(storage: &B) {
 
     assert!(!storage.exist::<Unspent, ()>(&unspent).unwrap());
 
-    storage.insert::<Unspent, ()>(&unspent, &()).unwrap();
+    storage.insert(&unspent, &()).unwrap();
 
     assert!(storage.exist::<Unspent, ()>(&unspent).unwrap());
 
@@ -49,7 +49,7 @@ pub fn output_id_unspent_access<B: StorageBackend>(storage: &B) {
 
     for _ in 0..10 {
         let unspent = rand_unspent_output_id();
-        storage.insert::<Unspent, ()>(&unspent, &()).unwrap();
+        storage.insert(&unspent, &()).unwrap();
         storage.batch_delete::<Unspent, ()>(&mut batch, &unspent).unwrap();
     }
 
@@ -57,7 +57,7 @@ pub fn output_id_unspent_access<B: StorageBackend>(storage: &B) {
 
     for _ in 0..10 {
         let unspent = rand_unspent_output_id();
-        storage.batch_insert::<Unspent, ()>(&mut batch, &unspent, &()).unwrap();
+        storage.batch_insert(&mut batch, &unspent, &()).unwrap();
         unspents.push(unspent);
     }
 

--- a/bee-storage/bee-storage-test/src/output_id_unspent.rs
+++ b/bee-storage/bee-storage-test/src/output_id_unspent.rs
@@ -35,35 +35,35 @@ impl<T> StorageBackend for T where
 pub fn output_id_unspent_access<B: StorageBackend>(storage: &B) {
     let unspent = rand_unspent_output_id();
 
-    assert!(!Exist::<Unspent, ()>::exist(storage, &unspent).unwrap());
+    assert!(!Exist::<Unspent, ()>::exist_op(storage, &unspent).unwrap());
 
-    Insert::<Unspent, ()>::insert(storage, &unspent, &()).unwrap();
+    Insert::<Unspent, ()>::insert_op(storage, &unspent, &()).unwrap();
 
-    assert!(Exist::<Unspent, ()>::exist(storage, &unspent).unwrap());
+    assert!(Exist::<Unspent, ()>::exist_op(storage, &unspent).unwrap());
 
-    Delete::<Unspent, ()>::delete(storage, &unspent).unwrap();
+    Delete::<Unspent, ()>::delete_op(storage, &unspent).unwrap();
 
-    assert!(!Exist::<Unspent, ()>::exist(storage, &unspent).unwrap());
+    assert!(!Exist::<Unspent, ()>::exist_op(storage, &unspent).unwrap());
 
     let mut batch = B::batch_begin();
 
     for _ in 0..10 {
         let unspent = rand_unspent_output_id();
-        Insert::<Unspent, ()>::insert(storage, &unspent, &()).unwrap();
-        Batch::<Unspent, ()>::batch_delete(storage, &mut batch, &unspent).unwrap();
+        Insert::<Unspent, ()>::insert_op(storage, &unspent, &()).unwrap();
+        Batch::<Unspent, ()>::batch_delete_op(storage, &mut batch, &unspent).unwrap();
     }
 
     let mut unspents = Vec::new();
 
     for _ in 0..10 {
         let unspent = rand_unspent_output_id();
-        Batch::<Unspent, ()>::batch_insert(storage, &mut batch, &unspent, &()).unwrap();
+        Batch::<Unspent, ()>::batch_insert_op(storage, &mut batch, &unspent, &()).unwrap();
         unspents.push(unspent);
     }
 
     storage.batch_commit(batch, true).unwrap();
 
-    let iter = AsIterator::<Unspent, ()>::iter(storage).unwrap();
+    let iter = AsIterator::<Unspent, ()>::iter_op(storage).unwrap();
     let mut count = 0;
 
     for result in iter {
@@ -74,9 +74,9 @@ pub fn output_id_unspent_access<B: StorageBackend>(storage: &B) {
 
     assert_eq!(count, unspents.len());
 
-    Truncate::<Unspent, ()>::truncate(storage).unwrap();
+    Truncate::<Unspent, ()>::truncate_op(storage).unwrap();
 
-    let mut iter = AsIterator::<Unspent, ()>::iter(storage).unwrap();
+    let mut iter = AsIterator::<Unspent, ()>::iter_op(storage).unwrap();
 
     assert!(iter.next().is_none());
 }

--- a/bee-storage/bee-storage-test/src/output_id_unspent.rs
+++ b/bee-storage/bee-storage-test/src/output_id_unspent.rs
@@ -41,7 +41,7 @@ pub fn output_id_unspent_access<B: StorageBackend>(storage: &B) {
 
     assert!(Exist::<Unspent, ()>::exist_op(storage, &unspent).unwrap());
 
-    Delete::<Unspent, ()>::delete_op(storage, &unspent).unwrap();
+    storage.delete::<Unspent, ()>(&unspent).unwrap();
 
     assert!(!Exist::<Unspent, ()>::exist_op(storage, &unspent).unwrap());
 

--- a/bee-storage/bee-storage-test/src/output_id_unspent.rs
+++ b/bee-storage/bee-storage-test/src/output_id_unspent.rs
@@ -63,7 +63,7 @@ pub fn output_id_unspent_access<B: StorageBackend>(storage: &B) {
 
     storage.batch_commit(batch, true).unwrap();
 
-    let iter = AsIterator::<Unspent, ()>::iter_op(storage).unwrap();
+    let iter = storage.iter::<Unspent, ()>().unwrap();
     let mut count = 0;
 
     for result in iter {
@@ -76,7 +76,7 @@ pub fn output_id_unspent_access<B: StorageBackend>(storage: &B) {
 
     Truncate::<Unspent, ()>::truncate_op(storage).unwrap();
 
-    let mut iter = AsIterator::<Unspent, ()>::iter_op(storage).unwrap();
+    let mut iter = storage.iter::<Unspent, ()>().unwrap();
 
     assert!(iter.next().is_none());
 }

--- a/bee-storage/bee-storage-test/src/snapshot_info.rs
+++ b/bee-storage/bee-storage-test/src/snapshot_info.rs
@@ -53,7 +53,9 @@ pub fn snapshot_info_access<B: StorageBackend>(storage: &B) {
 
     let mut batch = B::batch_begin();
 
-    Batch::<(), SnapshotInfo>::batch_insert_op(storage, &mut batch, &(), &snapshot_info).unwrap();
+    storage
+        .batch_insert::<(), SnapshotInfo>(&mut batch, &(), &snapshot_info)
+        .unwrap();
 
     storage.batch_commit(batch, true).unwrap();
 
@@ -62,7 +64,7 @@ pub fn snapshot_info_access<B: StorageBackend>(storage: &B) {
 
     let mut batch = B::batch_begin();
 
-    Batch::<(), SnapshotInfo>::batch_delete_op(storage, &mut batch, &()).unwrap();
+    storage.batch_delete::<(), SnapshotInfo>(&mut batch, &()).unwrap();
 
     storage.batch_commit(batch, true).unwrap();
 

--- a/bee-storage/bee-storage-test/src/snapshot_info.rs
+++ b/bee-storage/bee-storage-test/src/snapshot_info.rs
@@ -84,7 +84,7 @@ pub fn snapshot_info_access<B: StorageBackend>(storage: &B) {
 
     assert_eq!(count, 1);
 
-    Truncate::<(), SnapshotInfo>::truncate_op(storage).unwrap();
+    storage.truncate::<(), SnapshotInfo>().unwrap();
 
     assert!(!storage.exist::<(), SnapshotInfo>(&()).unwrap());
 

--- a/bee-storage/bee-storage-test/src/snapshot_info.rs
+++ b/bee-storage/bee-storage-test/src/snapshot_info.rs
@@ -38,40 +38,40 @@ impl<T> StorageBackend for T where
 pub fn snapshot_info_access<B: StorageBackend>(storage: &B) {
     let snapshot_info = rand_snapshot_info();
 
-    assert!(!Exist::<(), SnapshotInfo>::exist(storage, &()).unwrap());
+    assert!(!Exist::<(), SnapshotInfo>::exist_op(storage, &()).unwrap());
     assert!(storage.fetch::<(), SnapshotInfo>(&()).unwrap().is_none());
 
-    Insert::<(), SnapshotInfo>::insert(storage, &(), &snapshot_info).unwrap();
+    Insert::<(), SnapshotInfo>::insert_op(storage, &(), &snapshot_info).unwrap();
 
-    assert!(Exist::<(), SnapshotInfo>::exist(storage, &()).unwrap());
+    assert!(Exist::<(), SnapshotInfo>::exist_op(storage, &()).unwrap());
     assert_eq!(storage.fetch::<(), SnapshotInfo>(&()).unwrap().unwrap(), snapshot_info);
 
-    Delete::<(), SnapshotInfo>::delete(storage, &()).unwrap();
+    Delete::<(), SnapshotInfo>::delete_op(storage, &()).unwrap();
 
-    assert!(!Exist::<(), SnapshotInfo>::exist(storage, &()).unwrap());
+    assert!(!Exist::<(), SnapshotInfo>::exist_op(storage, &()).unwrap());
     assert!(storage.fetch::<(), SnapshotInfo>(&()).unwrap().is_none());
 
     let mut batch = B::batch_begin();
 
-    Batch::<(), SnapshotInfo>::batch_insert(storage, &mut batch, &(), &snapshot_info).unwrap();
+    Batch::<(), SnapshotInfo>::batch_insert_op(storage, &mut batch, &(), &snapshot_info).unwrap();
 
     storage.batch_commit(batch, true).unwrap();
 
-    assert!(Exist::<(), SnapshotInfo>::exist(storage, &()).unwrap());
+    assert!(Exist::<(), SnapshotInfo>::exist_op(storage, &()).unwrap());
     assert_eq!(storage.fetch::<(), SnapshotInfo>(&()).unwrap().unwrap(), snapshot_info);
 
     let mut batch = B::batch_begin();
 
-    Batch::<(), SnapshotInfo>::batch_delete(storage, &mut batch, &()).unwrap();
+    Batch::<(), SnapshotInfo>::batch_delete_op(storage, &mut batch, &()).unwrap();
 
     storage.batch_commit(batch, true).unwrap();
 
-    assert!(!Exist::<(), SnapshotInfo>::exist(storage, &()).unwrap());
+    assert!(!Exist::<(), SnapshotInfo>::exist_op(storage, &()).unwrap());
     assert!(storage.fetch::<(), SnapshotInfo>(&()).unwrap().is_none());
 
-    Insert::<(), SnapshotInfo>::insert(storage, &(), &snapshot_info).unwrap();
+    Insert::<(), SnapshotInfo>::insert_op(storage, &(), &snapshot_info).unwrap();
 
-    let iter = AsIterator::<(), SnapshotInfo>::iter(storage).unwrap();
+    let iter = AsIterator::<(), SnapshotInfo>::iter_op(storage).unwrap();
     let mut count = 0;
 
     for result in iter {
@@ -82,11 +82,11 @@ pub fn snapshot_info_access<B: StorageBackend>(storage: &B) {
 
     assert_eq!(count, 1);
 
-    Truncate::<(), SnapshotInfo>::truncate(storage).unwrap();
+    Truncate::<(), SnapshotInfo>::truncate_op(storage).unwrap();
 
-    assert!(!Exist::<(), SnapshotInfo>::exist(storage, &()).unwrap());
+    assert!(!Exist::<(), SnapshotInfo>::exist_op(storage, &()).unwrap());
 
-    let mut iter = AsIterator::<(), SnapshotInfo>::iter(storage).unwrap();
+    let mut iter = AsIterator::<(), SnapshotInfo>::iter_op(storage).unwrap();
 
     assert!(iter.next().is_none());
 }

--- a/bee-storage/bee-storage-test/src/snapshot_info.rs
+++ b/bee-storage/bee-storage-test/src/snapshot_info.rs
@@ -46,7 +46,7 @@ pub fn snapshot_info_access<B: StorageBackend>(storage: &B) {
     assert!(Exist::<(), SnapshotInfo>::exist_op(storage, &()).unwrap());
     assert_eq!(storage.fetch::<(), SnapshotInfo>(&()).unwrap().unwrap(), snapshot_info);
 
-    Delete::<(), SnapshotInfo>::delete_op(storage, &()).unwrap();
+    storage.delete::<(), SnapshotInfo>(&()).unwrap();
 
     assert!(!Exist::<(), SnapshotInfo>::exist_op(storage, &()).unwrap());
     assert!(storage.fetch::<(), SnapshotInfo>(&()).unwrap().is_none());

--- a/bee-storage/bee-storage-test/src/snapshot_info.rs
+++ b/bee-storage/bee-storage-test/src/snapshot_info.rs
@@ -41,7 +41,7 @@ pub fn snapshot_info_access<B: StorageBackend>(storage: &B) {
     assert!(!storage.exist::<(), SnapshotInfo>(&()).unwrap());
     assert!(storage.fetch::<(), SnapshotInfo>(&()).unwrap().is_none());
 
-    Insert::<(), SnapshotInfo>::insert_op(storage, &(), &snapshot_info).unwrap();
+    storage.insert::<(), SnapshotInfo>(&(), &snapshot_info).unwrap();
 
     assert!(storage.exist::<(), SnapshotInfo>(&()).unwrap());
     assert_eq!(storage.fetch::<(), SnapshotInfo>(&()).unwrap().unwrap(), snapshot_info);
@@ -71,7 +71,7 @@ pub fn snapshot_info_access<B: StorageBackend>(storage: &B) {
     assert!(!storage.exist::<(), SnapshotInfo>(&()).unwrap());
     assert!(storage.fetch::<(), SnapshotInfo>(&()).unwrap().is_none());
 
-    Insert::<(), SnapshotInfo>::insert_op(storage, &(), &snapshot_info).unwrap();
+    storage.insert::<(), SnapshotInfo>(&(), &snapshot_info).unwrap();
 
     let iter = AsIterator::<(), SnapshotInfo>::iter_op(storage).unwrap();
     let mut count = 0;

--- a/bee-storage/bee-storage-test/src/snapshot_info.rs
+++ b/bee-storage/bee-storage-test/src/snapshot_info.rs
@@ -5,6 +5,7 @@ use bee_ledger::types::snapshot::SnapshotInfo;
 use bee_storage::{
     access::{AsIterator, Batch, BatchBuilder, Delete, Exist, Fetch, Insert, Truncate},
     backend,
+    backend::StorageBackendExt,
 };
 use bee_test::rand::snapshot::rand_snapshot_info;
 
@@ -38,20 +39,20 @@ pub fn snapshot_info_access<B: StorageBackend>(storage: &B) {
     let snapshot_info = rand_snapshot_info();
 
     assert!(!Exist::<(), SnapshotInfo>::exist(storage, &()).unwrap());
-    assert!(Fetch::<(), SnapshotInfo>::fetch(storage, &()).unwrap().is_none());
+    assert!(storage.fetch_access::<(), SnapshotInfo>(&()).unwrap().is_none());
 
     Insert::<(), SnapshotInfo>::insert(storage, &(), &snapshot_info).unwrap();
 
     assert!(Exist::<(), SnapshotInfo>::exist(storage, &()).unwrap());
     assert_eq!(
-        Fetch::<(), SnapshotInfo>::fetch(storage, &()).unwrap().unwrap(),
+        storage.fetch_access::<(), SnapshotInfo>(&()).unwrap().unwrap(),
         snapshot_info
     );
 
     Delete::<(), SnapshotInfo>::delete(storage, &()).unwrap();
 
     assert!(!Exist::<(), SnapshotInfo>::exist(storage, &()).unwrap());
-    assert!(Fetch::<(), SnapshotInfo>::fetch(storage, &()).unwrap().is_none());
+    assert!(storage.fetch_access::<(), SnapshotInfo>(&()).unwrap().is_none());
 
     let mut batch = B::batch_begin();
 
@@ -61,7 +62,7 @@ pub fn snapshot_info_access<B: StorageBackend>(storage: &B) {
 
     assert!(Exist::<(), SnapshotInfo>::exist(storage, &()).unwrap());
     assert_eq!(
-        Fetch::<(), SnapshotInfo>::fetch(storage, &()).unwrap().unwrap(),
+        storage.fetch_access::<(), SnapshotInfo>(&()).unwrap().unwrap(),
         snapshot_info
     );
 
@@ -72,7 +73,7 @@ pub fn snapshot_info_access<B: StorageBackend>(storage: &B) {
     storage.batch_commit(batch, true).unwrap();
 
     assert!(!Exist::<(), SnapshotInfo>::exist(storage, &()).unwrap());
-    assert!(Fetch::<(), SnapshotInfo>::fetch(storage, &()).unwrap().is_none());
+    assert!(storage.fetch_access::<(), SnapshotInfo>(&()).unwrap().is_none());
 
     Insert::<(), SnapshotInfo>::insert(storage, &(), &snapshot_info).unwrap();
 

--- a/bee-storage/bee-storage-test/src/snapshot_info.rs
+++ b/bee-storage/bee-storage-test/src/snapshot_info.rs
@@ -41,7 +41,7 @@ pub fn snapshot_info_access<B: StorageBackend>(storage: &B) {
     assert!(!storage.exist::<(), SnapshotInfo>(&()).unwrap());
     assert!(storage.fetch::<(), SnapshotInfo>(&()).unwrap().is_none());
 
-    storage.insert::<(), SnapshotInfo>(&(), &snapshot_info).unwrap();
+    storage.insert(&(), &snapshot_info).unwrap();
 
     assert!(storage.exist::<(), SnapshotInfo>(&()).unwrap());
     assert_eq!(storage.fetch::<(), SnapshotInfo>(&()).unwrap().unwrap(), snapshot_info);
@@ -53,9 +53,7 @@ pub fn snapshot_info_access<B: StorageBackend>(storage: &B) {
 
     let mut batch = B::batch_begin();
 
-    storage
-        .batch_insert::<(), SnapshotInfo>(&mut batch, &(), &snapshot_info)
-        .unwrap();
+    storage.batch_insert(&mut batch, &(), &snapshot_info).unwrap();
 
     storage.batch_commit(batch, true).unwrap();
 
@@ -71,7 +69,7 @@ pub fn snapshot_info_access<B: StorageBackend>(storage: &B) {
     assert!(!storage.exist::<(), SnapshotInfo>(&()).unwrap());
     assert!(storage.fetch::<(), SnapshotInfo>(&()).unwrap().is_none());
 
-    storage.insert::<(), SnapshotInfo>(&(), &snapshot_info).unwrap();
+    storage.insert(&(), &snapshot_info).unwrap();
 
     let iter = storage.iter::<(), SnapshotInfo>().unwrap();
     let mut count = 0;

--- a/bee-storage/bee-storage-test/src/snapshot_info.rs
+++ b/bee-storage/bee-storage-test/src/snapshot_info.rs
@@ -38,17 +38,17 @@ impl<T> StorageBackend for T where
 pub fn snapshot_info_access<B: StorageBackend>(storage: &B) {
     let snapshot_info = rand_snapshot_info();
 
-    assert!(!Exist::<(), SnapshotInfo>::exist_op(storage, &()).unwrap());
+    assert!(!storage.exist::<(), SnapshotInfo>(&()).unwrap());
     assert!(storage.fetch::<(), SnapshotInfo>(&()).unwrap().is_none());
 
     Insert::<(), SnapshotInfo>::insert_op(storage, &(), &snapshot_info).unwrap();
 
-    assert!(Exist::<(), SnapshotInfo>::exist_op(storage, &()).unwrap());
+    assert!(storage.exist::<(), SnapshotInfo>(&()).unwrap());
     assert_eq!(storage.fetch::<(), SnapshotInfo>(&()).unwrap().unwrap(), snapshot_info);
 
     storage.delete::<(), SnapshotInfo>(&()).unwrap();
 
-    assert!(!Exist::<(), SnapshotInfo>::exist_op(storage, &()).unwrap());
+    assert!(!storage.exist::<(), SnapshotInfo>(&()).unwrap());
     assert!(storage.fetch::<(), SnapshotInfo>(&()).unwrap().is_none());
 
     let mut batch = B::batch_begin();
@@ -59,7 +59,7 @@ pub fn snapshot_info_access<B: StorageBackend>(storage: &B) {
 
     storage.batch_commit(batch, true).unwrap();
 
-    assert!(Exist::<(), SnapshotInfo>::exist_op(storage, &()).unwrap());
+    assert!(storage.exist::<(), SnapshotInfo>(&()).unwrap());
     assert_eq!(storage.fetch::<(), SnapshotInfo>(&()).unwrap().unwrap(), snapshot_info);
 
     let mut batch = B::batch_begin();
@@ -68,7 +68,7 @@ pub fn snapshot_info_access<B: StorageBackend>(storage: &B) {
 
     storage.batch_commit(batch, true).unwrap();
 
-    assert!(!Exist::<(), SnapshotInfo>::exist_op(storage, &()).unwrap());
+    assert!(!storage.exist::<(), SnapshotInfo>(&()).unwrap());
     assert!(storage.fetch::<(), SnapshotInfo>(&()).unwrap().is_none());
 
     Insert::<(), SnapshotInfo>::insert_op(storage, &(), &snapshot_info).unwrap();
@@ -86,7 +86,7 @@ pub fn snapshot_info_access<B: StorageBackend>(storage: &B) {
 
     Truncate::<(), SnapshotInfo>::truncate_op(storage).unwrap();
 
-    assert!(!Exist::<(), SnapshotInfo>::exist_op(storage, &()).unwrap());
+    assert!(!storage.exist::<(), SnapshotInfo>(&()).unwrap());
 
     let mut iter = AsIterator::<(), SnapshotInfo>::iter_op(storage).unwrap();
 

--- a/bee-storage/bee-storage-test/src/snapshot_info.rs
+++ b/bee-storage/bee-storage-test/src/snapshot_info.rs
@@ -73,7 +73,7 @@ pub fn snapshot_info_access<B: StorageBackend>(storage: &B) {
 
     storage.insert::<(), SnapshotInfo>(&(), &snapshot_info).unwrap();
 
-    let iter = AsIterator::<(), SnapshotInfo>::iter_op(storage).unwrap();
+    let iter = storage.iter::<(), SnapshotInfo>().unwrap();
     let mut count = 0;
 
     for result in iter {
@@ -88,7 +88,7 @@ pub fn snapshot_info_access<B: StorageBackend>(storage: &B) {
 
     assert!(!storage.exist::<(), SnapshotInfo>(&()).unwrap());
 
-    let mut iter = AsIterator::<(), SnapshotInfo>::iter_op(storage).unwrap();
+    let mut iter = storage.iter::<(), SnapshotInfo>().unwrap();
 
     assert!(iter.next().is_none());
 }

--- a/bee-storage/bee-storage-test/src/snapshot_info.rs
+++ b/bee-storage/bee-storage-test/src/snapshot_info.rs
@@ -39,20 +39,17 @@ pub fn snapshot_info_access<B: StorageBackend>(storage: &B) {
     let snapshot_info = rand_snapshot_info();
 
     assert!(!Exist::<(), SnapshotInfo>::exist(storage, &()).unwrap());
-    assert!(storage.fetch_access::<(), SnapshotInfo>(&()).unwrap().is_none());
+    assert!(storage.fetch::<(), SnapshotInfo>(&()).unwrap().is_none());
 
     Insert::<(), SnapshotInfo>::insert(storage, &(), &snapshot_info).unwrap();
 
     assert!(Exist::<(), SnapshotInfo>::exist(storage, &()).unwrap());
-    assert_eq!(
-        storage.fetch_access::<(), SnapshotInfo>(&()).unwrap().unwrap(),
-        snapshot_info
-    );
+    assert_eq!(storage.fetch::<(), SnapshotInfo>(&()).unwrap().unwrap(), snapshot_info);
 
     Delete::<(), SnapshotInfo>::delete(storage, &()).unwrap();
 
     assert!(!Exist::<(), SnapshotInfo>::exist(storage, &()).unwrap());
-    assert!(storage.fetch_access::<(), SnapshotInfo>(&()).unwrap().is_none());
+    assert!(storage.fetch::<(), SnapshotInfo>(&()).unwrap().is_none());
 
     let mut batch = B::batch_begin();
 
@@ -61,10 +58,7 @@ pub fn snapshot_info_access<B: StorageBackend>(storage: &B) {
     storage.batch_commit(batch, true).unwrap();
 
     assert!(Exist::<(), SnapshotInfo>::exist(storage, &()).unwrap());
-    assert_eq!(
-        storage.fetch_access::<(), SnapshotInfo>(&()).unwrap().unwrap(),
-        snapshot_info
-    );
+    assert_eq!(storage.fetch::<(), SnapshotInfo>(&()).unwrap().unwrap(), snapshot_info);
 
     let mut batch = B::batch_begin();
 
@@ -73,7 +67,7 @@ pub fn snapshot_info_access<B: StorageBackend>(storage: &B) {
     storage.batch_commit(batch, true).unwrap();
 
     assert!(!Exist::<(), SnapshotInfo>::exist(storage, &()).unwrap());
-    assert!(storage.fetch_access::<(), SnapshotInfo>(&()).unwrap().is_none());
+    assert!(storage.fetch::<(), SnapshotInfo>(&()).unwrap().is_none());
 
     Insert::<(), SnapshotInfo>::insert(storage, &(), &snapshot_info).unwrap();
 

--- a/bee-storage/bee-storage-test/src/solid_entry_point_to_milestone_index.rs
+++ b/bee-storage/bee-storage-test/src/solid_entry_point_to_milestone_index.rs
@@ -89,14 +89,18 @@ pub fn solid_entry_point_to_milestone_index_access<B: StorageBackend>(storage: &
     for _ in 0..10 {
         let (sep, index) = (rand_solid_entry_point(), rand_milestone_index());
         Insert::<SolidEntryPoint, MilestoneIndex>::insert_op(storage, &sep, &index).unwrap();
-        Batch::<SolidEntryPoint, MilestoneIndex>::batch_delete_op(storage, &mut batch, &sep).unwrap();
+        storage
+            .batch_delete::<SolidEntryPoint, MilestoneIndex>(&mut batch, &sep)
+            .unwrap();
         seps_ids.push(sep);
         seps.push((sep, None));
     }
 
     for _ in 0..10 {
         let (sep, index) = (rand_solid_entry_point(), rand_milestone_index());
-        Batch::<SolidEntryPoint, MilestoneIndex>::batch_insert_op(storage, &mut batch, &sep, &index).unwrap();
+        storage
+            .batch_insert::<SolidEntryPoint, MilestoneIndex>(&mut batch, &sep, &index)
+            .unwrap();
         seps_ids.push(sep);
         seps.push((sep, Some(index)));
     }

--- a/bee-storage/bee-storage-test/src/solid_entry_point_to_milestone_index.rs
+++ b/bee-storage/bee-storage-test/src/solid_entry_point_to_milestone_index.rs
@@ -44,7 +44,7 @@ pub fn solid_entry_point_to_milestone_index_access<B: StorageBackend>(storage: &
     assert!(!Exist::<SolidEntryPoint, MilestoneIndex>::exist(storage, &sep).unwrap());
     assert!(
         storage
-            .fetch_access::<SolidEntryPoint, MilestoneIndex>(&sep)
+            .fetch::<SolidEntryPoint, MilestoneIndex>(&sep)
             .unwrap()
             .is_none()
     );
@@ -58,10 +58,7 @@ pub fn solid_entry_point_to_milestone_index_access<B: StorageBackend>(storage: &
 
     assert!(Exist::<SolidEntryPoint, MilestoneIndex>::exist(storage, &sep).unwrap());
     assert_eq!(
-        storage
-            .fetch_access::<SolidEntryPoint, MilestoneIndex>(&sep)
-            .unwrap()
-            .unwrap(),
+        storage.fetch::<SolidEntryPoint, MilestoneIndex>(&sep).unwrap().unwrap(),
         index
     );
     let results = MultiFetch::<SolidEntryPoint, MilestoneIndex>::multi_fetch(storage, &[sep])
@@ -75,7 +72,7 @@ pub fn solid_entry_point_to_milestone_index_access<B: StorageBackend>(storage: &
     assert!(!Exist::<SolidEntryPoint, MilestoneIndex>::exist(storage, &sep).unwrap());
     assert!(
         storage
-            .fetch_access::<SolidEntryPoint, MilestoneIndex>(&sep)
+            .fetch::<SolidEntryPoint, MilestoneIndex>(&sep)
             .unwrap()
             .is_none()
     );

--- a/bee-storage/bee-storage-test/src/solid_entry_point_to_milestone_index.rs
+++ b/bee-storage/bee-storage-test/src/solid_entry_point_to_milestone_index.rs
@@ -54,7 +54,7 @@ pub fn solid_entry_point_to_milestone_index_access<B: StorageBackend>(storage: &
     assert_eq!(results.len(), 1);
     assert!(matches!(results.get(0), Some(Ok(None))));
 
-    Insert::<SolidEntryPoint, MilestoneIndex>::insert_op(storage, &sep, &index).unwrap();
+    storage.insert::<SolidEntryPoint, MilestoneIndex>(&sep, &index).unwrap();
 
     assert!(storage.exist::<SolidEntryPoint, MilestoneIndex>(&sep).unwrap());
     assert_eq!(
@@ -88,7 +88,7 @@ pub fn solid_entry_point_to_milestone_index_access<B: StorageBackend>(storage: &
 
     for _ in 0..10 {
         let (sep, index) = (rand_solid_entry_point(), rand_milestone_index());
-        Insert::<SolidEntryPoint, MilestoneIndex>::insert_op(storage, &sep, &index).unwrap();
+        storage.insert::<SolidEntryPoint, MilestoneIndex>(&sep, &index).unwrap();
         storage
             .batch_delete::<SolidEntryPoint, MilestoneIndex>(&mut batch, &sep)
             .unwrap();

--- a/bee-storage/bee-storage-test/src/solid_entry_point_to_milestone_index.rs
+++ b/bee-storage/bee-storage-test/src/solid_entry_point_to_milestone_index.rs
@@ -5,6 +5,7 @@ use bee_message::milestone::MilestoneIndex;
 use bee_storage::{
     access::{AsIterator, Batch, BatchBuilder, Delete, Exist, Fetch, Insert, MultiFetch, Truncate},
     backend,
+    backend::StorageBackendExt,
 };
 use bee_tangle::solid_entry_point::SolidEntryPoint;
 use bee_test::rand::{milestone::rand_milestone_index, solid_entry_point::rand_solid_entry_point};
@@ -42,7 +43,8 @@ pub fn solid_entry_point_to_milestone_index_access<B: StorageBackend>(storage: &
 
     assert!(!Exist::<SolidEntryPoint, MilestoneIndex>::exist(storage, &sep).unwrap());
     assert!(
-        Fetch::<SolidEntryPoint, MilestoneIndex>::fetch(storage, &sep)
+        storage
+            .fetch_access::<SolidEntryPoint, MilestoneIndex>(&sep)
             .unwrap()
             .is_none()
     );
@@ -56,7 +58,8 @@ pub fn solid_entry_point_to_milestone_index_access<B: StorageBackend>(storage: &
 
     assert!(Exist::<SolidEntryPoint, MilestoneIndex>::exist(storage, &sep).unwrap());
     assert_eq!(
-        Fetch::<SolidEntryPoint, MilestoneIndex>::fetch(storage, &sep)
+        storage
+            .fetch_access::<SolidEntryPoint, MilestoneIndex>(&sep)
             .unwrap()
             .unwrap(),
         index
@@ -71,7 +74,8 @@ pub fn solid_entry_point_to_milestone_index_access<B: StorageBackend>(storage: &
 
     assert!(!Exist::<SolidEntryPoint, MilestoneIndex>::exist(storage, &sep).unwrap());
     assert!(
-        Fetch::<SolidEntryPoint, MilestoneIndex>::fetch(storage, &sep)
+        storage
+            .fetch_access::<SolidEntryPoint, MilestoneIndex>(&sep)
             .unwrap()
             .is_none()
     );

--- a/bee-storage/bee-storage-test/src/solid_entry_point_to_milestone_index.rs
+++ b/bee-storage/bee-storage-test/src/solid_entry_point_to_milestone_index.rs
@@ -41,42 +41,42 @@ impl<T> StorageBackend for T where
 pub fn solid_entry_point_to_milestone_index_access<B: StorageBackend>(storage: &B) {
     let (sep, index) = (rand_solid_entry_point(), rand_milestone_index());
 
-    assert!(!Exist::<SolidEntryPoint, MilestoneIndex>::exist(storage, &sep).unwrap());
+    assert!(!Exist::<SolidEntryPoint, MilestoneIndex>::exist_op(storage, &sep).unwrap());
     assert!(
         storage
             .fetch::<SolidEntryPoint, MilestoneIndex>(&sep)
             .unwrap()
             .is_none()
     );
-    let results = MultiFetch::<SolidEntryPoint, MilestoneIndex>::multi_fetch(storage, &[sep])
+    let results = MultiFetch::<SolidEntryPoint, MilestoneIndex>::multi_fetch_op(storage, &[sep])
         .unwrap()
         .collect::<Vec<_>>();
     assert_eq!(results.len(), 1);
     assert!(matches!(results.get(0), Some(Ok(None))));
 
-    Insert::<SolidEntryPoint, MilestoneIndex>::insert(storage, &sep, &index).unwrap();
+    Insert::<SolidEntryPoint, MilestoneIndex>::insert_op(storage, &sep, &index).unwrap();
 
-    assert!(Exist::<SolidEntryPoint, MilestoneIndex>::exist(storage, &sep).unwrap());
+    assert!(Exist::<SolidEntryPoint, MilestoneIndex>::exist_op(storage, &sep).unwrap());
     assert_eq!(
         storage.fetch::<SolidEntryPoint, MilestoneIndex>(&sep).unwrap().unwrap(),
         index
     );
-    let results = MultiFetch::<SolidEntryPoint, MilestoneIndex>::multi_fetch(storage, &[sep])
+    let results = MultiFetch::<SolidEntryPoint, MilestoneIndex>::multi_fetch_op(storage, &[sep])
         .unwrap()
         .collect::<Vec<_>>();
     assert_eq!(results.len(), 1);
     assert!(matches!(results.get(0), Some(Ok(Some(v))) if v == &index));
 
-    Delete::<SolidEntryPoint, MilestoneIndex>::delete(storage, &sep).unwrap();
+    Delete::<SolidEntryPoint, MilestoneIndex>::delete_op(storage, &sep).unwrap();
 
-    assert!(!Exist::<SolidEntryPoint, MilestoneIndex>::exist(storage, &sep).unwrap());
+    assert!(!Exist::<SolidEntryPoint, MilestoneIndex>::exist_op(storage, &sep).unwrap());
     assert!(
         storage
             .fetch::<SolidEntryPoint, MilestoneIndex>(&sep)
             .unwrap()
             .is_none()
     );
-    let results = MultiFetch::<SolidEntryPoint, MilestoneIndex>::multi_fetch(storage, &[sep])
+    let results = MultiFetch::<SolidEntryPoint, MilestoneIndex>::multi_fetch_op(storage, &[sep])
         .unwrap()
         .collect::<Vec<_>>();
     assert_eq!(results.len(), 1);
@@ -88,22 +88,22 @@ pub fn solid_entry_point_to_milestone_index_access<B: StorageBackend>(storage: &
 
     for _ in 0..10 {
         let (sep, index) = (rand_solid_entry_point(), rand_milestone_index());
-        Insert::<SolidEntryPoint, MilestoneIndex>::insert(storage, &sep, &index).unwrap();
-        Batch::<SolidEntryPoint, MilestoneIndex>::batch_delete(storage, &mut batch, &sep).unwrap();
+        Insert::<SolidEntryPoint, MilestoneIndex>::insert_op(storage, &sep, &index).unwrap();
+        Batch::<SolidEntryPoint, MilestoneIndex>::batch_delete_op(storage, &mut batch, &sep).unwrap();
         seps_ids.push(sep);
         seps.push((sep, None));
     }
 
     for _ in 0..10 {
         let (sep, index) = (rand_solid_entry_point(), rand_milestone_index());
-        Batch::<SolidEntryPoint, MilestoneIndex>::batch_insert(storage, &mut batch, &sep, &index).unwrap();
+        Batch::<SolidEntryPoint, MilestoneIndex>::batch_insert_op(storage, &mut batch, &sep, &index).unwrap();
         seps_ids.push(sep);
         seps.push((sep, Some(index)));
     }
 
     storage.batch_commit(batch, true).unwrap();
 
-    let iter = AsIterator::<SolidEntryPoint, MilestoneIndex>::iter(storage).unwrap();
+    let iter = AsIterator::<SolidEntryPoint, MilestoneIndex>::iter_op(storage).unwrap();
     let mut count = 0;
 
     for result in iter {
@@ -114,7 +114,7 @@ pub fn solid_entry_point_to_milestone_index_access<B: StorageBackend>(storage: &
 
     assert_eq!(count, 10);
 
-    let results = MultiFetch::<SolidEntryPoint, MilestoneIndex>::multi_fetch(storage, &seps_ids)
+    let results = MultiFetch::<SolidEntryPoint, MilestoneIndex>::multi_fetch_op(storage, &seps_ids)
         .unwrap()
         .collect::<Vec<_>>();
 
@@ -124,9 +124,9 @@ pub fn solid_entry_point_to_milestone_index_access<B: StorageBackend>(storage: &
         assert_eq!(index, result.unwrap());
     }
 
-    Truncate::<SolidEntryPoint, MilestoneIndex>::truncate(storage).unwrap();
+    Truncate::<SolidEntryPoint, MilestoneIndex>::truncate_op(storage).unwrap();
 
-    let mut iter = AsIterator::<SolidEntryPoint, MilestoneIndex>::iter(storage).unwrap();
+    let mut iter = AsIterator::<SolidEntryPoint, MilestoneIndex>::iter_op(storage).unwrap();
 
     assert!(iter.next().is_none());
 }

--- a/bee-storage/bee-storage-test/src/solid_entry_point_to_milestone_index.rs
+++ b/bee-storage/bee-storage-test/src/solid_entry_point_to_milestone_index.rs
@@ -55,7 +55,7 @@ pub fn solid_entry_point_to_milestone_index_access<B: StorageBackend>(storage: &
     assert_eq!(results.len(), 1);
     assert!(matches!(results.get(0), Some(Ok(None))));
 
-    storage.insert::<SolidEntryPoint, MilestoneIndex>(&sep, &index).unwrap();
+    storage.insert(&sep, &index).unwrap();
 
     assert!(storage.exist::<SolidEntryPoint, MilestoneIndex>(&sep).unwrap());
     assert_eq!(
@@ -91,7 +91,7 @@ pub fn solid_entry_point_to_milestone_index_access<B: StorageBackend>(storage: &
 
     for _ in 0..10 {
         let (sep, index) = (rand_solid_entry_point(), rand_milestone_index());
-        storage.insert::<SolidEntryPoint, MilestoneIndex>(&sep, &index).unwrap();
+        storage.insert(&sep, &index).unwrap();
         storage
             .batch_delete::<SolidEntryPoint, MilestoneIndex>(&mut batch, &sep)
             .unwrap();
@@ -101,9 +101,7 @@ pub fn solid_entry_point_to_milestone_index_access<B: StorageBackend>(storage: &
 
     for _ in 0..10 {
         let (sep, index) = (rand_solid_entry_point(), rand_milestone_index());
-        storage
-            .batch_insert::<SolidEntryPoint, MilestoneIndex>(&mut batch, &sep, &index)
-            .unwrap();
+        storage.batch_insert(&mut batch, &sep, &index).unwrap();
         seps_ids.push(sep);
         seps.push((sep, Some(index)));
     }

--- a/bee-storage/bee-storage-test/src/solid_entry_point_to_milestone_index.rs
+++ b/bee-storage/bee-storage-test/src/solid_entry_point_to_milestone_index.rs
@@ -107,7 +107,7 @@ pub fn solid_entry_point_to_milestone_index_access<B: StorageBackend>(storage: &
 
     storage.batch_commit(batch, true).unwrap();
 
-    let iter = AsIterator::<SolidEntryPoint, MilestoneIndex>::iter_op(storage).unwrap();
+    let iter = storage.iter::<SolidEntryPoint, MilestoneIndex>().unwrap();
     let mut count = 0;
 
     for result in iter {
@@ -130,7 +130,7 @@ pub fn solid_entry_point_to_milestone_index_access<B: StorageBackend>(storage: &
 
     Truncate::<SolidEntryPoint, MilestoneIndex>::truncate_op(storage).unwrap();
 
-    let mut iter = AsIterator::<SolidEntryPoint, MilestoneIndex>::iter_op(storage).unwrap();
+    let mut iter = storage.iter::<SolidEntryPoint, MilestoneIndex>().unwrap();
 
     assert!(iter.next().is_none());
 }

--- a/bee-storage/bee-storage-test/src/solid_entry_point_to_milestone_index.rs
+++ b/bee-storage/bee-storage-test/src/solid_entry_point_to_milestone_index.rs
@@ -67,7 +67,7 @@ pub fn solid_entry_point_to_milestone_index_access<B: StorageBackend>(storage: &
     assert_eq!(results.len(), 1);
     assert!(matches!(results.get(0), Some(Ok(Some(v))) if v == &index));
 
-    Delete::<SolidEntryPoint, MilestoneIndex>::delete_op(storage, &sep).unwrap();
+    storage.delete::<SolidEntryPoint, MilestoneIndex>(&sep).unwrap();
 
     assert!(!Exist::<SolidEntryPoint, MilestoneIndex>::exist_op(storage, &sep).unwrap());
     assert!(

--- a/bee-storage/bee-storage-test/src/solid_entry_point_to_milestone_index.rs
+++ b/bee-storage/bee-storage-test/src/solid_entry_point_to_milestone_index.rs
@@ -41,7 +41,7 @@ impl<T> StorageBackend for T where
 pub fn solid_entry_point_to_milestone_index_access<B: StorageBackend>(storage: &B) {
     let (sep, index) = (rand_solid_entry_point(), rand_milestone_index());
 
-    assert!(!Exist::<SolidEntryPoint, MilestoneIndex>::exist_op(storage, &sep).unwrap());
+    assert!(!storage.exist::<SolidEntryPoint, MilestoneIndex>(&sep).unwrap());
     assert!(
         storage
             .fetch::<SolidEntryPoint, MilestoneIndex>(&sep)
@@ -56,7 +56,7 @@ pub fn solid_entry_point_to_milestone_index_access<B: StorageBackend>(storage: &
 
     Insert::<SolidEntryPoint, MilestoneIndex>::insert_op(storage, &sep, &index).unwrap();
 
-    assert!(Exist::<SolidEntryPoint, MilestoneIndex>::exist_op(storage, &sep).unwrap());
+    assert!(storage.exist::<SolidEntryPoint, MilestoneIndex>(&sep).unwrap());
     assert_eq!(
         storage.fetch::<SolidEntryPoint, MilestoneIndex>(&sep).unwrap().unwrap(),
         index
@@ -69,7 +69,7 @@ pub fn solid_entry_point_to_milestone_index_access<B: StorageBackend>(storage: &
 
     storage.delete::<SolidEntryPoint, MilestoneIndex>(&sep).unwrap();
 
-    assert!(!Exist::<SolidEntryPoint, MilestoneIndex>::exist_op(storage, &sep).unwrap());
+    assert!(!storage.exist::<SolidEntryPoint, MilestoneIndex>(&sep).unwrap());
     assert!(
         storage
             .fetch::<SolidEntryPoint, MilestoneIndex>(&sep)

--- a/bee-storage/bee-storage-test/src/solid_entry_point_to_milestone_index.rs
+++ b/bee-storage/bee-storage-test/src/solid_entry_point_to_milestone_index.rs
@@ -48,7 +48,8 @@ pub fn solid_entry_point_to_milestone_index_access<B: StorageBackend>(storage: &
             .unwrap()
             .is_none()
     );
-    let results = MultiFetch::<SolidEntryPoint, MilestoneIndex>::multi_fetch_op(storage, &[sep])
+    let results = storage
+        .multi_fetch::<SolidEntryPoint, MilestoneIndex>(&[sep])
         .unwrap()
         .collect::<Vec<_>>();
     assert_eq!(results.len(), 1);
@@ -61,7 +62,8 @@ pub fn solid_entry_point_to_milestone_index_access<B: StorageBackend>(storage: &
         storage.fetch::<SolidEntryPoint, MilestoneIndex>(&sep).unwrap().unwrap(),
         index
     );
-    let results = MultiFetch::<SolidEntryPoint, MilestoneIndex>::multi_fetch_op(storage, &[sep])
+    let results = storage
+        .multi_fetch::<SolidEntryPoint, MilestoneIndex>(&[sep])
         .unwrap()
         .collect::<Vec<_>>();
     assert_eq!(results.len(), 1);
@@ -76,7 +78,8 @@ pub fn solid_entry_point_to_milestone_index_access<B: StorageBackend>(storage: &
             .unwrap()
             .is_none()
     );
-    let results = MultiFetch::<SolidEntryPoint, MilestoneIndex>::multi_fetch_op(storage, &[sep])
+    let results = storage
+        .multi_fetch::<SolidEntryPoint, MilestoneIndex>(&[sep])
         .unwrap()
         .collect::<Vec<_>>();
     assert_eq!(results.len(), 1);
@@ -118,7 +121,8 @@ pub fn solid_entry_point_to_milestone_index_access<B: StorageBackend>(storage: &
 
     assert_eq!(count, 10);
 
-    let results = MultiFetch::<SolidEntryPoint, MilestoneIndex>::multi_fetch_op(storage, &seps_ids)
+    let results = storage
+        .multi_fetch::<SolidEntryPoint, MilestoneIndex>(&seps_ids)
         .unwrap()
         .collect::<Vec<_>>();
 

--- a/bee-storage/bee-storage-test/src/solid_entry_point_to_milestone_index.rs
+++ b/bee-storage/bee-storage-test/src/solid_entry_point_to_milestone_index.rs
@@ -132,7 +132,7 @@ pub fn solid_entry_point_to_milestone_index_access<B: StorageBackend>(storage: &
         assert_eq!(index, result.unwrap());
     }
 
-    Truncate::<SolidEntryPoint, MilestoneIndex>::truncate_op(storage).unwrap();
+    storage.truncate::<SolidEntryPoint, MilestoneIndex>().unwrap();
 
     let mut iter = storage.iter::<SolidEntryPoint, MilestoneIndex>().unwrap();
 

--- a/bee-storage/bee-storage-test/src/spent_to_treasury_output.rs
+++ b/bee-storage/bee-storage-test/src/spent_to_treasury_output.rs
@@ -73,7 +73,9 @@ pub fn spent_to_treasury_output_access<B: StorageBackend>(storage: &B) {
     for _ in 0..10 {
         let (spent, treasury_output) = (rand_bool(), rand_ledger_treasury_output());
         Insert::<(bool, TreasuryOutput), ()>::insert_op(storage, &(spent, treasury_output.clone()), &()).unwrap();
-        Batch::<(bool, TreasuryOutput), ()>::batch_delete_op(storage, &mut batch, &(spent, treasury_output)).unwrap();
+        storage
+            .batch_delete::<(bool, TreasuryOutput), ()>(&mut batch, &(spent, treasury_output))
+            .unwrap();
     }
 
     let mut treasury_outputs = HashMap::<bool, Vec<TreasuryOutput>>::new();
@@ -81,26 +83,18 @@ pub fn spent_to_treasury_output_access<B: StorageBackend>(storage: &B) {
     for _ in 0..10 {
         let spent = false;
         let treasury_output = rand_ledger_treasury_output();
-        Batch::<(bool, TreasuryOutput), ()>::batch_insert_op(
-            storage,
-            &mut batch,
-            &(spent, treasury_output.clone()),
-            &(),
-        )
-        .unwrap();
+        storage
+            .batch_insert::<(bool, TreasuryOutput), ()>(&mut batch, &(spent, treasury_output.clone()), &())
+            .unwrap();
         treasury_outputs.entry(spent).or_default().push(treasury_output);
     }
 
     for _ in 0..10 {
         let spent = true;
         let treasury_output = rand_ledger_treasury_output();
-        Batch::<(bool, TreasuryOutput), ()>::batch_insert_op(
-            storage,
-            &mut batch,
-            &(spent, treasury_output.clone()),
-            &(),
-        )
-        .unwrap();
+        storage
+            .batch_insert::<(bool, TreasuryOutput), ()>(&mut batch, &(spent, treasury_output.clone()), &())
+            .unwrap();
         treasury_outputs.entry(spent).or_default().push(treasury_output);
     }
 

--- a/bee-storage/bee-storage-test/src/spent_to_treasury_output.rs
+++ b/bee-storage/bee-storage-test/src/spent_to_treasury_output.rs
@@ -53,9 +53,7 @@ pub fn spent_to_treasury_output_access<B: StorageBackend>(storage: &B) {
             .is_empty()
     );
 
-    storage
-        .insert::<(bool, TreasuryOutput), ()>(&(spent, treasury_output.clone()), &())
-        .unwrap();
+    storage.insert(&(spent, treasury_output.clone()), &()).unwrap();
 
     assert!(
         storage
@@ -88,9 +86,7 @@ pub fn spent_to_treasury_output_access<B: StorageBackend>(storage: &B) {
 
     for _ in 0..10 {
         let (spent, treasury_output) = (rand_bool(), rand_ledger_treasury_output());
-        storage
-            .insert::<(bool, TreasuryOutput), ()>(&(spent, treasury_output.clone()), &())
-            .unwrap();
+        storage.insert(&(spent, treasury_output.clone()), &()).unwrap();
         storage
             .batch_delete::<(bool, TreasuryOutput), ()>(&mut batch, &(spent, treasury_output))
             .unwrap();
@@ -102,7 +98,7 @@ pub fn spent_to_treasury_output_access<B: StorageBackend>(storage: &B) {
         let spent = false;
         let treasury_output = rand_ledger_treasury_output();
         storage
-            .batch_insert::<(bool, TreasuryOutput), ()>(&mut batch, &(spent, treasury_output.clone()), &())
+            .batch_insert(&mut batch, &(spent, treasury_output.clone()), &())
             .unwrap();
         treasury_outputs.entry(spent).or_default().push(treasury_output);
     }
@@ -111,7 +107,7 @@ pub fn spent_to_treasury_output_access<B: StorageBackend>(storage: &B) {
         let spent = true;
         let treasury_output = rand_ledger_treasury_output();
         storage
-            .batch_insert::<(bool, TreasuryOutput), ()>(&mut batch, &(spent, treasury_output.clone()), &())
+            .batch_insert(&mut batch, &(spent, treasury_output.clone()), &())
             .unwrap();
         treasury_outputs.entry(spent).or_default().push(treasury_output);
     }

--- a/bee-storage/bee-storage-test/src/spent_to_treasury_output.rs
+++ b/bee-storage/bee-storage-test/src/spent_to_treasury_output.rs
@@ -53,7 +53,9 @@ pub fn spent_to_treasury_output_access<B: StorageBackend>(storage: &B) {
             .is_empty()
     );
 
-    Insert::<(bool, TreasuryOutput), ()>::insert_op(storage, &(spent, treasury_output.clone()), &()).unwrap();
+    storage
+        .insert::<(bool, TreasuryOutput), ()>(&(spent, treasury_output.clone()), &())
+        .unwrap();
 
     assert!(
         storage
@@ -86,7 +88,9 @@ pub fn spent_to_treasury_output_access<B: StorageBackend>(storage: &B) {
 
     for _ in 0..10 {
         let (spent, treasury_output) = (rand_bool(), rand_ledger_treasury_output());
-        Insert::<(bool, TreasuryOutput), ()>::insert_op(storage, &(spent, treasury_output.clone()), &()).unwrap();
+        storage
+            .insert::<(bool, TreasuryOutput), ()>(&(spent, treasury_output.clone()), &())
+            .unwrap();
         storage
             .batch_delete::<(bool, TreasuryOutput), ()>(&mut batch, &(spent, treasury_output))
             .unwrap();

--- a/bee-storage/bee-storage-test/src/spent_to_treasury_output.rs
+++ b/bee-storage/bee-storage-test/src/spent_to_treasury_output.rs
@@ -57,7 +57,9 @@ pub fn spent_to_treasury_output_access<B: StorageBackend>(storage: &B) {
         vec![treasury_output.clone()]
     );
 
-    Delete::<(bool, TreasuryOutput), ()>::delete_op(storage, &(spent, treasury_output.clone())).unwrap();
+    storage
+        .delete::<(bool, TreasuryOutput), ()>(&(spent, treasury_output.clone()))
+        .unwrap();
 
     assert!(!Exist::<(bool, TreasuryOutput), ()>::exist_op(storage, &(spent, treasury_output)).unwrap());
     assert!(

--- a/bee-storage/bee-storage-test/src/spent_to_treasury_output.rs
+++ b/bee-storage/bee-storage-test/src/spent_to_treasury_output.rs
@@ -43,7 +43,7 @@ pub fn spent_to_treasury_output_access<B: StorageBackend>(storage: &B) {
     assert!(!Exist::<(bool, TreasuryOutput), ()>::exist(storage, &(spent, treasury_output.clone())).unwrap());
     assert!(
         storage
-            .fetch_access::<bool, Vec<TreasuryOutput>>(&spent)
+            .fetch::<bool, Vec<TreasuryOutput>>(&spent)
             .unwrap()
             .unwrap()
             .is_empty()
@@ -53,10 +53,7 @@ pub fn spent_to_treasury_output_access<B: StorageBackend>(storage: &B) {
 
     assert!(Exist::<(bool, TreasuryOutput), ()>::exist(storage, &(spent, treasury_output.clone())).unwrap());
     assert_eq!(
-        storage
-            .fetch_access::<bool, Vec<TreasuryOutput>>(&spent)
-            .unwrap()
-            .unwrap(),
+        storage.fetch::<bool, Vec<TreasuryOutput>>(&spent).unwrap().unwrap(),
         vec![treasury_output.clone()]
     );
 
@@ -65,7 +62,7 @@ pub fn spent_to_treasury_output_access<B: StorageBackend>(storage: &B) {
     assert!(!Exist::<(bool, TreasuryOutput), ()>::exist(storage, &(spent, treasury_output)).unwrap());
     assert!(
         storage
-            .fetch_access::<bool, Vec<TreasuryOutput>>(&spent)
+            .fetch::<bool, Vec<TreasuryOutput>>(&spent)
             .unwrap()
             .unwrap()
             .is_empty()

--- a/bee-storage/bee-storage-test/src/spent_to_treasury_output.rs
+++ b/bee-storage/bee-storage-test/src/spent_to_treasury_output.rs
@@ -129,7 +129,7 @@ pub fn spent_to_treasury_output_access<B: StorageBackend>(storage: &B) {
 
     assert_eq!(count, treasury_outputs.iter().fold(0, |acc, v| acc + v.1.len()));
 
-    Truncate::<(bool, TreasuryOutput), ()>::truncate_op(storage).unwrap();
+    storage.truncate::<(bool, TreasuryOutput), ()>().unwrap();
 
     let mut iter = storage.iter::<(bool, TreasuryOutput), ()>().unwrap();
 

--- a/bee-storage/bee-storage-test/src/spent_to_treasury_output.rs
+++ b/bee-storage/bee-storage-test/src/spent_to_treasury_output.rs
@@ -40,7 +40,11 @@ impl<T> StorageBackend for T where
 pub fn spent_to_treasury_output_access<B: StorageBackend>(storage: &B) {
     let (spent, treasury_output) = (rand_bool(), rand_ledger_treasury_output());
 
-    assert!(!Exist::<(bool, TreasuryOutput), ()>::exist_op(storage, &(spent, treasury_output.clone())).unwrap());
+    assert!(
+        !storage
+            .exist::<(bool, TreasuryOutput), ()>(&(spent, treasury_output.clone()))
+            .unwrap()
+    );
     assert!(
         storage
             .fetch::<bool, Vec<TreasuryOutput>>(&spent)
@@ -51,7 +55,11 @@ pub fn spent_to_treasury_output_access<B: StorageBackend>(storage: &B) {
 
     Insert::<(bool, TreasuryOutput), ()>::insert_op(storage, &(spent, treasury_output.clone()), &()).unwrap();
 
-    assert!(Exist::<(bool, TreasuryOutput), ()>::exist_op(storage, &(spent, treasury_output.clone())).unwrap());
+    assert!(
+        storage
+            .exist::<(bool, TreasuryOutput), ()>(&(spent, treasury_output.clone()))
+            .unwrap()
+    );
     assert_eq!(
         storage.fetch::<bool, Vec<TreasuryOutput>>(&spent).unwrap().unwrap(),
         vec![treasury_output.clone()]
@@ -61,7 +69,11 @@ pub fn spent_to_treasury_output_access<B: StorageBackend>(storage: &B) {
         .delete::<(bool, TreasuryOutput), ()>(&(spent, treasury_output.clone()))
         .unwrap();
 
-    assert!(!Exist::<(bool, TreasuryOutput), ()>::exist_op(storage, &(spent, treasury_output)).unwrap());
+    assert!(
+        !storage
+            .exist::<(bool, TreasuryOutput), ()>(&(spent, treasury_output))
+            .unwrap()
+    );
     assert!(
         storage
             .fetch::<bool, Vec<TreasuryOutput>>(&spent)

--- a/bee-storage/bee-storage-test/src/spent_to_treasury_output.rs
+++ b/bee-storage/bee-storage-test/src/spent_to_treasury_output.rs
@@ -118,7 +118,7 @@ pub fn spent_to_treasury_output_access<B: StorageBackend>(storage: &B) {
 
     storage.batch_commit(batch, true).unwrap();
 
-    let iter = AsIterator::<(bool, TreasuryOutput), ()>::iter_op(storage).unwrap();
+    let iter = storage.iter::<(bool, TreasuryOutput), ()>().unwrap();
     let mut count = 0;
 
     for result in iter {
@@ -131,7 +131,7 @@ pub fn spent_to_treasury_output_access<B: StorageBackend>(storage: &B) {
 
     Truncate::<(bool, TreasuryOutput), ()>::truncate_op(storage).unwrap();
 
-    let mut iter = AsIterator::<(bool, TreasuryOutput), ()>::iter_op(storage).unwrap();
+    let mut iter = storage.iter::<(bool, TreasuryOutput), ()>().unwrap();
 
     assert!(iter.next().is_none());
 }

--- a/bee-storage/bee-storage-test/src/spent_to_treasury_output.rs
+++ b/bee-storage/bee-storage-test/src/spent_to_treasury_output.rs
@@ -7,6 +7,7 @@ use bee_ledger::types::TreasuryOutput;
 use bee_storage::{
     access::{AsIterator, Batch, BatchBuilder, Delete, Exist, Fetch, Insert, Truncate},
     backend,
+    backend::StorageBackendExt,
 };
 use bee_test::rand::{bool::rand_bool, output::rand_ledger_treasury_output};
 
@@ -41,7 +42,8 @@ pub fn spent_to_treasury_output_access<B: StorageBackend>(storage: &B) {
 
     assert!(!Exist::<(bool, TreasuryOutput), ()>::exist(storage, &(spent, treasury_output.clone())).unwrap());
     assert!(
-        Fetch::<bool, Vec<TreasuryOutput>>::fetch(storage, &spent)
+        storage
+            .fetch_access::<bool, Vec<TreasuryOutput>>(&spent)
             .unwrap()
             .unwrap()
             .is_empty()
@@ -51,7 +53,8 @@ pub fn spent_to_treasury_output_access<B: StorageBackend>(storage: &B) {
 
     assert!(Exist::<(bool, TreasuryOutput), ()>::exist(storage, &(spent, treasury_output.clone())).unwrap());
     assert_eq!(
-        Fetch::<bool, Vec<TreasuryOutput>>::fetch(storage, &spent)
+        storage
+            .fetch_access::<bool, Vec<TreasuryOutput>>(&spent)
             .unwrap()
             .unwrap(),
         vec![treasury_output.clone()]
@@ -61,7 +64,8 @@ pub fn spent_to_treasury_output_access<B: StorageBackend>(storage: &B) {
 
     assert!(!Exist::<(bool, TreasuryOutput), ()>::exist(storage, &(spent, treasury_output)).unwrap());
     assert!(
-        Fetch::<bool, Vec<TreasuryOutput>>::fetch(storage, &spent)
+        storage
+            .fetch_access::<bool, Vec<TreasuryOutput>>(&spent)
             .unwrap()
             .unwrap()
             .is_empty()

--- a/bee-storage/bee-storage/src/access/batch.rs
+++ b/bee-storage/bee-storage/src/access/batch.rs
@@ -23,7 +23,7 @@ pub trait BatchBuilder: StorageBackend {
 /// therefore, it should be explicitly implemented for the corresponding `StorageBackend`.
 pub trait Batch<K, V>: BatchBuilder {
     /// Add Insert batch operation for the provided key value pair into the Batch memory buffer.
-    fn batch_insert(&self, batch: &mut Self::Batch, key: &K, value: &V) -> Result<(), Self::Error>;
+    fn batch_insert_op(&self, batch: &mut Self::Batch, key: &K, value: &V) -> Result<(), Self::Error>;
     /// Add Delete batch operation for the provided key value pair into the Batch memory buffer.
-    fn batch_delete(&self, batch: &mut Self::Batch, key: &K) -> Result<(), Self::Error>;
+    fn batch_delete_op(&self, batch: &mut Self::Batch, key: &K) -> Result<(), Self::Error>;
 }

--- a/bee-storage/bee-storage/src/access/delete.rs
+++ b/bee-storage/bee-storage/src/access/delete.rs
@@ -7,5 +7,5 @@ use crate::backend::StorageBackend;
 /// therefore, it should be explicitly implemented for the corresponding `StorageBackend`.
 pub trait Delete<K, V>: StorageBackend {
     /// Deletes the value associated with the key from the storage.
-    fn delete(&self, key: &K) -> Result<(), Self::Error>;
+    fn delete_op(&self, key: &K) -> Result<(), Self::Error>;
 }

--- a/bee-storage/bee-storage/src/access/exist.rs
+++ b/bee-storage/bee-storage/src/access/exist.rs
@@ -7,5 +7,5 @@ use crate::backend::StorageBackend;
 /// therefore, it should be explicitly implemented for the corresponding `StorageBackend`.
 pub trait Exist<K, V>: StorageBackend {
     /// Checks if a value exists in the storage for the given key.
-    fn exist(&self, key: &K) -> Result<bool, Self::Error>;
+    fn exist_op(&self, key: &K) -> Result<bool, Self::Error>;
 }

--- a/bee-storage/bee-storage/src/access/fetch.rs
+++ b/bee-storage/bee-storage/src/access/fetch.rs
@@ -7,5 +7,5 @@ use crate::backend::StorageBackend;
 /// therefore, it should be explicitly implemented for the corresponding `StorageBackend`.
 pub trait Fetch<K, V>: StorageBackend {
     /// Fetches the value associated with the key from the storage.
-    fn fetch(&self, key: &K) -> Result<Option<V>, Self::Error>;
+    fn fetch_op(&self, key: &K) -> Result<Option<V>, Self::Error>;
 }

--- a/bee-storage/bee-storage/src/access/insert.rs
+++ b/bee-storage/bee-storage/src/access/insert.rs
@@ -7,7 +7,7 @@ use crate::backend::StorageBackend;
 /// therefore, it should be explicitly implemented for the corresponding `StorageBackend`.
 pub trait Insert<K, V>: StorageBackend {
     /// Inserts the (K, V) pair in the storage overwriting the value if it already exists.
-    fn insert(&self, key: &K, value: &V) -> Result<(), Self::Error>;
+    fn insert_op(&self, key: &K, value: &V) -> Result<(), Self::Error>;
 }
 
 /// `InsertStrict<K, V>` trait extends the `StorageBackend` with `insert_strict` operation for the
@@ -15,5 +15,5 @@ pub trait Insert<K, V>: StorageBackend {
 /// `StorageBackend`.
 pub trait InsertStrict<K, V>: StorageBackend {
     /// Inserts the (K, V) pair in the storage without overwriting the value if it already exists.
-    fn insert_strict(&self, key: &K, value: &V) -> Result<(), Self::Error>;
+    fn insert_strict_op(&self, key: &K, value: &V) -> Result<(), Self::Error>;
 }

--- a/bee-storage/bee-storage/src/access/iter.rs
+++ b/bee-storage/bee-storage/src/access/iter.rs
@@ -10,5 +10,5 @@ pub trait AsIterator<'a, K, V>: StorageBackend {
     type AsIter: Iterator<Item = Result<(K, V), Self::Error>>;
 
     /// Returns a `Iterator` object for the provided <K, V> collection.
-    fn iter(&'a self) -> Result<Self::AsIter, Self::Error>;
+    fn iter_op(&'a self) -> Result<Self::AsIter, Self::Error>;
 }

--- a/bee-storage/bee-storage/src/access/multi_fetch.rs
+++ b/bee-storage/bee-storage/src/access/multi_fetch.rs
@@ -10,5 +10,5 @@ pub trait MultiFetch<'a, K, V>: StorageBackend {
     type Iter: 'a + Iterator<Item = Result<Option<V>, Self::Error>>;
 
     /// Fetches the values associated with the keys from the storage.
-    fn multi_fetch(&'a self, keys: &'a [K]) -> Result<Self::Iter, Self::Error>;
+    fn multi_fetch_op(&'a self, keys: &'a [K]) -> Result<Self::Iter, Self::Error>;
 }

--- a/bee-storage/bee-storage/src/access/truncate.rs
+++ b/bee-storage/bee-storage/src/access/truncate.rs
@@ -7,5 +7,5 @@ use crate::backend::StorageBackend;
 /// therefore, it should be explicitly implemented for the corresponding `StorageBackend`.
 pub trait Truncate<K, V>: StorageBackend {
     /// Truncates all the entries associated with the (K, V) pair from the storage.
-    fn truncate(&self) -> Result<(), Self::Error>;
+    fn truncate_op(&self) -> Result<(), Self::Error>;
 }

--- a/bee-storage/bee-storage/src/access/update.rs
+++ b/bee-storage/bee-storage/src/access/update.rs
@@ -7,5 +7,5 @@ use crate::backend::StorageBackend;
 /// therefore, it should be explicitly implemented for the corresponding `StorageBackend`.
 pub trait Update<K, V>: StorageBackend {
     /// Fetches the value for the key `K` and updates it using `f`.
-    fn update(&self, key: &K, f: impl FnMut(&mut V)) -> Result<(), Self::Error>;
+    fn update_op(&self, key: &K, f: impl FnMut(&mut V)) -> Result<(), Self::Error>;
 }

--- a/bee-storage/bee-storage/src/backend.rs
+++ b/bee-storage/bee-storage/src/backend.rs
@@ -111,7 +111,7 @@ impl<S: StorageBackend> StorageBackendExt for S {
     where
         Self: Batch<K, V>,
     {
-        Batch::<K, V>::batch_insert(self, batch, key, value)
+        Batch::<K, V>::batch_insert_op(self, batch, key, value)
     }
 
     #[inline(always)]
@@ -119,7 +119,7 @@ impl<S: StorageBackend> StorageBackendExt for S {
     where
         Self: Batch<K, V>,
     {
-        Batch::<K, V>::batch_delete(self, batch, key)
+        Batch::<K, V>::batch_delete_op(self, batch, key)
     }
 
     #[inline(always)]
@@ -127,7 +127,7 @@ impl<S: StorageBackend> StorageBackendExt for S {
     where
         Self: Delete<K, V>,
     {
-        Delete::<K, V>::delete(self, key)
+        Delete::<K, V>::delete_op(self, key)
     }
 
     #[inline(always)]
@@ -135,7 +135,7 @@ impl<S: StorageBackend> StorageBackendExt for S {
     where
         Self: Exist<K, V>,
     {
-        Exist::<K, V>::exist(self, key)
+        Exist::<K, V>::exist_op(self, key)
     }
 
     #[inline(always)]
@@ -151,7 +151,7 @@ impl<S: StorageBackend> StorageBackendExt for S {
     where
         Self: Insert<K, V>,
     {
-        Insert::<K, V>::insert(self, key, value)
+        Insert::<K, V>::insert_op(self, key, value)
     }
 
     #[inline(always)]
@@ -159,7 +159,7 @@ impl<S: StorageBackend> StorageBackendExt for S {
     where
         Self: InsertStrict<K, V>,
     {
-        InsertStrict::<K, V>::insert_strict(self, key, value)
+        InsertStrict::<K, V>::insert_strict_op(self, key, value)
     }
 
     #[inline(always)]
@@ -167,7 +167,7 @@ impl<S: StorageBackend> StorageBackendExt for S {
     where
         Self: AsIterator<'a, K, V>,
     {
-        AsIterator::<'a, K, V>::iter(self)
+        AsIterator::<'a, K, V>::iter_op(self)
     }
 
     #[inline(always)]
@@ -175,7 +175,7 @@ impl<S: StorageBackend> StorageBackendExt for S {
     where
         Self: MultiFetch<'a, K, V>,
     {
-        MultiFetch::<'a, K, V>::multi_fetch(self, keys)
+        MultiFetch::<'a, K, V>::multi_fetch_op(self, keys)
     }
 
     #[inline(always)]
@@ -183,7 +183,7 @@ impl<S: StorageBackend> StorageBackendExt for S {
     where
         Self: Truncate<K, V>,
     {
-        Truncate::<K, V>::truncate(self)
+        Truncate::<K, V>::truncate_op(self)
     }
 
     #[inline(always)]
@@ -191,6 +191,6 @@ impl<S: StorageBackend> StorageBackendExt for S {
     where
         Self: Update<K, V>,
     {
-        Update::<K, V>::update(self, key, f)
+        Update::<K, V>::update_op(self, key, f)
     }
 }

--- a/bee-storage/bee-storage/src/backend.rs
+++ b/bee-storage/bee-storage/src/backend.rs
@@ -6,7 +6,12 @@
 
 use serde::de::DeserializeOwned;
 
-use crate::system::StorageHealth;
+use crate::{
+    access::{
+        AsIterator, Batch, BatchBuilder, Delete, Exist, Fetch, Insert, InsertStrict, MultiFetch, Truncate, Update,
+    },
+    system::StorageHealth,
+};
 
 /// Trait to be implemented on a storage backend.
 /// Determines how to start and shutdown the backend.
@@ -35,4 +40,157 @@ pub trait StorageBackend: Send + Sized + Sync + 'static {
     /// Sets the health status of the database.
     /// Not all backends may be able to provide this operation.
     fn set_health(&self, health: StorageHealth) -> Result<(), Self::Error>;
+}
+
+/// Convenience trait to simplify access operations.
+pub trait StorageBackendExt: StorageBackend {
+    /// Add Insert batch operation for the provided key value pair into the Batch memory buffer.
+    fn batch_insert<K, V>(&self, batch: &mut Self::Batch, key: &K, value: &V) -> Result<(), Self::Error>
+    where
+        Self: Batch<K, V>;
+
+    /// Add Delete batch operation for the provided key value pair into the Batch memory buffer.
+    fn batch_delete<K, V>(&self, batch: &mut Self::Batch, key: &K) -> Result<(), Self::Error>
+    where
+        Self: Batch<K, V>;
+
+    /// Deletes the value associated with the key from the storage.
+    fn delete<K, V>(&self, key: &K) -> Result<(), Self::Error>
+    where
+        Self: Delete<K, V>;
+
+    /// Checks if a value exists in the storage for the given key.
+    fn exist<K, V>(&self, key: &K) -> Result<bool, Self::Error>
+    where
+        Self: Exist<K, V>;
+
+    /// Fetches the value associated with the key from the storage.
+    fn fetch_access<K, V>(&self, key: &K) -> Result<Option<V>, Self::Error>
+    where
+        Self: Fetch<K, V>;
+
+    /// Inserts the (K, V) pair in the storage overwriting the value if it already exists.
+    fn insert<K, V>(&self, key: &K, value: &V) -> Result<(), Self::Error>
+    where
+        Self: Insert<K, V>;
+
+    /// Inserts the (K, V) pair in the storage without overwriting the value if it already exists.
+    fn insert_strict<K, V>(&self, key: &K, value: &V) -> Result<(), Self::Error>
+    where
+        Self: InsertStrict<K, V>;
+
+    /// Returns a `Iterator` object for the provided <K, V> collection.
+    fn iter<'a, K, V>(&'a self) -> Result<Self::AsIter, Self::Error>
+    where
+        Self: AsIterator<'a, K, V>;
+
+    /// Fetches the values associated with the keys from the storage.
+    fn multi_fetch<'a, K, V>(&'a self, keys: &'a [K]) -> Result<Self::Iter, Self::Error>
+    where
+        Self: MultiFetch<'a, K, V>;
+
+    /// Truncates all the entries associated with the (K, V) pair from the storage.
+    fn truncate<K, V>(&self) -> Result<(), Self::Error>
+    where
+        Self: Truncate<K, V>;
+
+    /// Fetches the value for the key `K` and updates it using `f`.
+    fn update<K, V>(&self, key: &K, f: impl FnMut(&mut V)) -> Result<(), Self::Error>
+    where
+        Self: Update<K, V>;
+}
+
+impl<S: StorageBackend> StorageBackendExt for S {
+    #[inline(always)]
+    fn batch_insert<K, V>(
+        &self,
+        batch: &mut <Self as BatchBuilder>::Batch,
+        key: &K,
+        value: &V,
+    ) -> Result<(), Self::Error>
+    where
+        Self: Batch<K, V>,
+    {
+        Batch::<K, V>::batch_insert(self, batch, key, value)
+    }
+
+    #[inline(always)]
+    fn batch_delete<K, V>(&self, batch: &mut <Self as BatchBuilder>::Batch, key: &K) -> Result<(), Self::Error>
+    where
+        Self: Batch<K, V>,
+    {
+        Batch::<K, V>::batch_delete(self, batch, key)
+    }
+
+    #[inline(always)]
+    fn delete<K, V>(&self, key: &K) -> Result<(), Self::Error>
+    where
+        Self: Delete<K, V>,
+    {
+        Delete::<K, V>::delete(self, key)
+    }
+
+    #[inline(always)]
+    fn exist<K, V>(&self, key: &K) -> Result<bool, Self::Error>
+    where
+        Self: Exist<K, V>,
+    {
+        Exist::<K, V>::exist(self, key)
+    }
+
+    #[inline(always)]
+    fn fetch_access<K, V>(&self, key: &K) -> Result<Option<V>, Self::Error>
+    where
+        Self: Fetch<K, V>,
+    {
+        Fetch::<K, V>::fetch(self, key)
+    }
+
+    #[inline(always)]
+    fn insert<K, V>(&self, key: &K, value: &V) -> Result<(), Self::Error>
+    where
+        Self: Insert<K, V>,
+    {
+        Insert::<K, V>::insert(self, key, value)
+    }
+
+    #[inline(always)]
+    fn insert_strict<K, V>(&self, key: &K, value: &V) -> Result<(), Self::Error>
+    where
+        Self: InsertStrict<K, V>,
+    {
+        InsertStrict::<K, V>::insert_strict(self, key, value)
+    }
+
+    #[inline(always)]
+    fn iter<'a, K, V>(&'a self) -> Result<<Self as AsIterator<'a, K, V>>::AsIter, Self::Error>
+    where
+        Self: AsIterator<'a, K, V>,
+    {
+        AsIterator::<'a, K, V>::iter(self)
+    }
+
+    #[inline(always)]
+    fn multi_fetch<'a, K, V>(&'a self, keys: &'a [K]) -> Result<<Self as MultiFetch<'a, K, V>>::Iter, Self::Error>
+    where
+        Self: MultiFetch<'a, K, V>,
+    {
+        MultiFetch::<'a, K, V>::multi_fetch(self, keys)
+    }
+
+    #[inline(always)]
+    fn truncate<K, V>(&self) -> Result<(), Self::Error>
+    where
+        Self: Truncate<K, V>,
+    {
+        Truncate::<K, V>::truncate(self)
+    }
+
+    #[inline(always)]
+    fn update<K, V>(&self, key: &K, f: impl FnMut(&mut V)) -> Result<(), Self::Error>
+    where
+        Self: Update<K, V>,
+    {
+        Update::<K, V>::update(self, key, f)
+    }
 }

--- a/bee-storage/bee-storage/src/backend.rs
+++ b/bee-storage/bee-storage/src/backend.rs
@@ -65,7 +65,7 @@ pub trait StorageBackendExt: StorageBackend {
         Self: Exist<K, V>;
 
     /// Fetches the value associated with the key from the storage.
-    fn fetch_access<K, V>(&self, key: &K) -> Result<Option<V>, Self::Error>
+    fn fetch<K, V>(&self, key: &K) -> Result<Option<V>, Self::Error>
     where
         Self: Fetch<K, V>;
 
@@ -139,11 +139,11 @@ impl<S: StorageBackend> StorageBackendExt for S {
     }
 
     #[inline(always)]
-    fn fetch_access<K, V>(&self, key: &K) -> Result<Option<V>, Self::Error>
+    fn fetch<K, V>(&self, key: &K) -> Result<Option<V>, Self::Error>
     where
         Self: Fetch<K, V>,
     {
-        Fetch::<K, V>::fetch(self, key)
+        Fetch::<K, V>::fetch_op(self, key)
     }
 
     #[inline(always)]

--- a/bee-storage/bee-storage/src/backend.rs
+++ b/bee-storage/bee-storage/src/backend.rs
@@ -95,9 +95,10 @@ pub trait StorageBackendExt: StorageBackend {
         Self: Truncate<K, V>;
 
     /// Fetches the value for the key `K` and updates it using `f`.
-    fn update<K, V>(&self, key: &K, f: impl FnMut(&mut V)) -> Result<(), Self::Error>
+    fn update<K, V, F>(&self, key: &K, f: F) -> Result<(), Self::Error>
     where
-        Self: Update<K, V>;
+        Self: Update<K, V>,
+        F: FnMut(&mut V);
 }
 
 impl<S: StorageBackend> StorageBackendExt for S {
@@ -187,9 +188,10 @@ impl<S: StorageBackend> StorageBackendExt for S {
     }
 
     #[inline(always)]
-    fn update<K, V>(&self, key: &K, f: impl FnMut(&mut V)) -> Result<(), Self::Error>
+    fn update<K, V, F>(&self, key: &K, f: F) -> Result<(), Self::Error>
     where
         Self: Update<K, V>,
+        F: FnMut(&mut V),
     {
         Update::<K, V>::update_op(self, key, f)
     }

--- a/bee-tangle/src/tangle.rs
+++ b/bee-tangle/src/tangle.rs
@@ -385,7 +385,7 @@ impl<B: StorageBackend> Tangle<B> {
         let mut output = None;
 
         self.storage
-            .update_op(message_id, |metadata| output = Some(update(metadata)))
+            .update(message_id, |metadata| output = Some(update(metadata)))
             .unwrap_or_default();
 
         output

--- a/bee-tangle/src/tangle.rs
+++ b/bee-tangle/src/tangle.rs
@@ -8,6 +8,7 @@ use bee_message::{
     Message, MessageId,
 };
 use bee_runtime::resource::ResourceHandle;
+use bee_storage::backend::StorageBackendExt;
 use hashbrown::HashMap;
 use log::warn;
 use ref_cast::RefCast;
@@ -131,7 +132,7 @@ impl<B: StorageBackend> Tangle<B> {
     /// Return whether the tangle contains the given milestone index.
     #[cfg_attr(feature = "trace", trace_tools::observe)]
     pub fn contains_milestone(&self, index: MilestoneIndex) -> bool {
-        self.storage.exist_op(&index).unwrap_or_default()
+        self.storage.exist(&index).unwrap_or_default()
     }
 
     /// Get the index of the latest milestone.
@@ -365,7 +366,7 @@ impl<B: StorageBackend> Tangle<B> {
     /// Returns whether the message is stored in the Tangle.
     #[cfg_attr(feature = "trace", trace_tools::observe)]
     pub fn contains(&self, message_id: &MessageId) -> bool {
-        self.storage.exist_op(message_id).unwrap_or_default()
+        self.storage.exist(message_id).unwrap_or_default()
     }
 
     /// Get the metadata of a vertex associated with the given `message_id`.

--- a/bee-tangle/src/tangle.rs
+++ b/bee-tangle/src/tangle.rs
@@ -110,7 +110,7 @@ impl<B: StorageBackend> Tangle<B> {
     /// Get the milestone from the tangle that corresponds to the given milestone index.
     #[cfg_attr(feature = "trace", trace_tools::observe)]
     pub fn get_milestone(&self, index: MilestoneIndex) -> Option<Milestone> {
-        self.storage.fetch(&index).unwrap_or_else(|e| {
+        self.storage.fetch_op(&index).unwrap_or_else(|e| {
             warn!("Failed to fetch milestone {:?}", e);
             None
         })
@@ -350,14 +350,14 @@ impl<B: StorageBackend> Tangle<B> {
     /// Get the data of a vertex associated with the given `message_id`.
     #[cfg_attr(feature = "trace", trace_tools::observe)]
     pub fn get(&self, message_id: &MessageId) -> Option<Message> {
-        self.storage.fetch(message_id).unwrap_or_default()
+        self.storage.fetch_op(message_id).unwrap_or_default()
     }
 
     /// Get the data and metadata of a vertex associated with the given `message_id`.
     #[cfg_attr(feature = "trace", trace_tools::observe)]
     pub fn get_message_and_metadata(&self, message_id: &MessageId) -> Option<(Message, MessageMetadata)> {
-        let msg = self.storage.fetch(message_id).unwrap_or_default()?;
-        let meta = self.storage.fetch(message_id).unwrap_or_default()?;
+        let msg = self.storage.fetch_op(message_id).unwrap_or_default()?;
+        let meta = self.storage.fetch_op(message_id).unwrap_or_default()?;
 
         Some((msg, meta))
     }
@@ -371,7 +371,7 @@ impl<B: StorageBackend> Tangle<B> {
     /// Get the metadata of a vertex associated with the given `message_id`.
     #[cfg_attr(feature = "trace", trace_tools::observe)]
     pub fn get_metadata(&self, message_id: &MessageId) -> Option<MessageMetadata> {
-        self.storage.fetch(message_id).unwrap_or_default()
+        self.storage.fetch_op(message_id).unwrap_or_default()
     }
 
     /// Updates the metadata of a vertex.
@@ -393,6 +393,6 @@ impl<B: StorageBackend> Tangle<B> {
     /// Returns the children of a vertex, if we know about them.
     #[cfg_attr(feature = "trace", trace_tools::observe)]
     pub fn get_children(&self, message_id: &MessageId) -> Option<Vec<MessageId>> {
-        self.storage.fetch(message_id).unwrap_or_default()
+        self.storage.fetch_op(message_id).unwrap_or_default()
     }
 }

--- a/bee-tangle/src/tangle.rs
+++ b/bee-tangle/src/tangle.rs
@@ -111,7 +111,7 @@ impl<B: StorageBackend> Tangle<B> {
     /// Get the milestone from the tangle that corresponds to the given milestone index.
     #[cfg_attr(feature = "trace", trace_tools::observe)]
     pub fn get_milestone(&self, index: MilestoneIndex) -> Option<Milestone> {
-        self.storage.fetch_op(&index).unwrap_or_else(|e| {
+        self.storage.fetch(&index).unwrap_or_else(|e| {
             warn!("Failed to fetch milestone {:?}", e);
             None
         })
@@ -351,14 +351,14 @@ impl<B: StorageBackend> Tangle<B> {
     /// Get the data of a vertex associated with the given `message_id`.
     #[cfg_attr(feature = "trace", trace_tools::observe)]
     pub fn get(&self, message_id: &MessageId) -> Option<Message> {
-        self.storage.fetch_op(message_id).unwrap_or_default()
+        self.storage.fetch(message_id).unwrap_or_default()
     }
 
     /// Get the data and metadata of a vertex associated with the given `message_id`.
     #[cfg_attr(feature = "trace", trace_tools::observe)]
     pub fn get_message_and_metadata(&self, message_id: &MessageId) -> Option<(Message, MessageMetadata)> {
-        let msg = self.storage.fetch_op(message_id).unwrap_or_default()?;
-        let meta = self.storage.fetch_op(message_id).unwrap_or_default()?;
+        let msg = self.storage.fetch(message_id).unwrap_or_default()?;
+        let meta = self.storage.fetch(message_id).unwrap_or_default()?;
 
         Some((msg, meta))
     }
@@ -372,7 +372,7 @@ impl<B: StorageBackend> Tangle<B> {
     /// Get the metadata of a vertex associated with the given `message_id`.
     #[cfg_attr(feature = "trace", trace_tools::observe)]
     pub fn get_metadata(&self, message_id: &MessageId) -> Option<MessageMetadata> {
-        self.storage.fetch_op(message_id).unwrap_or_default()
+        self.storage.fetch(message_id).unwrap_or_default()
     }
 
     /// Updates the metadata of a vertex.
@@ -394,6 +394,6 @@ impl<B: StorageBackend> Tangle<B> {
     /// Returns the children of a vertex, if we know about them.
     #[cfg_attr(feature = "trace", trace_tools::observe)]
     pub fn get_children(&self, message_id: &MessageId) -> Option<Vec<MessageId>> {
-        self.storage.fetch_op(message_id).unwrap_or_default()
+        self.storage.fetch(message_id).unwrap_or_default()
     }
 }

--- a/bee-tangle/src/tangle.rs
+++ b/bee-tangle/src/tangle.rs
@@ -70,7 +70,7 @@ impl<B: StorageBackend> Tangle<B> {
     #[cfg_attr(feature = "trace", trace_tools::observe)]
     pub fn insert(&self, message: &Message, message_id: &MessageId, metadata: &MessageMetadata) {
         self.storage
-            .insert_op(message_id, message)
+            .insert(message_id, message)
             .ok()
             .and_then(|()| {
                 self.storage.insert_strict_op(message_id, metadata).ok()?;
@@ -78,7 +78,7 @@ impl<B: StorageBackend> Tangle<B> {
                 let message_id = *message_id;
                 for &parent in message.parents().iter() {
                     self.storage
-                        .insert_op(&(parent, message_id), &())
+                        .insert(&(parent, message_id), &())
                         .unwrap_or_else(|e| warn!("Failed to update approvers for message {:?}", e));
                 }
                 Some(())
@@ -104,7 +104,7 @@ impl<B: StorageBackend> Tangle<B> {
             metadata.set_omrsi_and_ymrsi(index, index);
         });
         self.storage
-            .insert_op(&idx, &milestone)
+            .insert(&idx, &milestone)
             .unwrap_or_else(|e| warn!("Failed to insert milestone message {:?}", e));
     }
 


### PR DESCRIPTION
The idea of this PR is avoiding the classical `Access::<K, V>::access(storage, args)` syntax call everywhere by creating a new trait that has a `fn access<K, V>(&self, args)` method for every `Access` trait.

This means that we need to write less code to do access operations and import less traits. Sadly this isn't reflected in the line count because `rustfmt` is not able to split `Bar::bar(&foo, args)` but it is able to split `foo.bar(args)`.