### PR TITLE
Change type of `target_score` parameter of `NonceProvider::nonce` from `f64` to `u32` to better match TIP32

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -313,7 +313,7 @@ name = "bee-block"
 version = "1.0.0-beta.6"
 dependencies = [
  "bech32",
- "bee-pow 1.0.0-alpha.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "bee-pow 1.0.0-alpha.1",
  "bee-ternary 1.0.0-alpha.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "bitflags",
  "bytemuck",
@@ -520,21 +520,21 @@ dependencies = [
 [[package]]
 name = "bee-pow"
 version = "1.0.0-alpha.1"
-dependencies = [
- "bee-block",
- "bee-ternary 1.0.0-alpha.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "iota-crypto 0.14.0",
- "thiserror",
-]
-
-[[package]]
-name = "bee-pow"
-version = "1.0.0-alpha.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d8e36e724dc98f8671c4f674b8419785def4ea81ad7af4fba061ff11724210c1"
 dependencies = [
  "bee-ternary 1.0.0-alpha.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "iota-crypto 0.13.0",
+ "thiserror",
+]
+
+[[package]]
+name = "bee-pow"
+version = "1.0.0-beta.1"
+dependencies = [
+ "bee-block",
+ "bee-ternary 1.0.0-alpha.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "iota-crypto 0.14.0",
  "thiserror",
 ]
 
@@ -549,7 +549,7 @@ dependencies = [
  "bee-block",
  "bee-gossip",
  "bee-ledger",
- "bee-pow 1.0.0-alpha.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "bee-pow 1.0.0-alpha.1",
  "bee-protocol-types",
  "bee-runtime",
  "bee-storage",
@@ -593,7 +593,7 @@ dependencies = [
  "bee-block",
  "bee-gossip",
  "bee-ledger",
- "bee-pow 1.0.0-alpha.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "bee-pow 1.0.0-alpha.1",
  "bee-protocol",
  "bee-runtime",
  "bee-storage",

--- a/bee-pow/CHANGELOG.md
+++ b/bee-pow/CHANGELOG.md
@@ -21,8 +21,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased - 2022-XX-XX
 
+## 1.0.0-beta.1 - 2022-08-29
+
 ### Changed
 
+- Type of `target_score` parameter of `NonceProvider::nonce` from `f64` to `u32` to better match TIP32;
 - Updated dependencies;
 
 ### Fixed

--- a/bee-pow/Cargo.toml
+++ b/bee-pow/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bee-pow"
-version = "1.0.0-alpha.1"
+version = "1.0.0-beta.1"
 authors = [ "IOTA Stiftung" ]
 edition = "2021"
 description = "Provides Proof of Work utilities for the IOTA protocol"

--- a/bee-pow/src/providers/miner.rs
+++ b/bee-pow/src/providers/miner.rs
@@ -37,7 +37,7 @@ pub enum Error {
     Cancelled,
     /// Invalid proof of work score.
     #[error("invalid proof of work score {0}, requiring {1} trailing zeros")]
-    InvalidPowScore(f64, usize),
+    InvalidPowScore(u32, usize),
 }
 
 /// A type to cancel the `Miner` nonce provider to abort operations.
@@ -149,13 +149,13 @@ impl NonceProvider for Miner {
     type Builder = MinerBuilder;
     type Error = Error;
 
-    fn nonce(&self, bytes: &[u8], target_score: f64) -> Result<u64, Self::Error> {
+    fn nonce(&self, bytes: &[u8], target_score: u32) -> Result<u64, Self::Error> {
         self.cancel.reset();
 
         let mut nonce = 0;
         let mut pow_digest = TritBuf::<T1B1Buf>::new();
         let target_zeros =
-            (((bytes.len() + std::mem::size_of::<u64>()) as f64 * target_score).ln() / LN_3).ceil() as usize;
+            (((bytes.len() + std::mem::size_of::<u64>()) as f64 * target_score as f64).ln() / LN_3).ceil() as usize;
 
         if target_zeros > HASH_LENGTH {
             return Err(Self::Error::InvalidPowScore(target_score, target_zeros));

--- a/bee-pow/src/providers/mod.rs
+++ b/bee-pow/src/providers/mod.rs
@@ -33,5 +33,5 @@ pub trait NonceProvider: Sized {
     }
 
     /// Provides a nonce given bytes and a target score.
-    fn nonce(&self, bytes: &[u8], target_score: f64) -> Result<u64, Self::Error>;
+    fn nonce(&self, bytes: &[u8], target_score: u32) -> Result<u64, Self::Error>;
 }

--- a/bee-pow/src/providers/u64.rs
+++ b/bee-pow/src/providers/u64.rs
@@ -19,7 +19,7 @@ impl NonceProvider for u64 {
     type Builder = u64;
     type Error = std::convert::Infallible;
 
-    fn nonce(&self, _: &[u8], _: f64) -> Result<u64, Self::Error> {
+    fn nonce(&self, _: &[u8], _: u32) -> Result<u64, Self::Error> {
         Ok(*self)
     }
 }

--- a/bee-pow/tests/miner.rs
+++ b/bee-pow/tests/miner.rs
@@ -15,7 +15,7 @@ fn miner_provide() {
     let miner = MinerBuilder::new().with_num_workers(4).finish();
     let mut bytes = rand_bytes(256);
 
-    let nonce = miner.nonce(&bytes[0..248], 4000f64).unwrap();
+    let nonce = miner.nonce(&bytes[0..248], 4000).unwrap();
     bytes[248..].copy_from_slice(&nonce.to_le_bytes());
 
     assert!(PoWScorer::new().score(&bytes) >= 4000f64);
@@ -46,7 +46,7 @@ fn miner_abort() {
 
     let now = std::time::Instant::now();
 
-    let handle = std::thread::spawn(move || miner.nonce(&bytes[0..248], 100000f64).unwrap());
+    let handle = std::thread::spawn(move || miner.nonce(&bytes[0..248], 100000).unwrap());
 
     std::thread::sleep(std::time::Duration::from_secs(1));
 

--- a/bee-pow/tests/u64.rs
+++ b/bee-pow/tests/u64.rs
@@ -8,7 +8,7 @@ use bee_pow::providers::NonceProvider;
 fn constant_provide() {
     let bytes = rand_bytes(256);
     let nonce_1 = 42;
-    let nonce_2 = nonce_1.nonce(&bytes[0..248], 4000f64).unwrap();
+    let nonce_2 = nonce_1.nonce(&bytes[0..248], 4000).unwrap();
 
     assert_eq!(nonce_1, nonce_2);
 }


### PR DESCRIPTION
## Change checklist

<!-- Tick the boxes that are relevant to your changes, and delete any items that are not. -->

- [ ] I have followed the contribution guidelines for this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that new and existing unit tests pass locally with my changes
- [ ] I have updated the CHANGELOG.md, if my changes are significant enough
