### PR TITLE
Fix return type of `ImmutableAliasAddressUnlockCondition::address`

### DIFF
--- a/bee-block/src/output/foundry.rs
+++ b/bee-block/src/output/foundry.rs
@@ -366,7 +366,7 @@ impl FoundryOutput {
         // A FoundryOutput must have an ImmutableAliasAddressUnlockCondition.
         self.unlock_conditions
             .immutable_alias_address()
-            .map(|unlock_condition| unlock_condition.address())
+            .map(|unlock_condition| unlock_condition.alias_address())
             .unwrap()
     }
 

--- a/bee-block/src/output/unlock_condition/immutable_alias_address.rs
+++ b/bee-block/src/output/unlock_condition/immutable_alias_address.rs
@@ -25,14 +25,11 @@ impl ImmutableAliasAddressUnlockCondition {
 
     /// Returns the address of a [`ImmutableAliasAddressUnlockCondition`].
     #[inline(always)]
-    pub fn address(&self) -> &AliasAddress {
+    pub fn address(&self) -> &Address {
         // An ImmutableAliasAddressUnlockCondition must have an AliasAddress.
-        if let Address::Alias(alias_address) = &self.0 {
-            alias_address
-        } else {
-            // It has already been validated at construction that the address is an `AliasAddress`.
-            unreachable!();
-        }
+        // It has already been validated at construction that the address is an `AliasAddress`.
+        debug_assert!(&self.0.is_alias());
+        &self.0
     }
 }
 

--- a/bee-block/src/output/unlock_condition/immutable_alias_address.rs
+++ b/bee-block/src/output/unlock_condition/immutable_alias_address.rs
@@ -23,13 +23,24 @@ impl ImmutableAliasAddressUnlockCondition {
         Self(Address::Alias(address))
     }
 
-    /// Returns the address of a [`ImmutableAliasAddressUnlockCondition`].
+    /// Returns the address of an [`ImmutableAliasAddressUnlockCondition`].
     #[inline(always)]
     pub fn address(&self) -> &Address {
         // An ImmutableAliasAddressUnlockCondition must have an AliasAddress.
         // It has already been validated at construction that the address is an `AliasAddress`.
         debug_assert!(&self.0.is_alias());
         &self.0
+    }
+
+    /// Returns the alias address of an [`ImmutableAliasAddressUnlockCondition`].
+    pub fn alias_address(&self) -> &AliasAddress {
+        // An ImmutableAliasAddressUnlockCondition must have an AliasAddress.
+        if let Address::Alias(alias_address) = &self.0 {
+            alias_address
+        } else {
+            // It has already been validated at construction that the address is an `AliasAddress`.
+            unreachable!();
+        }
     }
 }
 

--- a/bee-block/src/output/unlock_condition/mod.rs
+++ b/bee-block/src/output/unlock_condition/mod.rs
@@ -476,7 +476,7 @@ pub mod dto {
                 UnlockCondition::ImmutableAliasAddress(v) => {
                     Self::ImmutableAliasAddress(ImmutableAliasAddressUnlockConditionDto {
                         kind: ImmutableAliasAddressUnlockCondition::KIND,
-                        address: AddressDto::Alias(v.address().into()),
+                        address: v.address().into(),
                     })
                 }
             }


### PR DESCRIPTION
## Change checklist

<!-- Tick the boxes that are relevant to your changes, and delete any items that are not. -->

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that new and existing unit tests pass locally with my changes
- [x] I have updated the CHANGELOG.md, if my changes are significant enough
