### PR TITLE
Update libp2p deps

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -65,9 +65,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.64"
+version = "1.0.65"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9a8f622bcf6ff3df478e9deba3e03e4e04b300f8e6a139e192c05fa3490afc7"
+checksum = "98161a4e3e2184da77bb14f02184cdd111e83bbbcc9979dfee3c44b9a85f5602"
 
 [[package]]
 name = "anymap"
@@ -487,7 +487,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_repr",
- "sha2 0.10.5",
+ "sha2 0.10.6",
  "tempfile",
  "tokio",
  "tokio-stream",
@@ -600,7 +600,7 @@ dependencies = [
  "bee-runtime",
  "bee-storage",
  "bee-tangle",
- "digest 0.10.3",
+ "digest 0.10.5",
  "futures",
  "iota-crypto",
  "lazy_static",
@@ -798,7 +798,7 @@ version = "0.10.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9cf849ee05b2ee5fba5e36f97ff8ec2533916700fc0758d40d92136a42f3388"
 dependencies = [
- "digest 0.10.3",
+ "digest 0.10.5",
 ]
 
 [[package]]
@@ -1002,9 +1002,9 @@ dependencies = [
 
 [[package]]
 name = "clang-sys"
-version = "1.3.3"
+version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a050e2153c5be08febd6734e29298e844fdb0fa21aeddd63b4eb7baa106c69b"
+checksum = "fa2e27ae6ab525c3d369ded447057bca5438d86dc3a68f6faafb8269ba82ebf3"
 dependencies = [
  "glob",
  "libc",
@@ -1247,8 +1247,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "12dc3116fe595d7847c701796ac1b189bd86b81f4f593c6f775f9d80fb2e29f4"
 dependencies = [
  "byteorder",
- "digest 0.10.3",
- "rand_core 0.6.3",
+ "digest 0.10.5",
+ "rand_core 0.6.4",
  "subtle",
  "zeroize",
 ]
@@ -1304,9 +1304,9 @@ dependencies = [
 
 [[package]]
 name = "digest"
-version = "0.10.3"
+version = "0.10.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2fb860ca6fafa5552fb6d0e816a69c8e49f0908bf524e30a90d97c85892d506"
+checksum = "adfbc57365a37acbd2ebf2b64d7e69bb766e2fea813521ed536f5d0520dcf86c"
 dependencies = [
  "block-buffer 0.10.3",
  "crypto-common",
@@ -1371,7 +1371,7 @@ checksum = "403ef3e961ab98f0ba902771d29f842058578bb1ce7e3c59dad5a6a93e784c69"
 dependencies = [
  "curve25519-dalek 3.2.1",
  "hex",
- "rand_core 0.6.3",
+ "rand_core 0.6.4",
  "sha2 0.9.9",
  "thiserror",
  "zeroize",
@@ -1871,14 +1871,13 @@ dependencies = [
 
 [[package]]
 name = "iana-time-zone"
-version = "0.1.47"
+version = "0.1.50"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c495f162af0bf17656d0014a0eded5f3cd2f365fdd204548c2869db89359dc7"
+checksum = "fd911b35d940d2bd0bea0f9100068e5b97b51a1cbe13d13382f132e0365257a0"
 dependencies = [
  "android_system_properties",
  "core-foundation-sys",
  "js-sys",
- "once_cell",
  "wasm-bindgen",
  "winapi",
 ]
@@ -1981,10 +1980,10 @@ checksum = "d53239ace29cccec48af2f3b509090d546bcc52648c6147866d88bc70f4352b3"
 dependencies = [
  "bee-ternary 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "blake2",
- "digest 0.10.3",
+ "digest 0.10.5",
  "ed25519-zebra",
  "getrandom 0.2.7",
- "sha2 0.10.5",
+ "sha2 0.10.6",
 ]
 
 [[package]]
@@ -2013,9 +2012,9 @@ checksum = "d101775d2bc8f99f4ac18bf29b9ed70c0dd138b9a1e88d7b80179470cbbe8bd2"
 
 [[package]]
 name = "itertools"
-version = "0.10.3"
+version = "0.10.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9a9d19fa1e79b6215ff29b9d6880b706147f16e9b1dbb1e4e5947b5b02bc5e3"
+checksum = "b0fd2260e829bddf4cb6ea802289de2f86d6a7a690192fbe91b3f46e0f2c8473"
 dependencies = [
  "either",
 ]
@@ -2034,18 +2033,18 @@ checksum = "6c8af84674fe1f223a982c933a0ee1086ac4d4052aa0fb8060c12c6ad838e754"
 
 [[package]]
 name = "jobserver"
-version = "0.1.24"
+version = "0.1.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af25a77299a7f711a01975c35a6a424eb6862092cc2d6c72c4ed6cbc56dfc1fa"
+checksum = "068b1ee6743e4d11fb9c6a1e6064b3693a1b600e7f5f5988047d98b3dc9fb90b"
 dependencies = [
  "libc",
 ]
 
 [[package]]
 name = "js-sys"
-version = "0.3.59"
+version = "0.3.60"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "258451ab10b34f8af53416d1fdab72c22e805f0c92a1136d59470ec0b11138b2"
+checksum = "49409df3e3bf0856b916e2ceaca09ee28e6871cf7d9ce97a692cacfdb2a25a47"
 dependencies = [
  "wasm-bindgen",
 ]
@@ -2078,9 +2077,9 @@ checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
 
 [[package]]
 name = "libc"
-version = "0.2.132"
+version = "0.2.133"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8371e4e5341c3a96db127eb2465ac681ced4c433e01dd0e938adbef26ba93ba5"
+checksum = "c0f80d65747a3e43d1596c7c5492d95d5edddaabd45a7fcdb02b95f644164966"
 
 [[package]]
 name = "libloading"
@@ -2147,7 +2146,7 @@ dependencies = [
  "rand 0.8.5",
  "ring",
  "rw-stream-sink",
- "sha2 0.10.5",
+ "sha2 0.10.6",
  "smallvec",
  "thiserror",
  "unsigned-varint",
@@ -2235,7 +2234,7 @@ dependencies = [
  "prost",
  "prost-build",
  "rand 0.8.5",
- "sha2 0.10.5",
+ "sha2 0.10.6",
  "snow",
  "static_assertions",
  "x25519-dalek",
@@ -2336,9 +2335,9 @@ checksum = "0717cef1bc8b636c6e1c1bbdefc09e6322da8a9321966e8928ef80d20f7f770f"
 
 [[package]]
 name = "lock_api"
-version = "0.4.8"
+version = "0.4.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f80bf5aacaf25cbfc8210d1cfb718f2bf3b11c4c54e5afe36c236853a8ec390"
+checksum = "435011366fe56583b16cf956f9df0095b405b82d76425bc8981c0e22e60ec4df"
 dependencies = [
  "autocfg",
  "scopeguard",
@@ -2473,9 +2472,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1c346cf9999c631f002d8f977c4eaeaa0e6386f16007202308d0b3757522c2cc"
 dependencies = [
  "core2",
- "digest 0.10.3",
+ "digest 0.10.5",
  "multihash-derive",
- "sha2 0.10.5",
+ "sha2 0.10.6",
  "unsigned-varint",
 ]
 
@@ -2671,9 +2670,9 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.14.0"
+version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f7254b99e31cad77da24b08ebf628882739a608578bb1bcdfc1f9c21260d7c0"
+checksum = "e82dad04139b71a90c080c8463fe0dc7902db5192d939bd0950f074d014339e1"
 
 [[package]]
 name = "oorandom"
@@ -2759,9 +2758,9 @@ dependencies = [
 
 [[package]]
 name = "parity-scale-codec"
-version = "3.1.5"
+version = "3.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9182e4a71cae089267ab03e67c99368db7cd877baf50f931e5d6d4b71e195ac0"
+checksum = "366e44391a8af4cfd6002ef6ba072bae071a96aafca98d7d448a34c5dca38b6a"
 dependencies = [
  "arrayvec 0.7.2",
  "bitvec",
@@ -3059,9 +3058,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.43"
+version = "1.0.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0a2ca2c61bc9f3d74d2886294ab7b9853abd9c1ad903a3ac7815c58989bb7bab"
+checksum = "7bd7356a8122b6c4a24a82b278680c73357984ca2fc79a0f9fa6dea7dced7c58"
 dependencies = [
  "unicode-ident",
 ]
@@ -3197,7 +3196,7 @@ checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
 dependencies = [
  "libc",
  "rand_chacha 0.3.1",
- "rand_core 0.6.3",
+ "rand_core 0.6.4",
 ]
 
 [[package]]
@@ -3217,7 +3216,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
 dependencies = [
  "ppv-lite86",
- "rand_core 0.6.3",
+ "rand_core 0.6.4",
 ]
 
 [[package]]
@@ -3231,9 +3230,9 @@ dependencies = [
 
 [[package]]
 name = "rand_core"
-version = "0.6.3"
+version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d34f1408f55294453790c48b2f1ebbb1c5b4b7563eb1f418bcfcfdbb06ebb4e7"
+checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
  "getrandom 0.2.7",
 ]
@@ -3343,9 +3342,9 @@ dependencies = [
 
 [[package]]
 name = "reqwest"
-version = "0.11.11"
+version = "0.11.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b75aa69a3f06bbcc66ede33af2af253c6f7a86b1ca0033f60c580a27074fbf92"
+checksum = "431949c384f4e2ae07605ccaa56d1d9d2ecdb5cadd4f9577ccfab29f2e5149fc"
 dependencies = [
  "base64 0.13.0",
  "bytes",
@@ -3359,10 +3358,10 @@ dependencies = [
  "hyper-tls",
  "ipnet",
  "js-sys",
- "lazy_static",
  "log",
  "mime",
  "native-tls",
+ "once_cell",
  "percent-encoding",
  "pin-project-lite",
  "serde",
@@ -3437,9 +3436,9 @@ dependencies = [
 
 [[package]]
 name = "rust-embed"
-version = "6.4.0"
+version = "6.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a17e5ac65b318f397182ae94e532da0ba56b88dd1200b774715d36c4943b1c3"
+checksum = "e26934cd67a1da1165efe61cba4047cc1b4a526019da609fcce13a1000afb5fa"
 dependencies = [
  "rust-embed-impl",
  "rust-embed-utils",
@@ -3448,9 +3447,9 @@ dependencies = [
 
 [[package]]
 name = "rust-embed-impl"
-version = "6.2.0"
+version = "6.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94e763e24ba2bf0c72bc6be883f967f794a019fafd1b86ba1daff9c91a7edd30"
+checksum = "e35d7b402e273544cc08e0824aa3404333fab8a90ac43589d3d5b72f4b346e12"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3462,11 +3461,11 @@ dependencies = [
 
 [[package]]
 name = "rust-embed-utils"
-version = "7.2.0"
+version = "7.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "756feca3afcbb1487a1d01f4ecd94cf8ec98ea074c55a69e7136d29fb6166029"
+checksum = "c1669d81dfabd1b5f8e2856b8bbe146c6192b0ba22162edc738ac0a5de18f054"
 dependencies = [
- "sha2 0.9.9",
+ "sha2 0.10.6",
  "walkdir",
 ]
 
@@ -3570,15 +3569,15 @@ dependencies = [
 
 [[package]]
 name = "semver"
-version = "1.0.13"
+version = "1.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "93f6841e709003d68bb2deee8c343572bf446003ec20a583e76f7b15cebf3711"
+checksum = "e25dfac463d778e353db5be2449d1cce89bd6fd23c9f1ea21310ce6e5a1b29c4"
 
 [[package]]
 name = "serde"
-version = "1.0.144"
+version = "1.0.145"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f747710de3dcd43b88c9168773254e809d8ddbdf9653b84e2554ab219f17860"
+checksum = "728eb6351430bccb993660dfffc5a72f91ccc1295abaa8ce19b27ebe4f75568b"
 dependencies = [
  "serde_derive",
 ]
@@ -3604,9 +3603,9 @@ dependencies = [
 
 [[package]]
 name = "serde_derive"
-version = "1.0.144"
+version = "1.0.145"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94ed3a816fb1d101812f83e789f888322c34e291f894f19590dc310963e87a00"
+checksum = "81fa1584d3d1bcacd84c277a0dfe21f5b0f6accf4a23d04d4c6d61f1af522b4c"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3687,13 +3686,13 @@ dependencies = [
 
 [[package]]
 name = "sha1"
-version = "0.10.4"
+version = "0.10.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "006769ba83e921b3085caa8334186b00cf92b4cb1a6cf4632fbccc8eff5c7549"
+checksum = "f04293dc80c3993519f2d7f6f511707ee7094fe0c6d3406feb330cdb3540eba3"
 dependencies = [
  "cfg-if",
  "cpufeatures",
- "digest 0.10.3",
+ "digest 0.10.5",
 ]
 
 [[package]]
@@ -3711,13 +3710,13 @@ dependencies = [
 
 [[package]]
 name = "sha2"
-version = "0.10.5"
+version = "0.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf9db03534dff993187064c4e0c05a5708d2a9728ace9a8959b77bedf415dac5"
+checksum = "82e6b795fe2e3b1e845bafcb27aa35405c4d47cdfc92af5fc8d3002f76cebdc0"
 dependencies = [
  "cfg-if",
  "cpufeatures",
- "digest 0.10.3",
+ "digest 0.10.5",
 ]
 
 [[package]]
@@ -3746,9 +3745,9 @@ dependencies = [
 
 [[package]]
 name = "signature"
-version = "1.6.0"
+version = "1.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f0ea32af43239f0d353a7dd75a22d94c329c8cdaafdcb4c1c1335aa10c298a4a"
+checksum = "deb766570a2825fa972bceff0d195727876a9cdf2460ab2e52d455dc2de47fd9"
 
 [[package]]
 name = "simple_asn1"
@@ -3803,10 +3802,10 @@ dependencies = [
  "blake2",
  "chacha20poly1305",
  "curve25519-dalek 4.0.0-pre.2",
- "rand_core 0.6.3",
+ "rand_core 0.6.4",
  "ring",
  "rustc_version",
- "sha2 0.10.5",
+ "sha2 0.10.6",
  "subtle",
 ]
 
@@ -3874,9 +3873,9 @@ checksum = "6bdef32e8150c2a081110b42772ffe7d7c9032b606bc226c8260fd97e0976601"
 
 [[package]]
 name = "syn"
-version = "1.0.99"
+version = "1.0.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "58dbef6ec655055e20b86b15a8cc6d439cca19b667537ac6a1369572d151ab13"
+checksum = "52205623b1b0f064a4e71182c3b18ae902267282930c6d5462c91b859668426e"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3932,18 +3931,18 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "1.0.34"
+version = "1.0.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c1b05ca9d106ba7d2e31a9dab4a64e7be2cce415321966ea3132c49a656e252"
+checksum = "0a99cb8c4b9a8ef0e7907cd3b617cc8dc04d571c4e73c8ae403d80ac160bb122"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.34"
+version = "1.0.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8f2591983642de85c921015f3f070c665a197ed69e417af436115e3a1407487"
+checksum = "3a891860d3c8d66fec8e73ddb3765f90082374dbaaa833407b904a94f1a7eb43"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4008,9 +4007,9 @@ checksum = "cda74da7e1a664f795bb1f8a87ec406fb89a02522cf6e50620d016add6dbbf5c"
 
 [[package]]
 name = "tokio"
-version = "1.21.0"
+version = "1.21.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89797afd69d206ccd11fb0ea560a44bbb87731d020670e79416d442919257d42"
+checksum = "0020c875007ad96677dcc890298f4b942882c5d4eb7cc8f439fc3bf813dc9c95"
 dependencies = [
  "autocfg",
  "bytes",
@@ -4059,9 +4058,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-stream"
-version = "0.1.9"
+version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df54d54117d6fdc4e4fea40fe1e4e566b3505700e148a6827e59b34b0d2600d9"
+checksum = "f6edf2d6bc038a43d31353570e27270603f4648d18f5ed10c0e179abe43255af"
 dependencies = [
  "futures-core",
  "pin-project-lite",
@@ -4354,9 +4353,9 @@ checksum = "dcf81ac59edc17cc8697ff311e8f5ef2d99fcbd9817b34cec66f90b6c3dfd987"
 
 [[package]]
 name = "uint"
-version = "0.9.3"
+version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "12f03af7ccf01dd611cc450a0d10dbc9b745770d096473e2faf0ca6e2d66d1e0"
+checksum = "a45526d29728d135c2900b0d30573fe3ee79fceb12ef534c7bb30e810a91b601"
 dependencies = [
  "byteorder",
  "crunchy",
@@ -4381,36 +4380,36 @@ checksum = "099b7128301d285f79ddd55b9a83d5e6b9e97c92e0ea0daebee7263e932de992"
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.3"
+version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4f5b37a154999a8f3f98cc23a628d850e154479cd94decf3414696e12e31aaf"
+checksum = "dcc811dc4066ac62f84f11307873c4850cb653bfa9b1719cee2bd2204a4bc5dd"
 
 [[package]]
 name = "unicode-normalization"
-version = "0.1.21"
+version = "0.1.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "854cbdc4f7bc6ae19c820d44abdc3277ac3e1b2b93db20a636825d9322fb60e6"
+checksum = "5c5713f0fc4b5db668a2ac63cdb7bb4469d8c9fed047b1d0292cc7b0ce2ba921"
 dependencies = [
  "tinyvec",
 ]
 
 [[package]]
 name = "unicode-segmentation"
-version = "1.9.0"
+version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e8820f5d777f6224dc4be3632222971ac30164d4a258d595640799554ebfd99"
+checksum = "0fdbf052a0783de01e944a6ce7a8cb939e295b1e7be835a1112c3b9a7f047a5a"
 
 [[package]]
 name = "unicode-width"
-version = "0.1.9"
+version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ed742d4ea2bd1176e236172c8429aaf54486e7ac098db29ffe6529e0ce50973"
+checksum = "c0edd1e5b14653f783770bce4a4dabb4a5108a5370a5f5d8cfe8710c361f6c8b"
 
 [[package]]
 name = "unicode-xid"
-version = "0.2.3"
+version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "957e51f3646910546462e67d5f7599b9e4fb8acdd304b087a6494730f9eebf04"
+checksum = "f962df74c8c05a667b5ee8bcf162993134c104e96440b663c8daa176dc772d8c"
 
 [[package]]
 name = "universal-hash"
@@ -4559,9 +4558,9 @@ checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.82"
+version = "0.2.83"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc7652e3f6c4706c8d9cd54832c4a4ccb9b5336e2c3bd154d5cccfbf1c1f5f7d"
+checksum = "eaf9f5aceeec8be17c128b2e93e031fb8a4d469bb9c4ae2d7dc1888b26887268"
 dependencies = [
  "cfg-if",
  "wasm-bindgen-macro",
@@ -4569,9 +4568,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.82"
+version = "0.2.83"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "662cd44805586bd52971b9586b1df85cdbbd9112e4ef4d8f41559c334dc6ac3f"
+checksum = "4c8ffb332579b0557b52d268b91feab8df3615f265d5270fec2a8c95b17c1142"
 dependencies = [
  "bumpalo",
  "log",
@@ -4584,9 +4583,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.32"
+version = "0.4.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa76fb221a1f8acddf5b54ace85912606980ad661ac7a503b4570ffd3a624dad"
+checksum = "23639446165ca5a5de86ae1d8896b737ae80319560fbaa4c2887b7da6e7ebd7d"
 dependencies = [
  "cfg-if",
  "js-sys",
@@ -4596,9 +4595,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.82"
+version = "0.2.83"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b260f13d3012071dfb1512849c033b1925038373aea48ced3012c09df952c602"
+checksum = "052be0f94026e6cbc75cdefc9bae13fd6052cdcaf532fa6c45e7ae33a1e6c810"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -4606,9 +4605,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.82"
+version = "0.2.83"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5be8e654bdd9b79216c2929ab90721aa82faf65c48cdf08bdc4e7f51357b80da"
+checksum = "07bc0c051dc5f23e307b13285f9d75df86bfdf816c5721e573dec1f9b8aa193c"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4619,15 +4618,15 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.82"
+version = "0.2.83"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6598dd0bd3c7d51095ff6531a5b23e02acdc81804e30d8f07afb77b7215a140a"
+checksum = "1c38c045535d93ec4f0b4defec448e4291638ee608530863b1e2ba115d4fff7f"
 
 [[package]]
 name = "web-sys"
-version = "0.3.59"
+version = "0.3.60"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed055ab27f941423197eb86b2035720b1a3ce40504df082cac2ecc6ed73335a1"
+checksum = "bcda906d8be16e728fd5adc5b729afad4e444e106ab28cd1c7256e54fa61510f"
 dependencies = [
  "js-sys",
  "wasm-bindgen",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -296,8 +296,8 @@ dependencies = [
  "num-derive",
  "num-traits",
  "priority-queue",
- "prost 0.11.0",
- "prost-build 0.11.1",
+ "prost",
+ "prost-build",
  "rand 0.8.5",
  "ring",
  "rocksdb",
@@ -1020,15 +1020,6 @@ dependencies = [
  "bitflags",
  "textwrap",
  "unicode-width",
-]
-
-[[package]]
-name = "cmake"
-version = "0.1.48"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8ad8cef104ac57b68b89df3208164d228503abbdce70f6880ffa3d970e7443a"
-dependencies = [
- "cc",
 ]
 
 [[package]]
@@ -1977,7 +1968,7 @@ version = "1.0.0-beta.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4b459b0f2ec8bc8434b8f4c0f70f91221738f7892f00150d15dc7edc075f70a0"
 dependencies = [
- "prost 0.11.0",
+ "prost",
  "tonic",
  "tonic-build",
 ]
@@ -2103,9 +2094,9 @@ dependencies = [
 
 [[package]]
 name = "libp2p"
-version = "0.45.1"
+version = "0.47.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41726ee8f662563fafba2d2d484b14037cc8ecb8c953fbfc8439d4ce3a0a9029"
+checksum = "2e7cc4d88e132823122905158c8e019173da72117825ad82154890beff02967e"
 dependencies = [
  "bytes",
  "futures",
@@ -2132,9 +2123,9 @@ dependencies = [
 
 [[package]]
 name = "libp2p-core"
-version = "0.33.0"
+version = "0.35.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42d46fca305dee6757022e2f5a4f6c023315084d0ed7441c3ab244e76666d979"
+checksum = "583862167683fea9e4712f2802910df067ca5f83e6b88979be16364904c2bdf1"
 dependencies = [
  "asn1_der",
  "bs58",
@@ -2151,8 +2142,8 @@ dependencies = [
  "multistream-select",
  "parking_lot 0.12.1",
  "pin-project",
- "prost 0.10.4",
- "prost-build 0.10.4",
+ "prost",
+ "prost-build",
  "rand 0.8.5",
  "ring",
  "rw-stream-sink",
@@ -2166,9 +2157,9 @@ dependencies = [
 
 [[package]]
 name = "libp2p-dns"
-version = "0.33.0"
+version = "0.35.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fbb462ec3a51fab457b4b44ac295e8b0a4b04dc175127e615cf996b1f0f1a268"
+checksum = "d8a09386cb4891343703614454a4e5f1084a22589f655d48a78c8dcad6b09d0a"
 dependencies = [
  "futures",
  "libp2p-core",
@@ -2180,9 +2171,9 @@ dependencies = [
 
 [[package]]
 name = "libp2p-identify"
-version = "0.36.1"
+version = "0.38.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b84b53490442d086db1fa5375670c9666e79143dccadef3f7c74a4346899a984"
+checksum = "edad807953d75e3c7f015a118c6a6bb85349eb134a2646a0a5a4c05db0f86737"
 dependencies = [
  "asynchronous-codec",
  "futures",
@@ -2191,8 +2182,8 @@ dependencies = [
  "libp2p-swarm",
  "log",
  "lru",
- "prost 0.10.4",
- "prost-build 0.10.4",
+ "prost",
+ "prost-build",
  "prost-codec",
  "smallvec",
  "thiserror",
@@ -2201,9 +2192,9 @@ dependencies = [
 
 [[package]]
 name = "libp2p-metrics"
-version = "0.6.1"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "564a7e5284d7d9b3140fdfc3cb6567bc32555e86a21de5604c2ec85da05cf384"
+checksum = "1d1364ebcfe0146428fceee2d12e57ba79f94f001945bddecdb70d97406b91c2"
 dependencies = [
  "libp2p-core",
  "libp2p-identify",
@@ -2213,9 +2204,9 @@ dependencies = [
 
 [[package]]
 name = "libp2p-mplex"
-version = "0.33.0"
+version = "0.35.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ff9c893f2367631a711301d703c47432af898c9bb8253bea0e2c051a13f7640"
+checksum = "17eb2b734c3c5dc49408e257a70872b42eb21cd3ca9dc34e3c20a2a131120088"
 dependencies = [
  "asynchronous-codec",
  "bytes",
@@ -2231,9 +2222,9 @@ dependencies = [
 
 [[package]]
 name = "libp2p-noise"
-version = "0.36.0"
+version = "0.38.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf2cee1dad1c83325bbd182a8e94555778699cec8a9da00086efb7522c4c15ad"
+checksum = "9a550a023fe31aafb3a5e9831ac124d43060807d7c201a035922ec75857c7e3e"
 dependencies = [
  "bytes",
  "curve25519-dalek 3.2.1",
@@ -2241,8 +2232,8 @@ dependencies = [
  "lazy_static",
  "libp2p-core",
  "log",
- "prost 0.10.4",
- "prost-build 0.10.4",
+ "prost",
+ "prost-build",
  "rand 0.8.5",
  "sha2 0.10.5",
  "snow",
@@ -2253,9 +2244,9 @@ dependencies = [
 
 [[package]]
 name = "libp2p-swarm"
-version = "0.36.1"
+version = "0.38.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f4bb21c5abadbf00360c734f16bf87f1712ed4f23cd46148f625d2ddb867346"
+checksum = "d91932a67f579ac6d66b51603a75b04c2737af7f84c9e44743f81978be951933"
 dependencies = [
  "either",
  "fnv",
@@ -2273,19 +2264,20 @@ dependencies = [
 
 [[package]]
 name = "libp2p-swarm-derive"
-version = "0.27.2"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f693c8c68213034d472cbb93a379c63f4f307d97c06f1c41e4985de481687a5"
+checksum = "27b2aac6a51e400168345fd89aaa5ce55395f49297e1d4fbf4acf0c6104ad096"
 dependencies = [
+ "heck 0.4.0",
  "quote",
  "syn",
 ]
 
 [[package]]
 name = "libp2p-tcp"
-version = "0.33.0"
+version = "0.35.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f4933e38ef21b50698aefc87799c24f2a365c9d3f6cf50471f3f6a0bc410892"
+checksum = "ebf0bba86870fd7b2d74f9b939066be5b984b46989b02d13d292fcf3caab3fdb"
 dependencies = [
  "futures",
  "futures-timer",
@@ -2300,9 +2292,9 @@ dependencies = [
 
 [[package]]
 name = "libp2p-yamux"
-version = "0.37.0"
+version = "0.39.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8fe653639ad74877c759720febb0cbcbf4caa221adde4eed2d3126ce5c6f381f"
+checksum = "1d1dc106f1f0c67aa89d59184dd8ae1db0bc683337dcdc36b6dc6e31dafc35ea"
 dependencies = [
  "futures",
  "libp2p-core",
@@ -2741,15 +2733,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "owning_ref"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ff55baddef9e4ad00f88b6c743a2a8062d4c6ade126c2a528644b8e444d52ce"
-dependencies = [
- "stable_deref_trait",
-]
-
-[[package]]
 name = "packable"
 version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3085,35 +3068,25 @@ dependencies = [
 
 [[package]]
 name = "prometheus-client"
-version = "0.16.0"
+version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac1abe0255c04d15f571427a2d1e00099016506cf3297b53853acd2b7eb87825"
+checksum = "3c473049631c233933d6286c88bbb7be30e62ec534cf99a9ae0079211f7fa603"
 dependencies = [
  "dtoa",
  "itoa 1.0.3",
- "owning_ref",
+ "parking_lot 0.12.1",
  "prometheus-client-derive-text-encode",
 ]
 
 [[package]]
 name = "prometheus-client-derive-text-encode"
-version = "0.2.0"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8e12d01b9d66ad9eb4529c57666b6263fc1993cb30261d83ead658fdd932652"
+checksum = "66a455fbcb954c1a7decf3c586e860fd7889cddf4b8e164be736dbac95a953cd"
 dependencies = [
  "proc-macro2",
  "quote",
  "syn",
-]
-
-[[package]]
-name = "prost"
-version = "0.10.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "71adf41db68aa0daaefc69bb30bcd68ded9b9abaad5d1fbb6304c4fb390e083e"
-dependencies = [
- "bytes",
- "prost-derive 0.10.1",
 ]
 
 [[package]]
@@ -3123,29 +3096,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "399c3c31cdec40583bb68f0b18403400d01ec4289c383aa047560439952c4dd7"
 dependencies = [
  "bytes",
- "prost-derive 0.11.0",
-]
-
-[[package]]
-name = "prost-build"
-version = "0.10.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ae5a4388762d5815a9fc0dea33c56b021cdc8dde0c55e0c9ca57197254b0cab"
-dependencies = [
- "bytes",
- "cfg-if",
- "cmake",
- "heck 0.4.0",
- "itertools",
- "lazy_static",
- "log",
- "multimap",
- "petgraph",
- "prost 0.10.4",
- "prost-types 0.10.1",
- "regex",
- "tempfile",
- "which",
+ "prost-derive",
 ]
 
 [[package]]
@@ -3161,8 +3112,8 @@ dependencies = [
  "log",
  "multimap",
  "petgraph",
- "prost 0.11.0",
- "prost-types 0.11.1",
+ "prost",
+ "prost-types",
  "regex",
  "tempfile",
  "which",
@@ -3170,28 +3121,15 @@ dependencies = [
 
 [[package]]
 name = "prost-codec"
-version = "0.1.0"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "00af1e92c33b4813cc79fda3f2dbf56af5169709be0202df730e9ebc3e4cd007"
+checksum = "011ae9ff8359df7915f97302d591cdd9e0e27fbd5a4ddc5bd13b71079bb20987"
 dependencies = [
  "asynchronous-codec",
  "bytes",
- "prost 0.10.4",
+ "prost",
  "thiserror",
  "unsigned-varint",
-]
-
-[[package]]
-name = "prost-derive"
-version = "0.10.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b670f45da57fb8542ebdbb6105a925fe571b67f9e7ed9f47a06a84e72b4e7cc"
-dependencies = [
- "anyhow",
- "itertools",
- "proc-macro2",
- "quote",
- "syn",
 ]
 
 [[package]]
@@ -3209,22 +3147,12 @@ dependencies = [
 
 [[package]]
 name = "prost-types"
-version = "0.10.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d0a014229361011dc8e69c8a1ec6c2e8d0f2af7c91e3ea3f5b2170298461e68"
-dependencies = [
- "bytes",
- "prost 0.10.4",
-]
-
-[[package]]
-name = "prost-types"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4dfaa718ad76a44b3415e6c4d53b17c8f99160dcb3a99b10470fce8ad43f6e3e"
 dependencies = [
  "bytes",
- "prost 0.11.0",
+ "prost",
 ]
 
 [[package]]
@@ -3726,6 +3654,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "92761393ee4dc3ff8f4af487bd58f4307c9329bbedea02cac0089ad9c411e153"
 dependencies = [
  "dashmap",
+ "futures",
  "lazy_static",
  "parking_lot 0.12.1",
  "serial_test_derive",
@@ -3906,12 +3835,6 @@ dependencies = [
  "base64ct",
  "der",
 ]
-
-[[package]]
-name = "stable_deref_trait"
-version = "1.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
 
 [[package]]
 name = "static_assertions"
@@ -4215,8 +4138,8 @@ dependencies = [
  "hyper-timeout",
  "percent-encoding",
  "pin-project",
- "prost 0.11.0",
- "prost-derive 0.11.0",
+ "prost",
+ "prost-derive",
  "tokio",
  "tokio-stream",
  "tokio-util 0.7.4",
@@ -4235,7 +4158,7 @@ checksum = "2fbcd2800e34e743b9ae795867d5f77b535d3a3be69fd731e39145719752df8c"
 dependencies = [
  "prettyplease",
  "proc-macro2",
- "prost-build 0.11.1",
+ "prost-build",
  "quote",
  "syn",
 ]

--- a/bee-network/bee-autopeering/Cargo.toml
+++ b/bee-network/bee-autopeering/Cargo.toml
@@ -25,7 +25,7 @@ bytes = { version = "1.2.1", default-features = false }
 hash32 = { version = "0.3.1", default-features = false }
 hex = { version = "0.4.3", default-features = false }
 iota-crypto = { version = "0.14.3", default-features = false, features = [ "ed25519", "random", "sha" ] }
-libp2p-core = { version = "0.33.0", default-features = false }
+libp2p-core = { version = "0.35.0", default-features = false }
 log = { version = "0.4.17", default-features = false }
 num = { version = "0.4.0", default-features = false }
 num-derive = { version = "0.3.3", default-features = false  }

--- a/bee-network/bee-gossip/Cargo.toml
+++ b/bee-network/bee-gossip/Cargo.toml
@@ -46,8 +46,8 @@ bee-runtime = { version = "1.0.0", path = "../../bee-runtime", default-features 
 async-trait = { version = "0.1.57", default-features = false, optional = true }
 futures = { version = "0.3.23", default-features = false, optional = true }
 hashbrown = { version = "0.12.3", default-features = false, features = [ "ahash", "inline-more" ] }
-libp2p = { version = "0.45.1", default-features = false, optional = true }
-libp2p-core = { version = "0.33.0", default-features = false }
+libp2p = { version = "0.47.0", default-features = false, optional = true }
+libp2p-core = { version = "0.35.0", default-features = false }
 log = { version = "0.4.17", default-features = false, optional = true }
 once_cell = { version = "1.13.0", default-features = false, optional = true }
 rand = { version = "0.8.5", default-features = false, optional = true }
@@ -59,7 +59,7 @@ tokio-stream = { version = "0.1.9", default-features = false, features = [ "time
 [dev-dependencies]
 fern = { version = "0.6.1", default-features = false }
 hex = { version = "0.4.3", default-features = false, features = [ "alloc" ] }
-serial_test = { version = "0.9.0", default-features = false }
+serial_test = { version = "0.9.0", default-features = false, features = [ "async" ] }
 tokio = { version = "1.20.1", default-features = false, features = [ "io-std", "io-util", "macros", "rt", "rt-multi-thread", "signal", "time" ] }
 
 [[example]]

--- a/bee-network/bee-gossip/src/error.rs
+++ b/bee-network/bee-gossip/src/error.rs
@@ -19,8 +19,8 @@ pub enum Error {
     CreatingTransportFailed,
 
     /// Binding to an address failed.
-    #[error("failed to bind to an address")]
-    BindingAddressFailed,
+    #[error("failed to bind to an address: {0}")]
+    BindingAddressFailed(#[from] libp2p_core::transport::TransportError<std::io::Error>),
 
     /// An error occurred in the host event loop.
     #[error("failed to process an item in the host processor event loop")]

--- a/bee-network/bee-gossip/src/init.rs
+++ b/bee-network/bee-gossip/src/init.rs
@@ -205,7 +205,7 @@ fn init(
     }
 
     // Create the transport layer.
-    let swarm = build_swarm(&local_keys, internal_event_sender.clone()).map_err(|_| Error::CreatingTransportFailed)?;
+    let swarm = build_swarm(&local_keys).map_err(|_| Error::CreatingTransportFailed)?;
 
     let network_host_config = NetworkHostConfig {
         internal_event_sender: internal_event_sender.clone(),

--- a/bee-network/bee-gossip/src/network/host.rs
+++ b/bee-network/bee-gossip/src/network/host.rs
@@ -164,10 +164,10 @@ async fn process_swarm_event(
             debug!("Swarm event: being dialed from {}.", send_back_addr);
         }
         SwarmEvent::Behaviour(SwarmBehaviourEvent::Identify(identify_event)) => {
-            handle_identify_event(identify_event, internal_event_sender);
+            handle_identify_event(*identify_event, internal_event_sender);
         }
         SwarmEvent::Behaviour(SwarmBehaviourEvent::Gossip(gossip_event)) => {
-            handle_gossip_event(gossip_event, internal_event_sender);
+            handle_gossip_event(*gossip_event, internal_event_sender);
         }
         _ => {}
     }

--- a/bee-network/bee-gossip/src/network/host.rs
+++ b/bee-network/bee-gossip/src/network/host.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use futures::{channel::oneshot, StreamExt};
-use libp2p::{swarm::SwarmEvent, Multiaddr, PeerId, Swarm};
+use libp2p::{identify::IdentifyEvent, swarm::SwarmEvent, Multiaddr, PeerId, Swarm};
 use log::*;
 
 use super::error::Error;
@@ -13,7 +13,10 @@ use crate::{
         command::{Command, CommandReceiver},
         event::{InternalEvent, InternalEventSender},
     },
-    swarm::behaviour::SwarmBehaviour,
+    swarm::{
+        behaviour::{SwarmBehaviour, SwarmBehaviourEvent},
+        protocols::iota_gossip::IotaGossipEvent,
+    },
 };
 
 pub struct NetworkHostConfig {
@@ -127,7 +130,7 @@ async fn network_host_processor(
 }
 
 async fn process_swarm_event(
-    event: SwarmEvent<(), impl std::error::Error>,
+    event: SwarmEvent<SwarmBehaviourEvent, impl std::error::Error>,
     internal_event_sender: &InternalEventSender,
     peerlist: &PeerList,
 ) {
@@ -160,7 +163,77 @@ async fn process_swarm_event(
         SwarmEvent::IncomingConnection { send_back_addr, .. } => {
             debug!("Swarm event: being dialed from {}.", send_back_addr);
         }
+        SwarmEvent::Behaviour(SwarmBehaviourEvent::Identify(identify_event)) => {
+            handle_identify_event(identify_event, internal_event_sender);
+        }
+        SwarmEvent::Behaviour(SwarmBehaviourEvent::Gossip(gossip_event)) => {
+            handle_gossip_event(gossip_event, internal_event_sender);
+        }
         _ => {}
+    }
+}
+
+fn handle_identify_event(event: IdentifyEvent, internal_event_sender: &InternalEventSender) {
+    match event {
+        IdentifyEvent::Received { peer_id, info } => {
+            trace!("Received Identify response from {}: {:?}.", alias!(peer_id), info,);
+
+            // Panic: we made sure that the sender (network host) is always dropped before the receiver (service
+            // host) through the worker dependencies, hence this can never panic.
+            internal_event_sender
+                .send(InternalEvent::PeerIdentified { peer_id })
+                .expect("send internal event");
+        }
+        IdentifyEvent::Sent { peer_id } => {
+            trace!("Sent Identify request to {}.", alias!(peer_id));
+        }
+        IdentifyEvent::Pushed { peer_id } => {
+            trace!("Pushed Identify request to {}.", alias!(peer_id));
+        }
+        IdentifyEvent::Error { peer_id, error } => {
+            debug!("Identification error with {}: Cause: {:?}.", alias!(peer_id), error);
+
+            // Panic: we made sure that the sender (network host) is always dropped before the receiver (service
+            // host) through the worker dependencies, hence this can never panic.
+            internal_event_sender
+                .send(InternalEvent::PeerUnreachable { peer_id })
+                .expect("send internal event");
+        }
+    }
+}
+
+fn handle_gossip_event(event: IotaGossipEvent, internal_event_sender: &InternalEventSender) {
+    match event {
+        IotaGossipEvent::ReceivedUpgradeRequest { from } => {
+            trace!("Received IOTA gossip request from {}.", alias!(from));
+        }
+        IotaGossipEvent::SentUpgradeRequest { to } => {
+            trace!("Sent IOTA gossip request to {}.", alias!(to));
+        }
+        IotaGossipEvent::UpgradeCompleted {
+            peer_id,
+            peer_addr,
+            origin,
+            substream,
+        } => {
+            trace!("Successfully negotiated IOTA gossip protocol with {}.", alias!(peer_id));
+
+            internal_event_sender
+                .send(InternalEvent::ProtocolEstablished {
+                    peer_id,
+                    peer_addr,
+                    origin,
+                    substream,
+                })
+                .expect("send internal event");
+        }
+        IotaGossipEvent::UpgradeError { peer_id, error } => {
+            debug!(
+                "IOTA gossip upgrade error with {}: Cause: {:?}.",
+                alias!(peer_id),
+                error
+            );
+        }
     }
 }
 

--- a/bee-network/bee-gossip/src/network/host.rs
+++ b/bee-network/bee-gossip/src/network/host.rs
@@ -106,7 +106,7 @@ async fn network_host_processor(
 
     // Try binding to the configured bind address.
     info!("Binding to: {}", bind_multiaddr);
-    let _listener_id = Swarm::listen_on(&mut swarm, bind_multiaddr).map_err(|_| crate::Error::BindingAddressFailed)?;
+    let _listener_id = Swarm::listen_on(&mut swarm, bind_multiaddr)?;
 
     // Enter command/event loop.
     loop {

--- a/bee-network/bee-gossip/src/swarm/behaviour.rs
+++ b/bee-network/bee-gossip/src/swarm/behaviour.rs
@@ -3,106 +3,46 @@
 
 use libp2p::{
     identify::{Identify, IdentifyConfig, IdentifyEvent},
-    swarm::NetworkBehaviourEventProcess,
     NetworkBehaviour,
 };
 use libp2p_core::identity::PublicKey;
-use log::*;
 
 use super::protocols::iota_gossip::{IotaGossipEvent, IotaGossipProtocol};
-use crate::{
-    alias,
-    service::event::{InternalEvent, InternalEventSender},
-};
 
 const IOTA_PROTOCOL_VERSION: &str = "iota/0.1.0";
 
 #[derive(NetworkBehaviour)]
-#[behaviour(event_process = true)]
+#[behaviour(out_event = "SwarmBehaviourEvent")]
 pub struct SwarmBehaviour {
     identify: Identify,
     gossip: IotaGossipProtocol,
-    #[behaviour(ignore)]
-    internal_sender: InternalEventSender,
 }
 
 impl SwarmBehaviour {
-    pub fn new(local_pk: PublicKey, internal_sender: InternalEventSender) -> Self {
+    pub fn new(local_pk: PublicKey) -> Self {
         let protocol_version = IOTA_PROTOCOL_VERSION.to_string();
         let config = IdentifyConfig::new(protocol_version, local_pk);
 
         Self {
             identify: Identify::new(config),
             gossip: IotaGossipProtocol::new(),
-            internal_sender,
         }
     }
 }
 
-impl NetworkBehaviourEventProcess<IdentifyEvent> for SwarmBehaviour {
-    fn inject_event(&mut self, event: IdentifyEvent) {
-        match event {
-            IdentifyEvent::Received { peer_id, info } => {
-                trace!("Received Identify response from {}: {:?}.", alias!(peer_id), info,);
+pub enum SwarmBehaviourEvent {
+    Identify(IdentifyEvent),
+    Gossip(IotaGossipEvent),
+}
 
-                // Panic: we made sure that the sender (network host) is always dropped before the receiver (service
-                // host) through the worker dependencies, hence this can never panic.
-                self.internal_sender
-                    .send(InternalEvent::PeerIdentified { peer_id })
-                    .expect("send internal event");
-            }
-            IdentifyEvent::Sent { peer_id } => {
-                trace!("Sent Identify request to {}.", alias!(peer_id));
-            }
-            IdentifyEvent::Pushed { peer_id } => {
-                trace!("Pushed Identify request to {}.", alias!(peer_id));
-            }
-            IdentifyEvent::Error { peer_id, error } => {
-                debug!("Identification error with {}: Cause: {:?}.", alias!(peer_id), error);
-
-                // Panic: we made sure that the sender (network host) is always dropped before the receiver (service
-                // host) through the worker dependencies, hence this can never panic.
-                self.internal_sender
-                    .send(InternalEvent::PeerUnreachable { peer_id })
-                    .expect("send internal event");
-            }
-        }
+impl From<IdentifyEvent> for SwarmBehaviourEvent {
+    fn from(event: IdentifyEvent) -> Self {
+        SwarmBehaviourEvent::Identify(event)
     }
 }
 
-impl NetworkBehaviourEventProcess<IotaGossipEvent> for SwarmBehaviour {
-    fn inject_event(&mut self, event: IotaGossipEvent) {
-        match event {
-            IotaGossipEvent::ReceivedUpgradeRequest { from } => {
-                trace!("Received IOTA gossip request from {}.", alias!(from));
-            }
-            IotaGossipEvent::SentUpgradeRequest { to } => {
-                trace!("Sent IOTA gossip request to {}.", alias!(to));
-            }
-            IotaGossipEvent::UpgradeCompleted {
-                peer_id,
-                peer_addr,
-                origin,
-                substream,
-            } => {
-                trace!("Successfully negotiated IOTA gossip protocol with {}.", alias!(peer_id));
-
-                self.internal_sender
-                    .send(InternalEvent::ProtocolEstablished {
-                        peer_id,
-                        peer_addr,
-                        origin,
-                        substream,
-                    })
-                    .expect("send internal event");
-            }
-            IotaGossipEvent::UpgradeError { peer_id, error } => {
-                debug!(
-                    "IOTA gossip upgrade error with {}: Cause: {:?}.",
-                    alias!(peer_id),
-                    error
-                );
-            }
-        }
+impl From<IotaGossipEvent> for SwarmBehaviourEvent {
+    fn from(event: IotaGossipEvent) -> Self {
+        SwarmBehaviourEvent::Gossip(event)
     }
 }

--- a/bee-network/bee-gossip/src/swarm/behaviour.rs
+++ b/bee-network/bee-gossip/src/swarm/behaviour.rs
@@ -31,18 +31,18 @@ impl SwarmBehaviour {
 }
 
 pub enum SwarmBehaviourEvent {
-    Identify(IdentifyEvent),
-    Gossip(IotaGossipEvent),
+    Identify(Box<IdentifyEvent>),
+    Gossip(Box<IotaGossipEvent>),
 }
 
 impl From<IdentifyEvent> for SwarmBehaviourEvent {
     fn from(event: IdentifyEvent) -> Self {
-        SwarmBehaviourEvent::Identify(event)
+        SwarmBehaviourEvent::Identify(Box::new(event))
     }
 }
 
 impl From<IotaGossipEvent> for SwarmBehaviourEvent {
     fn from(event: IotaGossipEvent) -> Self {
-        SwarmBehaviourEvent::Gossip(event)
+        SwarmBehaviourEvent::Gossip(Box::new(event))
     }
 }

--- a/bee-network/bee-gossip/src/swarm/builder.rs
+++ b/bee-network/bee-gossip/src/swarm/builder.rs
@@ -11,15 +11,11 @@ use libp2p::{
 };
 
 use super::{behaviour::SwarmBehaviour, error::Error};
-use crate::service::event::InternalEventSender;
 
 const MAX_CONNECTIONS_PER_PEER: u32 = 1;
 const DEFAULT_CONNECTION_TIMEOUT_SECS: u64 = 10;
 
-pub fn build_swarm(
-    local_keys: &identity::Keypair,
-    internal_sender: InternalEventSender,
-) -> Result<Swarm<SwarmBehaviour>, Error> {
+pub fn build_swarm(local_keys: &identity::Keypair) -> Result<Swarm<SwarmBehaviour>, Error> {
     let local_pk = local_keys.public();
     let local_id = local_pk.to_peer_id();
 
@@ -52,7 +48,7 @@ pub fn build_swarm(
             .boxed()
     };
 
-    let behaviour = SwarmBehaviour::new(local_pk, internal_sender);
+    let behaviour = SwarmBehaviour::new(local_pk);
     let limits = ConnectionLimits::default().with_max_established_per_peer(Some(MAX_CONNECTIONS_PER_PEER));
 
     let swarm = SwarmBuilder::new(transport, behaviour, local_id)

--- a/bee-network/bee-gossip/src/swarm/builder.rs
+++ b/bee-network/bee-gossip/src/swarm/builder.rs
@@ -41,8 +41,8 @@ pub fn build_swarm(
             .timeout(Duration::from_secs(DEFAULT_CONNECTION_TIMEOUT_SECS))
             .boxed()
     } else {
-        let tcp_config = tcp::TokioTcpConfig::new().nodelay(true).port_reuse(true);
-        let dns_config = dns::TokioDnsConfig::system(tcp_config)?;
+        let tcp_transport = tcp::TokioTcpTransport::new(tcp::GenTcpConfig::new().nodelay(true).port_reuse(true));
+        let dns_config = dns::TokioDnsConfig::system(tcp_transport)?;
 
         dns_config
             .upgrade(upgrade::Version::V1Lazy)

--- a/bee-network/bee-gossip/src/tests/connect_peer.rs
+++ b/bee-network/bee-gossip/src/tests/connect_peer.rs
@@ -9,10 +9,10 @@ use crate::{standalone::init, Command, PeerRelation};
 #[tokio::test]
 #[serial_test::serial]
 async fn connect_peer() {
-    let config1 = get_in_memory_network_config(1337);
+    let config1 = get_in_memory_network_config(1338);
     let keys1 = gen_random_keys();
 
-    let config2 = get_in_memory_network_config(4242);
+    let config2 = get_in_memory_network_config(4243);
     let keys2 = gen_random_keys();
 
     let network_id = gen_constant_net_id();

--- a/bee-network/bee-gossip/src/tests/initialize.rs
+++ b/bee-network/bee-gossip/src/tests/initialize.rs
@@ -9,7 +9,7 @@ use crate::standalone::init;
 #[tokio::test]
 #[serial_test::serial]
 async fn initialize() {
-    let config = get_in_memory_network_config(1337);
+    let config = get_in_memory_network_config(1339);
     let config_bind_multiaddr = config.bind_multiaddr().clone();
 
     let keys = get_constant_keys();

--- a/bee-network/bee-gossip/src/tests/send_recv.rs
+++ b/bee-network/bee-gossip/src/tests/send_recv.rs
@@ -11,10 +11,10 @@ use crate::{standalone::init, Command, PeerRelation};
 #[tokio::test]
 #[serial_test::serial]
 async fn send_recv() {
-    let config1 = get_in_memory_network_config(1337);
+    let config1 = get_in_memory_network_config(1340);
     let keys1 = gen_random_keys();
 
-    let config2 = get_in_memory_network_config(4242);
+    let config2 = get_in_memory_network_config(4245);
     let keys2 = gen_random_keys();
 
     let network_id = gen_constant_net_id();


### PR DESCRIPTION
# Description of change

Bumps libp2p dependencies:
`libp2p ~> 0.47`
`libp2p-core ~> 0.35`

Note:
There seems to be a problem with binding multiaddr's in the test cases for `bee-gossip`. There ... we use the `serial_test` crate to make sure network tests are not run in parallel and no single test reserves network resources another test requires as well. (the same port numbers can be used in all those tests). With the previous and the current version of `libp2p`/`libp2p-core` this is no longer possible. To circumvent this problem within this PR each test now uses unique memory ports to make them run successfully.

## Type of change

<!-- Choose a type of change, and delete any options that are not relevant. -->

- Enhancement (a non-breaking change which adds functionality)

## How the change has been tested

<!-- Describe the tests that you ran to verify your changes. -->

Integration tests.

<!-- Make sure to provide instructions for the maintainer as well as any relevant configurations. -->

## Change checklist

<!-- Tick the boxes that are relevant to your changes, and delete any items that are not. -->

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that new and existing unit tests pass locally with my changes
- [x] I have updated the CHANGELOG.md, if my changes are significant enough
