### PR TITLE
Feature gate `axum` in `bee-api-types`

### DIFF
--- a/bee-api/bee-api-types/CHANGELOG.md
+++ b/bee-api/bee-api-types/CHANGELOG.md
@@ -24,6 +24,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Updated dependencies;
+- Added the `"axum"` feature to gate the `axum` dependency, `IntoResponse` impls;
 
 ## 1.0.0-beta.4 - 2022-07-26
 

--- a/bee-api/bee-api-types/Cargo.toml
+++ b/bee-api/bee-api-types/Cargo.toml
@@ -21,10 +21,12 @@ bee-block = { version = "1.0.0-beta.4", path = "../../bee-block", default-featur
 bee-ledger-types = { version = "1.0.0-beta.3", path = "../../bee-ledger/bee-ledger-types", default-features = false }
 bee-protocol-types = { version = "1.0.0-beta.2", path = "../../bee-protocol/bee-protocol-types", default-features = false, optional = true }
 
-axum = { version = "0.5.15", default-features = false, features = [ "json" ] }
+axum = { version = "0.5.15", default-features = false, features = [ "json" ], optional =  true }
 serde = { version = "1.0.143", default-features = false, features = [ "derive" ] }
 thiserror = { version = "1.0.32", default-features = false }
 
 [features]
-default = [ "peer" ]
+default = [ "axum", "peer" ]
+# Implement `axum::response::IntoResponse` for response types.
+axum = [ "dep:axum" ]
 peer = [ "bee-protocol-types" ]

--- a/bee-api/bee-api-types/src/responses.rs
+++ b/bee-api/bee-api-types/src/responses.rs
@@ -1,13 +1,6 @@
 // Copyright 2020-2022 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
-#[cfg(feature = "axum")]
-use axum::{
-    body::BoxBody,
-    http::StatusCode,
-    response::{IntoResponse, Response},
-    Json,
-};
 use bee_block::{output::dto::OutputDto, payload::dto::MilestonePayloadDto, BlockDto};
 use serde::{Deserialize, Serialize};
 
@@ -32,13 +25,6 @@ pub struct InfoResponse {
     pub base_token: BaseTokenResponse,
     pub metrics: MetricsResponse,
     pub features: Vec<String>,
-}
-
-#[cfg(feature = "axum")]
-impl IntoResponse for InfoResponse {
-    fn into_response(self) -> Response<BoxBody> {
-        Json(self).into_response()
-    }
 }
 
 impl BodyInner for InfoResponse {}
@@ -157,26 +143,12 @@ pub struct TipsResponse {
     pub tips: Vec<String>,
 }
 
-#[cfg(feature = "axum")]
-impl IntoResponse for TipsResponse {
-    fn into_response(self) -> Response<BoxBody> {
-        Json(self).into_response()
-    }
-}
-
 /// Response of POST /api/core/v2/blocks.
 /// Returns the block identifier of the submitted block.
 #[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
 pub struct SubmitBlockResponse {
     #[serde(rename = "blockId")]
     pub block_id: String,
-}
-
-#[cfg(feature = "axum")]
-impl IntoResponse for SubmitBlockResponse {
-    fn into_response(self) -> Response<BoxBody> {
-        (StatusCode::CREATED, Json(self)).into_response()
-    }
 }
 
 /// Response of GET /api/core/v2/blocks/{block_id}.
@@ -186,16 +158,6 @@ impl IntoResponse for SubmitBlockResponse {
 pub enum BlockResponse {
     Json(BlockDto),
     Raw(Vec<u8>),
-}
-
-#[cfg(feature = "axum")]
-impl IntoResponse for BlockResponse {
-    fn into_response(self) -> Response<BoxBody> {
-        match self {
-            BlockResponse::Json(dto) => Json(dto).into_response(),
-            BlockResponse::Raw(bytes) => bytes.into_response(),
-        }
-    }
 }
 
 /// Response of GET /api/core/v2/blocks/{block_id}/metadata.
@@ -223,26 +185,12 @@ pub struct BlockMetadataResponse {
     pub should_reattach: Option<bool>,
 }
 
-#[cfg(feature = "axum")]
-impl IntoResponse for BlockMetadataResponse {
-    fn into_response(self) -> Response<BoxBody> {
-        Json(self).into_response()
-    }
-}
-
 /// Response of GET /api/core/v2/outputs/{output_id}.
 /// Returns an output and its metadata.
 #[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
 pub struct OutputResponse {
     pub metadata: OutputMetadataResponse,
     pub output: OutputDto,
-}
-
-#[cfg(feature = "axum")]
-impl IntoResponse for OutputResponse {
-    fn into_response(self) -> Response<BoxBody> {
-        Json(self).into_response()
-    }
 }
 
 /// Response of GET /api/core/v2/outputs/{output_id}/metadata.
@@ -271,26 +219,12 @@ pub struct OutputMetadataResponse {
     pub ledger_index: u32,
 }
 
-#[cfg(feature = "axum")]
-impl IntoResponse for OutputMetadataResponse {
-    fn into_response(self) -> Response<BoxBody> {
-        Json(self).into_response()
-    }
-}
-
 /// Response of:
 /// * GET /api/core/v2/receipts/{milestone_index}, returns all stored receipts for the given milestone index.
 /// * GET /api/core/v2/receipts, returns all stored receipts, independent of a milestone index.
 #[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
 pub struct ReceiptsResponse {
     pub receipts: Vec<ReceiptDto>,
-}
-
-#[cfg(feature = "axum")]
-impl IntoResponse for ReceiptsResponse {
-    fn into_response(self) -> Response<BoxBody> {
-        Json(self).into_response()
-    }
 }
 
 /// Response of GET /api/core/v2/treasury.
@@ -302,13 +236,6 @@ pub struct TreasuryResponse {
     pub amount: String,
 }
 
-#[cfg(feature = "axum")]
-impl IntoResponse for TreasuryResponse {
-    fn into_response(self) -> Response<BoxBody> {
-        Json(self).into_response()
-    }
-}
-
 /// Response of GET /api/core/v2/milestone/{milestone_index}.
 /// Returns information about a milestone.
 #[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
@@ -316,16 +243,6 @@ impl IntoResponse for TreasuryResponse {
 pub enum MilestoneResponse {
     Json(MilestonePayloadDto),
     Raw(Vec<u8>),
-}
-
-#[cfg(feature = "axum")]
-impl IntoResponse for MilestoneResponse {
-    fn into_response(self) -> Response<BoxBody> {
-        match self {
-            MilestoneResponse::Json(dto) => Json(dto).into_response(),
-            MilestoneResponse::Raw(bytes) => bytes.into_response(),
-        }
-    }
 }
 
 /// Response of GET /api/core/v2/milestone/{milestone_index}/utxo-changes.
@@ -339,48 +256,20 @@ pub struct UtxoChangesResponse {
     pub consumed_outputs: Vec<String>,
 }
 
-#[cfg(feature = "axum")]
-impl IntoResponse for UtxoChangesResponse {
-    fn into_response(self) -> Response<BoxBody> {
-        Json(self).into_response()
-    }
-}
-
 /// Response of GET /api/core/v2/peers.
 /// Returns information about all peers of the node.
 #[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
 pub struct PeersResponse(pub Vec<PeerDto>);
-
-#[cfg(feature = "axum")]
-impl IntoResponse for PeersResponse {
-    fn into_response(self) -> Response<BoxBody> {
-        Json(self).into_response()
-    }
-}
 
 /// Response of POST /api/core/v2/peers.
 /// Returns information about the added peer.
 #[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
 pub struct AddPeerResponse(pub PeerDto);
 
-#[cfg(feature = "axum")]
-impl IntoResponse for AddPeerResponse {
-    fn into_response(self) -> Response<BoxBody> {
-        Json(self).into_response()
-    }
-}
-
 /// Response of GET /api/core/v2/peer/{peer_id}.
 /// Returns information about a specific peer of the node.
 #[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
 pub struct PeerResponse(pub PeerDto);
-
-#[cfg(feature = "axum")]
-impl IntoResponse for PeerResponse {
-    fn into_response(self) -> Response<BoxBody> {
-        Json(self).into_response()
-    }
-}
 
 /// Response of GET /api/plugins/debug/whiteflag.
 /// Returns the computed merkle tree hash for the given white flag traversal.
@@ -390,16 +279,71 @@ pub struct WhiteFlagResponse {
     pub merkle_tree_hash: String,
 }
 
-#[cfg(feature = "axum")]
-impl IntoResponse for WhiteFlagResponse {
-    fn into_response(self) -> Response<BoxBody> {
-        Json(self).into_response()
-    }
-}
-
 /// Response of GET /api/routes.
 /// Returns the available API route groups of the node.
 #[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
 pub struct RoutesResponse {
     pub routes: Vec<String>,
+}
+
+#[cfg(feature = "axum")]
+mod axum_response {
+    use axum::{
+        body::BoxBody,
+        http::StatusCode,
+        response::{IntoResponse, Response},
+        Json,
+    };
+
+    use super::*;
+
+    /// Macro to implement `IntoResponse` for simple cases which can just be wrapped in JSON.
+    macro_rules! impl_into_response {
+        ($($t:ty),*) => ($(
+            impl IntoResponse for $t {
+                fn into_response(self) -> Response<BoxBody> {
+                    Json(self).into_response()
+                }
+            }
+        )*)
+    }
+
+    impl_into_response!(
+        InfoResponse,
+        TipsResponse,
+        BlockMetadataResponse,
+        OutputResponse,
+        OutputMetadataResponse,
+        ReceiptsResponse,
+        TreasuryResponse,
+        UtxoChangesResponse,
+        AddPeerResponse,
+        PeersResponse,
+        PeerResponse,
+        WhiteFlagResponse
+    );
+
+    impl IntoResponse for SubmitBlockResponse {
+        fn into_response(self) -> Response<BoxBody> {
+            (StatusCode::CREATED, Json(self)).into_response()
+        }
+    }
+
+    impl IntoResponse for BlockResponse {
+        fn into_response(self) -> Response<BoxBody> {
+            match self {
+                BlockResponse::Json(dto) => Json(dto).into_response(),
+                BlockResponse::Raw(bytes) => bytes.into_response(),
+            }
+        }
+    }
+
+    impl IntoResponse for MilestoneResponse {
+        fn into_response(self) -> Response<BoxBody> {
+            match self {
+                MilestoneResponse::Json(dto) => Json(dto).into_response(),
+                MilestoneResponse::Raw(bytes) => bytes.into_response(),
+            }
+        }
+    }
 }

--- a/bee-api/bee-api-types/src/responses.rs
+++ b/bee-api/bee-api-types/src/responses.rs
@@ -1,6 +1,7 @@
 // Copyright 2020-2022 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
+#[cfg(feature = "axum")]
 use axum::{
     body::BoxBody,
     http::StatusCode,
@@ -33,6 +34,7 @@ pub struct InfoResponse {
     pub features: Vec<String>,
 }
 
+#[cfg(feature = "axum")]
 impl IntoResponse for InfoResponse {
     fn into_response(self) -> Response<BoxBody> {
         Json(self).into_response()
@@ -155,6 +157,7 @@ pub struct TipsResponse {
     pub tips: Vec<String>,
 }
 
+#[cfg(feature = "axum")]
 impl IntoResponse for TipsResponse {
     fn into_response(self) -> Response<BoxBody> {
         Json(self).into_response()
@@ -169,6 +172,7 @@ pub struct SubmitBlockResponse {
     pub block_id: String,
 }
 
+#[cfg(feature = "axum")]
 impl IntoResponse for SubmitBlockResponse {
     fn into_response(self) -> Response<BoxBody> {
         (StatusCode::CREATED, Json(self)).into_response()
@@ -184,6 +188,7 @@ pub enum BlockResponse {
     Raw(Vec<u8>),
 }
 
+#[cfg(feature = "axum")]
 impl IntoResponse for BlockResponse {
     fn into_response(self) -> Response<BoxBody> {
         match self {
@@ -218,6 +223,7 @@ pub struct BlockMetadataResponse {
     pub should_reattach: Option<bool>,
 }
 
+#[cfg(feature = "axum")]
 impl IntoResponse for BlockMetadataResponse {
     fn into_response(self) -> Response<BoxBody> {
         Json(self).into_response()
@@ -232,6 +238,7 @@ pub struct OutputResponse {
     pub output: OutputDto,
 }
 
+#[cfg(feature = "axum")]
 impl IntoResponse for OutputResponse {
     fn into_response(self) -> Response<BoxBody> {
         Json(self).into_response()
@@ -264,6 +271,7 @@ pub struct OutputMetadataResponse {
     pub ledger_index: u32,
 }
 
+#[cfg(feature = "axum")]
 impl IntoResponse for OutputMetadataResponse {
     fn into_response(self) -> Response<BoxBody> {
         Json(self).into_response()
@@ -278,6 +286,7 @@ pub struct ReceiptsResponse {
     pub receipts: Vec<ReceiptDto>,
 }
 
+#[cfg(feature = "axum")]
 impl IntoResponse for ReceiptsResponse {
     fn into_response(self) -> Response<BoxBody> {
         Json(self).into_response()
@@ -293,6 +302,7 @@ pub struct TreasuryResponse {
     pub amount: String,
 }
 
+#[cfg(feature = "axum")]
 impl IntoResponse for TreasuryResponse {
     fn into_response(self) -> Response<BoxBody> {
         Json(self).into_response()
@@ -308,6 +318,7 @@ pub enum MilestoneResponse {
     Raw(Vec<u8>),
 }
 
+#[cfg(feature = "axum")]
 impl IntoResponse for MilestoneResponse {
     fn into_response(self) -> Response<BoxBody> {
         match self {
@@ -328,6 +339,7 @@ pub struct UtxoChangesResponse {
     pub consumed_outputs: Vec<String>,
 }
 
+#[cfg(feature = "axum")]
 impl IntoResponse for UtxoChangesResponse {
     fn into_response(self) -> Response<BoxBody> {
         Json(self).into_response()
@@ -339,6 +351,7 @@ impl IntoResponse for UtxoChangesResponse {
 #[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
 pub struct PeersResponse(pub Vec<PeerDto>);
 
+#[cfg(feature = "axum")]
 impl IntoResponse for PeersResponse {
     fn into_response(self) -> Response<BoxBody> {
         Json(self).into_response()
@@ -350,6 +363,7 @@ impl IntoResponse for PeersResponse {
 #[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
 pub struct AddPeerResponse(pub PeerDto);
 
+#[cfg(feature = "axum")]
 impl IntoResponse for AddPeerResponse {
     fn into_response(self) -> Response<BoxBody> {
         Json(self).into_response()
@@ -361,6 +375,7 @@ impl IntoResponse for AddPeerResponse {
 #[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
 pub struct PeerResponse(pub PeerDto);
 
+#[cfg(feature = "axum")]
 impl IntoResponse for PeerResponse {
     fn into_response(self) -> Response<BoxBody> {
         Json(self).into_response()
@@ -375,6 +390,7 @@ pub struct WhiteFlagResponse {
     pub merkle_tree_hash: String,
 }
 
+#[cfg(feature = "axum")]
 impl IntoResponse for WhiteFlagResponse {
     fn into_response(self) -> Response<BoxBody> {
         Json(self).into_response()

--- a/bee-api/bee-rest-api/Cargo.toml
+++ b/bee-api/bee-rest-api/Cargo.toml
@@ -17,7 +17,7 @@ all-features = true
 rustdoc-args = [ "--cfg", "doc_cfg" ]
 
 [dependencies]
-bee-api-types = { version = "1.0.0-beta.1", path = "../bee-api-types", default-features = false, features = [ "peer" ] }
+bee-api-types = { version = "1.0.0-beta.1", path = "../bee-api-types", default-features = false, features = [ "axum", "peer" ] }
 bee-block = { version = "1.0.0-beta.3", path = "../../bee-block", default-features = false, features = [ "dto" ] }
 bee-gossip = { version = "1.0.0-beta.1", path = "../../bee-network/bee-gossip", default-features = false }
 bee-ledger = { version = "0.7.0", path = "../../bee-ledger/bee-ledger", default-features = false }


### PR DESCRIPTION
# Description of change

Adds a default `"axum"` feature to `bee-api-types`. This makes the `axum` dependency optional, which is only for the `axum::response::IntoResponse` trait required by `bee-rest-api`.

This is to prevent automatically pulling in `axum` and its dependencies unnecessarily in downstream crates, which is preventing the compilation of `iota.rs`/`iota-client` for the `wasm32-unknown-unknown` target.

- The feature name `"axum"` is arbitrary, could also be `"into-response"` for instance, but it is very much linked to the `axum`-specific trait.
- The imports and trait implementation code could be placed in a submodule to make the feature-gating clearer, and use a macro to simplify repetition, but I kept the changes minimal.

## Type of change

This is only technically a breaking change due to the feature-gate.

- Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How the change has been tested

`bee-api-types` compiles fine with different feature combinations:
- `cargo check`
- `cargo check --no-default-features`
- `cargo check --no-default-features --features "peer"`
- `cargo check --no-default-features --features "axum"`

Only two other crates (in `bee`) depend on `bee-api-types` directly:
- `bee-rest-api` requires the `"axum"` feature now, so it still compiles fine with no further changes.
- `bee-plugin-dashboard` compiles fine with no changes.

Also confirmed locally that `iota.rs` compiles to `wasm32-unknown-unknown` with this change (with only the `message-interface` feature enabled though).

## Change checklist

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that new and existing unit tests pass locally with my changes
- [x] I have updated the CHANGELOG.md, if my changes are significant enough
